### PR TITLE
Serve endpoint with hypercorn and uvloop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
     -   id: mypy
         additional_dependencies: [
             'globus-sdk',
+            'hypercorn',
             'types-redis',
             'types-requests',
             'quart',

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     aiortc>=1.3.2
     cloudpickle>=1.6.0
     globus-sdk>=3.3.0
+    hypercorn[uvloop]>=0.13.0
     lazy-object-proxy>=1.6.0
     parsl>=1.0.0
     quart>=0.18.0

--- a/testing/endpoint.py
+++ b/testing/endpoint.py
@@ -25,6 +25,7 @@ def serve_endpoint_silent(
         None,
     ):
         logging.disable(100000)
+        # https://stackoverflow.com/questions/66583461
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         serve(name, uuid, host, port, server=server)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Use Hypercorn with uvloop (rather than Python's native event loop) for serving the endpoint.

#### Before:

| Clients          | 1      | 4      | 8     |
|------------------|--------|--------|-------|
| Avg Latency (ms) | 1.238  | 3.042  | 5.780 |
| QPS              | 807    | 1315   | 1384  |

#### After:

| Clients          | 1     | 4     | 8     |
|------------------|-------|-------|-------|
| Avg Latency (ms) | 1.144 | 1.917 | 3.892 |
| QPS              | 873   | 2086  | 2056  |

Test was done using the QPS benchmark in [proxystore-benchmarks](https://github.com/proxystore/proxystore). The endpoint and clients were hosted on the same physical machine and the `/endpoint` route was queried.

#### Future changes:

This change sets us up for using multiple workers if needed for serving the endpoint. The only limiting factor is that the data storage in the endpoint also needs to support multiple independent processes (SQLite, Redis, etc.).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #72 
- Fixes logging regression in #69 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated unit tests where needed and ran QPS benchmark to verify performance improvements.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
