### PR TITLE
Add `endpoints` extras install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ Python Lazy Object Proxy Interface for Distributed Stores
 ## Installation
 
 Install via pip:
-```
-$ pip install proxystore
+```bash
+# Base install
+pip install proxystore
+# Extras install for serving Endpoints
+pip install proxystore[endpoints]
 ```
 
-See the [Contributing Guide](https://proxystore.readthedocs.io/en/latest/contributing.html) for getting started for local development.
+More details are available on the [Get Started](https://proxystore.readthedocs.io/en/latest/getstarted.html) guide.
+For local development, see the [Contributing](https://proxystore.readthedocs.io/en/latest/contributing.html) guide.
 
 ## Documentation
 

--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -54,6 +54,8 @@ Installation
 
    $ pip install proxystore
 
+Serving :doc:`ProxyStore Endpoints <./guides/endpoints>` requires installing
+using the extras install: ``pip install proxystore[endpoints]``.
 See :doc:`Contributing <./contributing>` if you are installing for local
 development.
 
@@ -168,3 +170,13 @@ Examples
 Examples of integrating ProxyStore into distributed applications built on
 `FuncX <https://funcx.org/>`_ and `Parsl <https://parsl-project.org/>`_ are
 `here <https://github.com/proxystore/proxystore/tree/main/examples>`_.
+
+
+Known Issues
+------------
+
+* :doc:`ProxyStore Endpoints <./guides/endpoints>` are not supported for
+  Python 3.7 on ARM-based Macs because
+  `aiortc <https://aiortc.readthedocs.io/>`_ does not have the corresponding
+  wheels. The base ProxyStore package can still be installed on this
+  software/hardware configurations---just not with the ``endpoints`` extras.

--- a/proxystore/endpoint/constants.py
+++ b/proxystore/endpoint/constants.py
@@ -1,0 +1,6 @@
+"""ProxyStore Endpoint Constants."""
+from __future__ import annotations
+
+
+# Maximum chunk length (bytes) for GET/SET requests to/from the endpoint.
+MAX_CHUNK_LENGTH = 16 * 1000 * 1000

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -7,12 +7,21 @@ import logging
 import os
 import uuid
 
-import hypercorn
-import quart
-import uvloop
-from quart import request
-from quart import Response
+try:
+    import hypercorn
+    import quart
+    import uvloop
+    from quart import request
+    from quart import Response
+except ImportError as e:  # pragma: no cover
+    # Usually we would just print a warning, but this file requires
+    # quart to be available to register functions to a top-level blueprint.
+    raise ImportError(
+        f'{e}. To enable endpoint serving, install proxystore with '
+        '"pip install proxystore[endpoints]".',
+    )
 
+from proxystore.endpoint.constants import MAX_CHUNK_LENGTH
 from proxystore.endpoint.endpoint import Endpoint
 from proxystore.endpoint.exceptions import PeerRequestError
 from proxystore.utils import chunk_bytes
@@ -20,8 +29,6 @@ from proxystore.utils import chunk_bytes
 logger = logging.getLogger(__name__)
 
 routes_blueprint = quart.Blueprint('routes', __name__)
-
-MAX_CHUNK_LENGTH = 16 * 1000 * 1000
 
 
 def create_app(

--- a/proxystore/p2p/connection.py
+++ b/proxystore/p2p/connection.py
@@ -6,22 +6,29 @@ import logging
 import warnings
 from uuid import UUID
 
-from aiortc import RTCDataChannel
-from aiortc import RTCIceCandidate
-from aiortc import RTCPeerConnection
-from aiortc import RTCSessionDescription
-from aiortc.contrib.signaling import BYE
-from aiortc.contrib.signaling import object_from_string
-from aiortc.contrib.signaling import object_to_string
-from cryptography.utils import CryptographyDeprecationWarning
-from websockets.client import WebSocketClientProtocol
+try:
+    from aiortc import RTCDataChannel
+    from aiortc import RTCIceCandidate
+    from aiortc import RTCPeerConnection
+    from aiortc import RTCSessionDescription
+    from aiortc.contrib.signaling import BYE
+    from aiortc.contrib.signaling import object_from_string
+    from aiortc.contrib.signaling import object_to_string
+    from cryptography.utils import CryptographyDeprecationWarning
+    from websockets.client import WebSocketClientProtocol
+
+    warnings.simplefilter('ignore', CryptographyDeprecationWarning)
+except ImportError as e:  # pragma: no cover
+    warnings.warn(
+        f'{e}. To enable endpoint serving, install proxystore with '
+        '"pip install proxystore[endpoints]".',
+    )
 
 from proxystore.p2p import messages
 from proxystore.p2p.exceptions import PeerConnectionError
 from proxystore.p2p.exceptions import PeerConnectionTimeout
 
 logger = logging.getLogger(__name__)
-warnings.simplefilter('ignore', CryptographyDeprecationWarning)
 
 
 class PeerConnection:

--- a/proxystore/p2p/manager.py
+++ b/proxystore/p2p/manager.py
@@ -9,8 +9,16 @@ from typing import Any
 from typing import Generator
 from uuid import UUID
 
-import websockets
-from websockets.client import WebSocketClientProtocol
+try:
+    import websockets
+    from websockets.client import WebSocketClientProtocol
+except ImportError as e:  # pragma: no cover
+    import warnings
+
+    warnings.warn(
+        f'{e}. To enable endpoint serving, install proxystore with '
+        '"pip install proxystore[endpoints]".',
+    )
 
 from proxystore.p2p import messages
 from proxystore.p2p.connection import log_name

--- a/proxystore/p2p/server.py
+++ b/proxystore/p2p/server.py
@@ -14,10 +14,18 @@ from typing import Sequence
 from uuid import UUID
 from uuid import uuid4
 
-import websockets.client
-import websockets.exceptions
-from websockets.client import WebSocketClientProtocol
-from websockets.server import WebSocketServerProtocol
+try:
+    import websockets.client
+    import websockets.exceptions
+    from websockets.client import WebSocketClientProtocol
+    from websockets.server import WebSocketServerProtocol
+except ImportError as e:  # pragma: no cover
+    import warnings
+
+    warnings.warn(
+        f'{e}. To enable endpoint serving, install proxystore with '
+        '"pip install proxystore[endpoints]".',
+    )
 
 from proxystore.p2p import messages
 from proxystore.p2p.exceptions import PeerRegistrationError

--- a/proxystore/store/endpoint.py
+++ b/proxystore/store/endpoint.py
@@ -11,7 +11,7 @@ import proxystore as ps
 from proxystore.endpoint.config import default_dir
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
-from proxystore.endpoint.serve import MAX_CHUNK_LENGTH
+from proxystore.endpoint.constants import MAX_CHUNK_LENGTH
 from proxystore.store.base import Store
 from proxystore.utils import chunk_bytes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,16 +18,12 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    aiortc>=1.3.2
     cloudpickle>=1.6.0
     globus-sdk>=3.3.0
-    hypercorn[uvloop]>=0.13.0
     lazy-object-proxy>=1.6.0
     parsl>=1.0.0
-    quart>=0.18.0
     redis>=3.4
     requests>=2.27.1
-    websockets>=9.0
 python_requires = >=3.7
 include_package_data = True
 
@@ -40,6 +36,13 @@ exclude =
 console_scripts =
     signaling-server = proxystore.p2p.server:main
     proxystore-endpoint = proxystore.endpoint.cli:main
+
+[options.extras_require]
+endpoints =
+    aiortc>=1.3.2
+    hypercorn[uvloop]>=0.13.0
+    quart>=0.18.0
+    websockets>=9.0
 
 [options.package_data]
 * = py.typed

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py37, py38, py39, py310, pre-commit, docs
 
 [testenv]
+extras = endpoints
 deps = -rrequirements-dev.txt
 commands =
     coverage erase
@@ -15,6 +16,7 @@ deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
+extras = endpoints
 changedir = docs
 deps = -rdocs/requirements.txt
 commands = sphinx-build -W -E -b html . _build/html


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Moves the specific dependencies of the `proxystore.{endpoint,p2p}` modules to an extras install `endpoints`. This will allow users to avoid install the somewhat heavy dependencies necessary for hosting an endpoint if the user will not be doing so.

### Caveats

- #73 mentioned excluding `endpoints` extras from Tox for Python 3.7 + MacOS. I decided against this because the problem only exists on ARM-based Macs and not x86-based Macs so we would be limiting more than needed.
- #73 mentioned adding MacOS as a platform in the GitHub actions testing matrix. I decided against this purely for keeping the CI runtime lower. We can revisit this in the future---especially if more MacOS specific issues come up (e.g., different code paths for Macs).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #73

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests pass. Installed `proxystore` in fresh virtualenv with and without the `endpoints` extra to verify that warnings/ImportErrors were raised as expected.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
