### PR TITLE
PEP440 Compliance

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -104,25 +104,29 @@ We use the standard GitHub contribution cycle.
 Release Instructions
 --------------------
 
-1. Update the versions in :code:`proxystore/__init__.py` and :code:`setup.py`.
-   ProxyStore uses semver (*major.minor.patch*) for version numbering with
-   optional suffixes for pre-releases (e.g., *1.2.3-alpha.1*).
-2. If this is a full release, add a changelog entry to
+1. Choose the next version number, referred to as :code:`{VERSION}` for the
+   rest of the instructions. ProxyStore versioning follows semver
+   (*major.minor.patch*) with optional `PEP-440 <https://peps.python.org/pep-0440>`_
+   pre-release/post-release/dev-release segments. Major/minor/patch numbers
+   start at 0 and pre-release/post-release/dev-release segments start at 1.
+2. Update the versions in :code:`proxystore/__init__.py` and :code:`setup.py`
+   to :code:`{VERSION}`.
+3. If this is a full release, add a changelog entry to
    :code:`docs/changelog.rst`.
-3. Verify the versions match with
-   :code:`python version_check.py {new-version}`.
-4. Commit and merge the version updates/changelogs into main.
-5. Tag the release commit and push (typically this is the commit updating the
+4. Verify the versions match with
+   :code:`python version_check.py {VERSION}`.
+5. Commit and merge the version updates/changelogs into main.
+6. Tag the release commit and push (typically this is the commit updating the
    version numbers).
 
    .. code-block:: bash
 
-      $ git tag -a v{version} -m "ProxyStore {version}"
-      $ git push origin v{version}
+      $ git tag -a v{VERSION} -m "ProxyStore {VERSION}"
+      $ git push origin v{VERSION}
 
    Note the version number is prepended by "v" for the tags so we can
    distinguish release tags from non-release tags.
-6. Build the package and upload to PyPI.
+7. Build the package and upload to PyPI.
 
    .. code-block:: bash
 
@@ -130,6 +134,6 @@ Release Instructions
       $ python -m build
       $ python -m twine upload dist/*
 
-7. Create a new release on GitHub using the tag. The ReadTheDocs changelog
+8. Create a new release on GitHub using the tag. The ReadTheDocs changelog
    is typically copied into the body, and the files in :code:`dist/*` are
    uploaded as well. See previous releases for the template.

--- a/proxystore/__init__.py
+++ b/proxystore/__init__.py
@@ -7,4 +7,4 @@ import proxystore.serialize as serialize  # noqa: F401
 import proxystore.utils as utils  # noqa: F401
 from proxystore import store  # noqa: F401
 
-__version__ = '0.4.0-alpha.1'
+__version__ = '0.4.0a1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = proxystore
-version = 0.4.0-alpha.1
+version = 0.4.0a1
 description = Python lazy object proxy interface for distributed stores.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Update `version_check.py`, release guide, and current version to be PEP440 compliant. #75 didn't quite get the pre-release segment right and PyPI automatically changed it, so this PR should help prevent that in the future.

Note: we are not 100% PEP-440 compliant for two reasons:
1. We require `MAJOR.MINOR.PATCH` (semver) while PEP440 only requires one or more segments.
2. We require the segment numbers for pre/post/dev-releases to start a 1.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #77 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
