### PR TITLE
Fix generic typing on `Store.proxy()`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -423,7 +423,7 @@ class Store(metaclass=ABCMeta):
 
     def proxy(
         self,
-        obj: Any | None = None,
+        obj: T | None = None,
         *,
         key: str | None = None,
         **kwargs: Any,
@@ -472,19 +472,18 @@ class Store(metaclass=ABCMeta):
             f"PROXY key='{final_key}' FROM {self.__class__.__name__}"
             f"(name='{self.name}')",
         )
-        return Proxy(
-            StoreFactory(
-                final_key,
-                store_type=type(self),
-                store_name=self.name,
-                store_kwargs=self.kwargs,
-                **kwargs,
-            ),
+        factory: StoreFactory[T] = StoreFactory(
+            final_key,
+            store_type=type(self),
+            store_name=self.name,
+            store_kwargs=self.kwargs,
+            **kwargs,
         )
+        return Proxy(factory)
 
     def proxy_batch(
         self,
-        objs: Sequence[Any] | None = None,
+        objs: Sequence[T] | None = None,
         *,
         keys: Sequence[str] | None = None,
         **kwargs: Any,


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #76 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Running `mypy` on the below script produces the following.

```Python
from proxystore.store.local import LocalStore

store = LocalStore('store')

p1 = store.proxy(b'abcd')
reveal_type(p1)
# note: Revealed type is "proxystore.proxy.Proxy[builtins.bytes]"

p2 = store.proxy([1, 2, 3])
reveal_type(p2)
# note: Revealed type is "proxystore.proxy.Proxy[builtins.list[builtins.int]]"

p3 = store.proxy_batch([[1, 2], 'str', 1.0])
reveal_type(p3)
# note: Revealed type is "builtins.list[proxystore.proxy.Proxy[builtins.object]]"
```

Note that `proxy_batch` types still do not work. This is because `proxy_batch()` uses the key-method of creating a proxy because it internally calls `set_batch()`. This is a limitation of creating proxies via the key (rather than the object) as noted in #76. Whenever #48 is worked on, this will need to be taken into consideration.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
