### PR TITLE
Native Globus Auth Tools

### DIFF
--- a/examples/funcx/mapreduce_funcx.py
+++ b/examples/funcx/mapreduce_funcx.py
@@ -9,6 +9,7 @@ import numpy as np
 from funcx.sdk.client import FuncXClient
 
 import proxystore as ps
+import proxystore.store
 
 # Note: types on function are not provided because FuncX has trouble
 # serializing them sometimes

--- a/examples/parsl/mapreduce_parsl.py
+++ b/examples/parsl/mapreduce_parsl.py
@@ -8,6 +8,7 @@ import parsl
 from parsl import python_app
 
 import proxystore as ps
+import proxystore.store
 
 
 @python_app

--- a/examples/store_stats.py
+++ b/examples/store_stats.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import proxystore as ps
+import proxystore.store
 
 store = ps.store.init_store(
     'file',

--- a/proxystore/__init__.py
+++ b/proxystore/__init__.py
@@ -1,10 +1,5 @@
 """Top-level module for ProxyStore."""
 from __future__ import annotations
 
-import proxystore.factory as factory  # noqa: F401
-import proxystore.proxy as proxy  # noqa: F401
-import proxystore.serialize as serialize  # noqa: F401
-import proxystore.utils as utils  # noqa: F401
-from proxystore import store  # noqa: F401
 
 __version__ = '0.4.0a1'

--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -12,12 +12,12 @@ import os
 import shutil
 import uuid
 
-from proxystore.endpoint.config import default_dir
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
 from proxystore.endpoint.config import read_config
 from proxystore.endpoint.config import write_config
 from proxystore.endpoint.serve import serve
+from proxystore.utils import home_dir
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ def configure_endpoint(
         return 1
 
     if proxystore_dir is None:
-        proxystore_dir = default_dir()
+        proxystore_dir = home_dir()
     endpoint_dir = os.path.join(proxystore_dir, name)
 
     if os.path.exists(endpoint_dir):
@@ -100,7 +100,7 @@ def list_endpoints(
         are logged to the default logger.
     """
     if proxystore_dir is None:
-        proxystore_dir = default_dir()
+        proxystore_dir = home_dir()
 
     endpoints = get_configs(proxystore_dir)
 
@@ -134,7 +134,7 @@ def remove_endpoint(
         are logged to the default logger.
     """
     if proxystore_dir is None:
-        proxystore_dir = default_dir()
+        proxystore_dir = home_dir()
     endpoint_dir = os.path.join(proxystore_dir, name)
 
     if not os.path.exists(endpoint_dir):
@@ -167,7 +167,7 @@ def start_endpoint(
         are logged to the default logger.
     """
     if proxystore_dir is None:
-        proxystore_dir = default_dir()
+        proxystore_dir = home_dir()
 
     endpoint_dir = os.path.join(proxystore_dir, name)
     if not os.path.exists(endpoint_dir):

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
-import pathlib
 import re
 import uuid
 
-_DEFAULT_HOME_DIR = '.proxystore'
 _ENDPOINT_CONFIG_FILE = 'endpoint.json'
 
 
@@ -51,11 +49,6 @@ class EndpointConfig:
             )
         if self.max_memory is not None and self.max_memory < 1:
             raise ValueError('Max memory must be None or positive.')
-
-
-def default_dir() -> str:
-    """Returns path of $HOME/.proxystore."""
-    return os.path.join(pathlib.Path.home(), _DEFAULT_HOME_DIR)
 
 
 def get_configs(proxystore_dir: str) -> list[EndpointConfig]:

--- a/proxystore/globus.py
+++ b/proxystore/globus.py
@@ -1,0 +1,152 @@
+"""Globus OAuth Utilities.
+
+This implementation is based on
+`Parsl's implementation <https://github.com/Parsl/parsl/blob/1.2.0/parsl/data_provider/globus.py>`_  # noqa: E501
+and the `Globus examples <https://github.com/globus/native-app-examples/blob/064569e103f7d328f3d6c4b1242234011c81dffb/example_copy_paste_refresh_token.py>`_.  # noqa: #501
+"""
+from __future__ import annotations
+
+import functools
+import json
+import os
+from typing import Any
+from typing import Iterable
+
+import globus_sdk
+
+from proxystore.utils import home_dir
+
+# Registered `ProxyStore Application` by jgpauloski@uchicago.edu
+_APPLICATION_ID = 'a3379dba-a492-459a-a8df-5e7676a0472f'
+_REDIRECT_URI = 'https://auth.globus.org/v2/web/auth-code'
+_SCOPES = ('openid ', 'urn:globus:auth:scope:transfer.api.globus.org:all')
+_TOKENS_FILE = 'globus-tokens.json'
+
+
+class GlobusAuthFileError(Exception):
+    """Exception raised if the Globus Auth token file cannot be read."""
+
+    pass
+
+
+def load_tokens_from_file(filepath: str) -> dict[str, dict[str, Any]]:
+    """Load a set of saved tokens."""
+    with open(filepath) as f:
+        tokens = json.load(f)
+
+    return tokens
+
+
+def save_tokens_to_file(
+    filepath: str,
+    tokens: globus_sdk.OAuthTokenResponse,
+) -> None:
+    """Save a set of tokens for later use."""
+    with open(filepath, 'w') as f:
+        json.dump(tokens.by_resource_server, f, indent=4)
+
+
+def authenticate(
+    client_id: str,
+    redirect_uri: str,
+    requested_scopes: Iterable[str] | None = None,
+) -> globus_sdk.OAuthTokenResponse:
+    """Perform Native App auth flow."""
+    client = globus_sdk.NativeAppAuthClient(client_id=client_id)
+    client.oauth2_start_flow(
+        redirect_uri=redirect_uri,
+        refresh_tokens=True,
+        requested_scopes=requested_scopes,
+    )
+
+    url = client.oauth2_get_authorize_url()
+    print(f'Please visit the following url to authenticate:\n{url}')
+
+    auth_code = input('Enter the auth code: ').strip()
+    return client.oauth2_exchange_code_for_tokens(auth_code)
+
+
+def get_authorizer(
+    client_id: str,
+    tokens_file: str,
+    redirect_uri: str,
+    requested_scopes: Iterable[str] | None = None,
+) -> globus_sdk.RefreshTokenAuthorizer:
+    """Get an authorizer for the Globus SDK.
+
+    Raises:
+        GlobusAuthFileError:
+            if `tokens_file` cannot be parsed.
+    """
+    try:
+        tokens = load_tokens_from_file(tokens_file)
+    except OSError as e:
+        raise GlobusAuthFileError(
+            f'Error loading tokens from {tokens_file}: {e}.',
+        )
+
+    transfer_tokens = tokens['transfer.api.globus.org']
+    auth_client = globus_sdk.NativeAppAuthClient(client_id=client_id)
+
+    return globus_sdk.RefreshTokenAuthorizer(
+        transfer_tokens['refresh_token'],
+        auth_client,
+        access_token=transfer_tokens['access_token'],
+        expires_at=transfer_tokens['expires_at_seconds'],
+        on_refresh=functools.partial(save_tokens_to_file, tokens_file),
+    )
+
+
+def proxystore_authenticate(
+    proxystore_dir: str | None = None,
+) -> None:
+    """Perform auth flow for ProxyStore native app."""
+    proxystore_dir = home_dir() if proxystore_dir is None else proxystore_dir
+    tokens_file = os.path.join(proxystore_dir, _TOKENS_FILE)
+    os.makedirs(proxystore_dir, exist_ok=True)
+
+    tokens = authenticate(
+        client_id=_APPLICATION_ID,
+        redirect_uri=_REDIRECT_URI,
+        requested_scopes=_SCOPES,
+    )
+    save_tokens_to_file(tokens_file, tokens)
+
+
+def get_proxystore_authorizer(
+    proxystore_dir: str | None = None,
+) -> globus_sdk.RefreshTokenAuthorizer:
+    """Get an authorizer for the ProxyStore native app."""
+    proxystore_dir = home_dir() if proxystore_dir is None else proxystore_dir
+    tokens_file = os.path.join(proxystore_dir, _TOKENS_FILE)
+
+    return get_authorizer(
+        client_id=_APPLICATION_ID,
+        tokens_file=tokens_file,
+        redirect_uri=_REDIRECT_URI,
+        requested_scopes=_SCOPES,
+    )
+
+
+def main() -> int:
+    """Perform Globus authentication."""
+    try:
+        get_proxystore_authorizer()
+    except GlobusAuthFileError:
+        print(
+            'Performing authentication for the ProxyStore Globus Native app.',
+        )
+        proxystore_authenticate()
+        get_proxystore_authorizer()
+        print('Globus authorization complete.')
+    else:
+        print(
+            'Globus authorization is already completed. To re-authenticate, '
+            f'remove {os.path.join(home_dir(), _TOKENS_FILE)} and try again.',
+        )
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -13,6 +13,7 @@ from typing import Sequence
 from typing import TypeVar
 
 import proxystore as ps
+import proxystore.serialize
 from proxystore.factory import Factory
 from proxystore.proxy import Proxy
 from proxystore.store.cache import LRUCache

--- a/proxystore/store/endpoint.py
+++ b/proxystore/store/endpoint.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import requests
 
 import proxystore as ps
+import proxystore.serialize
 from proxystore.endpoint.config import default_dir
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs

--- a/proxystore/store/endpoint.py
+++ b/proxystore/store/endpoint.py
@@ -9,12 +9,12 @@ import requests
 
 import proxystore as ps
 import proxystore.serialize
-from proxystore.endpoint.config import default_dir
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
 from proxystore.endpoint.constants import MAX_CHUNK_LENGTH
 from proxystore.store.base import Store
 from proxystore.utils import chunk_bytes
+from proxystore.utils import home_dir
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class EndpointStore(Store):
             e if isinstance(e, UUID) else UUID(e, version=4) for e in endpoints
         ]
         self.proxystore_dir = (
-            default_dir() if proxystore_dir is None else proxystore_dir
+            home_dir() if proxystore_dir is None else proxystore_dir
         )
 
         # Find the first locally accessible endpoint to use as our

--- a/proxystore/store/globus.py
+++ b/proxystore/store/globus.py
@@ -25,6 +25,7 @@ import globus_sdk
 from parsl.data_provider import globus
 
 import proxystore as ps
+import proxystore.serialize
 from proxystore.store.base import Store
 
 logger = logging.getLogger(__name__)

--- a/proxystore/store/globus.py
+++ b/proxystore/store/globus.py
@@ -22,10 +22,11 @@ else:  # pragma: <3.9 cover
     from typing_extensions import Literal
 
 import globus_sdk
-from parsl.data_provider import globus
 
 import proxystore as ps
 import proxystore.serialize
+from proxystore.globus import get_proxystore_authorizer
+from proxystore.globus import GlobusAuthFileError
 from proxystore.store.base import Store
 
 logger = logging.getLogger(__name__)
@@ -252,11 +253,9 @@ class GlobusStore(Store):
 
     Note:
         To use Globus for data transfer, Globus authentication needs to be
-        performed. The user will be prompted to authenticate when the
-        :class:`GlobusStore <.GlobusStore>` is initialized. Alternatively,
-        authentication can be performed on the command line with
-        :code:`$ parsl_globus_auth`. Note authentication only needs to be
-        performed once.
+        performed otherwise an error will be raised. Authentication can be
+        performed on the command line with :code:`$ proxystore-globus-auth`.
+        Authentication only needs to be performed once per system.
 
     Warning:
         The :class:`GlobusStore <.GlobusStore>` encodes the Globus transfer
@@ -301,6 +300,8 @@ class GlobusStore(Store):
             stats (bool): collect stats on store operations (default: False).
 
         Raise:
+            GlobusAuthFileError:
+                if the Globus authentication file cannot be found.
             ValueError:
                 if `endpoints` is not a list of
                 :class:`GlobusEndpoint <.GlobusEndpoint>`, instance of
@@ -329,10 +330,16 @@ class GlobusStore(Store):
         self.sync_level = sync_level
         self.timeout = timeout
 
-        parsl_globus_auth = globus.get_globus()
+        try:
+            authorizer = get_proxystore_authorizer()
+        except GlobusAuthFileError:
+            raise GlobusAuthFileError(
+                'Error loading Globus auth tokens. Complete the '
+                'authentication process with the proxystore-globus-auth tool.',
+            )
 
         self._transfer_client = globus_sdk.TransferClient(
-            authorizer=parsl_globus_auth.authorizer,
+            authorizer=authorizer,
         )
 
         super().__init__(

--- a/proxystore/store/stats.py
+++ b/proxystore/store/stats.py
@@ -15,6 +15,7 @@ from typing import NamedTuple
 from typing import TypeVar
 
 import proxystore as ps
+import proxystore.proxy
 
 GenericCallable = TypeVar('GenericCallable', bound=Callable[..., Any])
 

--- a/proxystore/utils.py
+++ b/proxystore/utils.py
@@ -1,9 +1,13 @@
 """Utility functions."""
 from __future__ import annotations
 
+import os
+import pathlib
 import random
 from typing import Any
 from typing import Generator
+
+_DEFAULT_HOME_DIR = '.proxystore'
 
 
 def chunk_bytes(
@@ -54,3 +58,8 @@ def fullname(obj: Any) -> str:
     if module is None or module == str.__module__:
         return name
     return f'{module}.{name}'
+
+
+def home_dir() -> str:
+    """Returns path of $HOME/.proxystore."""
+    return os.path.join(pathlib.Path.home(), _DEFAULT_HOME_DIR)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ install_requires =
     cloudpickle>=1.6.0
     globus-sdk>=3.3.0
     lazy-object-proxy>=1.6.0
-    parsl>=1.0.0
     redis>=3.4
     requests>=2.27.1
 python_requires = >=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ exclude =
 console_scripts =
     signaling-server = proxystore.p2p.server:main
     proxystore-endpoint = proxystore.endpoint.cli:main
+    proxystore-globus-auth = proxystore.globus:main
 
 [options.extras_require]
 endpoints =

--- a/testing/store_utils.py
+++ b/testing/store_utils.py
@@ -105,14 +105,6 @@ class MockTransferClient:
         return True
 
 
-class MockGlobusAuth:
-    """Mock Parsl GlobusAuth."""
-
-    def __init__(self):
-        """Init MockGlobusAuth."""
-        self.authorizer = None
-
-
 class MockStrictRedis:
     """Mock StrictRedis."""
 
@@ -210,8 +202,7 @@ def globus_store() -> Generator[StoreInfo, None, None]:
     )
 
     with mock.patch(
-        'parsl.data_provider.globus.get_globus',
-        return_value=MockGlobusAuth(),
+        'proxystore.store.globus.get_proxystore_authorizer',
     ), mock.patch(
         'globus_sdk.TransferClient',
         MockTransferClient,

--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -15,9 +15,12 @@ from proxystore.endpoint.config import read_config
 
 
 @pytest.fixture()
-def default_dir(tmp_dir) -> Generator[str, None, None]:
+def home_dir(tmp_dir: str) -> Generator[str, None, None]:
     with mock.patch(
-        'proxystore.endpoint.commands.default_dir',
+        'proxystore.utils.home_dir',
+        return_value=tmp_dir,
+    ), mock.patch(
+        'proxystore.endpoint.commands.home_dir',
         return_value=tmp_dir,
     ):
         yield tmp_dir
@@ -44,7 +47,7 @@ def test_help_with_command(capsys) -> None:
     assert captured.out.startswith('usage: proxystore-endpoint list [-h]')
 
 
-def test_configure(default_dir) -> None:
+def test_configure(home_dir) -> None:
     name = 'my-endpoint'
     host = '127.0.0.1'
     port = 4321
@@ -62,7 +65,7 @@ def test_configure(default_dir) -> None:
         ],
     )
 
-    endpoint_dir = os.path.join(default_dir, name)
+    endpoint_dir = os.path.join(home_dir, name)
     assert os.path.isdir(endpoint_dir)
     cfg = read_config(endpoint_dir)
     assert cfg.name == name
@@ -71,8 +74,8 @@ def test_configure(default_dir) -> None:
     assert cfg.server == server
 
 
-def test_list(default_dir, caplog) -> None:
-    # Note: because default_dir is mocked, there's nothing to list so we
+def test_list(home_dir, caplog) -> None:
+    # Note: because home_dir is mocked, there's nothing to list so we
     # are really testing that the correct command in
     # proxystore.endpoint.commands is called and leaving the testing of that
     # command to tests/endpoint/commands_test.py.
@@ -82,7 +85,7 @@ def test_list(default_dir, caplog) -> None:
     assert 'No valid endpoint configurations' in caplog.records[0].message
 
 
-def test_remove(default_dir, caplog) -> None:
+def test_remove(home_dir, caplog) -> None:
     # Note: similar to test_list()
     caplog.set_level(logging.ERROR)
     main(['remove', 'my-endpoint'])
@@ -92,7 +95,7 @@ def test_remove(default_dir, caplog) -> None:
     )
 
 
-def test_serve(default_dir, caplog) -> None:
+def test_serve(home_dir, caplog) -> None:
     # Note: similar to test_list()
     caplog.set_level(logging.ERROR)
     main(['start', 'my-endpoint'])

--- a/tests/endpoint/commands_test.py
+++ b/tests/endpoint/commands_test.py
@@ -48,9 +48,9 @@ def test_configure_endpoint_basic(tmp_dir, caplog) -> None:
     )
 
 
-def test_configure_endpoint_default_dir(tmp_dir) -> None:
+def test_configure_endpoint_home_dir(tmp_dir) -> None:
     with mock.patch(
-        'proxystore.endpoint.commands.default_dir',
+        'proxystore.endpoint.commands.home_dir',
         return_value=tmp_dir,
     ):
         rv = configure_endpoint(
@@ -133,7 +133,7 @@ def test_list_endpoints_empty(tmp_dir, caplog) -> None:
     caplog.set_level(logging.INFO)
 
     with mock.patch(
-        'proxystore.endpoint.commands.default_dir',
+        'proxystore.endpoint.commands.home_dir',
         return_value=tmp_dir,
     ):
         rv = list_endpoints()
@@ -167,7 +167,7 @@ def test_remove_endpoints_does_not_exist(tmp_dir, caplog) -> None:
     caplog.set_level(logging.ERROR)
 
     with mock.patch(
-        'proxystore.endpoint.commands.default_dir',
+        'proxystore.endpoint.commands.home_dir',
         return_value=tmp_dir,
     ):
         rv = remove_endpoint(_NAME)
@@ -195,7 +195,7 @@ def test_start_endpoint_does_not_exist(tmp_dir, caplog) -> None:
     caplog.set_level(logging.ERROR)
 
     with mock.patch(
-        'proxystore.endpoint.commands.default_dir',
+        'proxystore.endpoint.commands.home_dir',
         return_value=tmp_dir,
     ):
         rv = start_endpoint(_NAME)

--- a/tests/endpoint/config_test.py
+++ b/tests/endpoint/config_test.py
@@ -7,17 +7,11 @@ from typing import Any
 
 import pytest
 
-from proxystore.endpoint.config import default_dir
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
 from proxystore.endpoint.config import read_config
 from proxystore.endpoint.config import validate_name
 from proxystore.endpoint.config import write_config
-
-
-def test_default_dir() -> None:
-    assert isinstance(default_dir(), str)
-    assert os.path.isabs(default_dir())
 
 
 def test_write_read_config(tmp_dir) -> None:

--- a/tests/globus_test.py
+++ b/tests/globus_test.py
@@ -1,0 +1,94 @@
+"""Globus Auth Unit Tests."""
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from unittest import mock
+
+import globus_sdk
+import pytest
+
+from proxystore.globus import _TOKENS_FILE
+from proxystore.globus import authenticate
+from proxystore.globus import get_authorizer
+from proxystore.globus import get_proxystore_authorizer
+from proxystore.globus import GlobusAuthFileError
+from proxystore.globus import load_tokens_from_file
+from proxystore.globus import main
+from proxystore.globus import proxystore_authenticate
+from proxystore.globus import save_tokens_to_file
+
+
+def test_save_load_tokens(tmp_dir: str) -> None:
+    os.makedirs(tmp_dir, exist_ok=True)
+    tmp_file = os.path.join(tmp_dir, 'globus.json')
+    data = {'tokens': {'token': '123456789'}}
+    with mock.patch('globus_sdk.OAuthTokenResponse'):
+        tokens = globus_sdk.OAuthTokenResponse()
+        tokens.by_resource_server = data  # type: ignore
+
+    save_tokens_to_file(tmp_file, tokens)
+    assert load_tokens_from_file(tmp_file) == data
+
+
+def test_authenticate(capsys) -> None:
+    # This test is heavily mocked so most just checks for simple errors
+    with mock.patch('globus_sdk.NativeAppAuthClient'), mock.patch(
+        'builtins.input',
+        return_value='123456789',
+    ), contextlib.redirect_stdout(
+        None,
+    ):
+        authenticate('1234', 'https://redirect')
+
+
+def test_get_authorizer(tmp_dir: str) -> None:
+    tokens = {
+        'transfer.api.globus.org': {
+            'refresh_token': 1234,
+            'access_token': 1234,
+            'expires_at_seconds': 1234,
+        },
+    }
+    os.makedirs(tmp_dir, exist_ok=True)
+    filepath = os.path.join(tmp_dir, 'tokens.json')
+    with open(filepath, 'w') as f:
+        json.dump(tokens, f)
+
+    with mock.patch('globus_sdk.NativeAppAuthClient'), mock.patch(
+        'globus_sdk.RefreshTokenAuthorizer',
+    ):
+        get_authorizer('client id', filepath, 'redirect uri')
+
+
+def test_get_authorizer_missing_file(tmp_dir: str) -> None:
+    filepath = os.path.join(tmp_dir, 'missing_file')
+    with pytest.raises(GlobusAuthFileError):
+        get_authorizer('client id', filepath, 'redirect uri')
+
+
+def test_proxystore_authenticate(tmp_dir: str) -> None:
+    data = {'tokens': {'token': '123456789'}}
+    with mock.patch('globus_sdk.OAuthTokenResponse'):
+        tokens = globus_sdk.OAuthTokenResponse()
+        tokens.by_resource_server = data  # type: ignore
+
+    with mock.patch('proxystore.globus.authenticate', return_value=tokens):
+        proxystore_authenticate(tmp_dir)
+
+    assert load_tokens_from_file(os.path.join(tmp_dir, _TOKENS_FILE)) == data
+
+    with mock.patch('proxystore.globus.get_authorizer'):
+        get_proxystore_authorizer(tmp_dir)
+
+
+def test_main(tmp_dir: str) -> None:
+    with mock.patch('proxystore.globus.proxystore_authenticate'), mock.patch(
+        'proxystore.globus.get_proxystore_authorizer',
+        side_effect=[GlobusAuthFileError(), None, None],
+    ), contextlib.redirect_stdout(None):
+        # First will raise auth file missing error and trigger auth flow
+        main()
+        # Second will find auth file and just exit
+        main()

--- a/tests/integration/endpoints_test.py
+++ b/tests/integration/endpoints_test.py
@@ -154,10 +154,10 @@ def test_proxy_detects_endpoint(endpoints) -> None:
     """Test transferring data via proxy between two process and endpoints."""
     endpoints, proxystore_dirs = endpoints
 
-    # Mock default_dir to simulate different systems
+    # Mock home_dir to simulate different systems
     def produce(queue: Queue[Any]) -> None:
         with mock.patch(
-            'proxystore.store.endpoint.default_dir',
+            'proxystore.store.endpoint.home_dir',
             return_value=proxystore_dirs[0],
         ):
             store = EndpointStore('store', endpoints=endpoints)
@@ -167,7 +167,7 @@ def test_proxy_detects_endpoint(endpoints) -> None:
 
     def consume(queue: Queue[Any]) -> None:
         with mock.patch(
-            'proxystore.store.endpoint.default_dir',
+            'proxystore.store.endpoint.home_dir',
             return_value=proxystore_dirs[1],
         ):
             port = queue.get()

--- a/tests/store/globus_test.py
+++ b/tests/store/globus_test.py
@@ -5,11 +5,13 @@ import json
 import os
 import re
 import uuid
+from unittest import mock
 
 import globus_sdk
 import pytest
 
 import proxystore as ps
+from proxystore.globus import GlobusAuthFileError
 from proxystore.store.globus import GlobusEndpoint
 from proxystore.store.globus import GlobusEndpoints
 from proxystore.store.globus import GlobusStore
@@ -293,3 +295,10 @@ def test_expand_user_path(globus_store) -> None:
         filename,
         ep2,
     )
+
+
+def test_globus_auth_not_done(tmp_dir: str) -> None:
+    """Test Globus auth missing during Store init."""
+    with mock.patch('proxystore.globus.home_dir', return_value=tmp_dir):
+        with pytest.raises(GlobusAuthFileError):
+            GlobusStore('store', endpoints=[EP1, EP2])

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -8,6 +8,7 @@ import pytest
 from proxystore import utils
 from proxystore.factory import SimpleFactory
 from proxystore.utils import chunk_bytes
+from proxystore.utils import home_dir
 
 
 @pytest.mark.parametrize(
@@ -35,3 +36,8 @@ def test_fullname() -> None:
         == 'proxystore.factory.SimpleFactory'
     )
     assert utils.fullname('string') == 'str'
+
+
+def test_home_dir() -> None:
+    assert isinstance(home_dir(), str)
+    assert os.path.isabs(home_dir())


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This PR implements native authentication for a new Globus "ProxyStore Application" native app and switches the authorizer in the `GlobusStore` from Parsl to the new native version.

This removes Parsl as a dependency and is progress towards eventual endpoint authentication (#62).

This is a breaking change for anyone that has previously used the `GlobusStore` with Parsl authentication. Authentication will need to be redone with the `proxystore-globus-auth` command-line tool.

Also removed imports from `proxystore/__init__.py` because I typically do not like importing in `__init__.py`s because it is easy to create circular imports.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Unit tests pass. Ran example FuncX app with Globus backend between workstation and Midway to verify Globus auth+transfer works.

Added unit tests for the new `proxystore.globus` module but these are not particularly effective unit tests as all of the Globus API requests are mocked. I manually ran through all the code paths with the new CLI tool.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
