### PR TITLE
Fix warnings in tests

### DIFF
--- a/proxystore/endpoint/endpoint.py
+++ b/proxystore/endpoint/endpoint.py
@@ -471,6 +471,10 @@ class Endpoint:
         """Close the endpoint and any open connections safely."""
         if self._peer_handler_task is not None:
             self._peer_handler_task.cancel()
+            try:
+                await self._peer_handler_task
+            except asyncio.CancelledError:
+                pass
         if self._peer_manager is not None:
             await self._peer_manager.close()
         self._data.cleanup()

--- a/proxystore/p2p/manager.py
+++ b/proxystore/p2p/manager.py
@@ -285,8 +285,16 @@ class PeerManager:
         """Close the connection manager."""
         if self._server_task is not None:
             self._server_task.cancel()
+            try:
+                await self._server_task
+            except (asyncio.CancelledError, SafeTaskExit):
+                pass
         for task in self._tasks.values():
             task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, SafeTaskExit):
+                pass
         async with self._peers_lock:
             for connection in self._peers.values():
                 await connection.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,4 +96,6 @@ allow_untyped_defs = true
 asyncio_mode = auto
 filterwarnings =
     ignore::cryptography.utils.CryptographyDeprecationWarning
+markers =
+    integration: mark a test as an integration test.
 timeout = 30

--- a/tests/integration/endpoints_test.py
+++ b/tests/integration/endpoints_test.py
@@ -88,6 +88,7 @@ def endpoints(
     ss.terminate()
 
 
+@pytest.mark.integration
 def test_endpoint_transfer(endpoints) -> None:
     """Test transferring data between two endpoints."""
     endpoints, proxystore_dirs = endpoints
@@ -110,6 +111,7 @@ def test_endpoint_transfer(endpoints) -> None:
     assert not store1.exists(key)
 
 
+@pytest.mark.integration
 def test_endpoint_proxy_transfer(endpoints) -> None:
     """Test transferring data via proxy between processes sharing endpoint."""
     endpoints, proxystore_dirs = endpoints
@@ -147,6 +149,7 @@ def test_endpoint_proxy_transfer(endpoints) -> None:
         raise Exception('Caught exception in consume().')
 
 
+@pytest.mark.integration
 def test_proxy_detects_endpoint(endpoints) -> None:
     """Test transferring data via proxy between two process and endpoints."""
     endpoints, proxystore_dirs = endpoints

--- a/tests/p2p/server_cli_test.py
+++ b/tests/p2p/server_cli_test.py
@@ -28,7 +28,7 @@ def test_logging_dir(tmp_dir) -> None:
 
 
 def test_logging_config(tmp_dir) -> None:
-    server_handle = subprocess.Popen(
+    with subprocess.Popen(
         [
             'signaling-server',
             '--port',
@@ -41,15 +41,14 @@ def test_logging_config(tmp_dir) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         universal_newlines=True,
-    )
+    ) as server_handle:
+        # Wait for server to log that it is listening
+        assert server_handle.stdout is not None
+        for line in server_handle.stdout:  # pragma: no cover
+            if 'serving' in line:
+                break
 
-    # Wait for server to log that it is listening
-    assert server_handle.stdout is not None
-    for line in server_handle.stdout:  # pragma: no cover
-        if 'serving' in line:
-            break
-
-    server_handle.terminate()
+        server_handle.terminate()
 
     logs = [
         f


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Originally set out to fix flaky tests that I encountered on an M1 Mac (#84). After investigating though, it seems the issues were not Mac specified and mostly related unawaited/dangling asyncio tasks.

- Fix unclosed file in server logging test.
- Add integration test marking so they are easier to skip.
- Await cancelled asyncio tasks where forgotten.
- Fix task was destroyed but is pending warning message (see the commit message for the full details on this.. it was not that straight forward).

The one Mac specified issue is that `aiortc` does not have wheels for Python 3.7 on ARM Macs. The only work arounds for this are to: 1) remove Python 3.7 support for ARM Macs or 2) include `aiortc` as an extra includes. (2) seems like the better solution so ProxyStore is still usable on Python 3.7/M1 Mac---just with a reduced feature set.

#73 has been update to include the implementation of (2).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #84 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests now pass without and random warnings printed on linux and macos (except for macos Python 3.7 as stated above).

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
