### PR TITLE
Remove user-specified keys

### DIFF
--- a/proxystore/store/endpoint.py
+++ b/proxystore/store/endpoint.py
@@ -225,11 +225,6 @@ class EndpointStore(Store):
         else:
             raise EndpointStoreError(f'GET returned {response}')
 
-    def get_timestamp(self, key: str) -> float:
-        if not self.exists(key):
-            raise KeyError(f'key={key} does not exists in the endpoint')
-        return 0.0
-
     def set(
         self,
         obj: Any,

--- a/proxystore/store/endpoint.py
+++ b/proxystore/store/endpoint.py
@@ -7,8 +7,6 @@ from uuid import UUID
 
 import requests
 
-import proxystore as ps
-import proxystore.serialize
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
 from proxystore.endpoint.constants import MAX_CHUNK_LENGTH
@@ -121,9 +119,9 @@ class EndpointStore(Store):
             },
         )
 
-    @staticmethod
-    def _create_key(object_key: str, endpoint_uuid: UUID) -> str:
-        return f'{object_key}:{str(endpoint_uuid)}'
+    def create_key(self, obj: Any) -> str:
+        key = super().create_key(obj)
+        return f'{key}:{str(self.endpoint_uuid)}'
 
     @staticmethod
     def _parse_key(key: str) -> tuple[str, UUID | None]:
@@ -224,28 +222,6 @@ class EndpointStore(Store):
             return None
         else:
             raise EndpointStoreError(f'GET returned {response}')
-
-    def set(
-        self,
-        obj: Any,
-        *,
-        key: str | None = None,
-        serialize: bool = True,
-    ) -> str:
-        if serialize:
-            obj = ps.serialize.serialize(obj)
-        if not isinstance(obj, bytes):
-            raise TypeError('obj must be of type bytes if serialize=False.')
-        if key is None:
-            key = self.create_key(obj)
-        key = self._create_key(key, self.endpoint_uuid)
-
-        self.set_bytes(key, obj)
-        logger.debug(
-            f"SET key='{key}' IN {self.__class__.__name__}"
-            f"(name='{self.name}')",
-        )
-        return key
 
     def set_bytes(self, key: str, data: bytes) -> None:
         """Set serialized object in remote store with key.

--- a/proxystore/store/file.py
+++ b/proxystore/store/file.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-import time
 
 from proxystore.store.base import Store
 
@@ -80,13 +79,6 @@ class FileStore(Store):
                 return data
         return None
 
-    def get_timestamp(self, key: str) -> float:
-        if not self.exists(key):
-            raise KeyError(
-                f"Key='{key}' does not have a corresponding file in the store",
-            )
-        return os.path.getmtime(os.path.join(self.store_dir, key))
-
     def set_bytes(self, key: str, data: bytes) -> None:
         """Write serialized object to file system with key.
 
@@ -97,7 +89,3 @@ class FileStore(Store):
         path = os.path.join(self.store_dir, key)
         with open(path, 'wb', buffering=0) as f:
             f.write(data)
-        # Manually set timestamp on file with nanosecond precision because some
-        # filesystems can have low default file modified precisions
-        timestamp = time.time_ns()
-        os.utime(path, ns=(timestamp, timestamp))

--- a/proxystore/store/globus.py
+++ b/proxystore/store/globus.py
@@ -7,8 +7,6 @@ import os
 import re
 import socket
 import sys
-import time
-import warnings
 from typing import Any
 from typing import Collection
 from typing import Generator
@@ -261,12 +259,6 @@ class GlobusStore(Store):
         The :class:`GlobusStore <.GlobusStore>` encodes the Globus transfer
         IDs into the keys, thus the keys returned by functions such
         as :func:`set() <set>` will be different.
-
-    Warning:
-        :class:`GlobusStore <.GlobusStore>` enforces strict guarantees on
-        object versions. I.e., the parameter :code:`strict` will be ignored
-        and objects returned by the store will always be the most up to date
-        version.
     """
 
     def __init__(
@@ -549,36 +541,6 @@ class GlobusStore(Store):
         with open(path, 'rb') as f:
             return f.read()
 
-    def get_timestamp(self, key: str) -> float:
-        if not self.exists(key):
-            raise KeyError(
-                f"Key='{key}' does not have a corresponding file in the store",
-            )
-        return os.path.getmtime(self._get_filepath(self._get_filename(key)))
-
-    def get(
-        self,
-        key: str,
-        *,
-        deserialize: bool = True,
-        strict: bool = False,
-        default: Any | None = None,
-    ) -> Any | None:
-        if strict:
-            warnings.warn(
-                'GlobusStore objects are immutable so setting strict=True '
-                'has no effect.',
-            )
-        return super().get(
-            key,
-            deserialize=deserialize,
-            strict=False,
-            default=default,
-        )
-
-    def is_cached(self, key: str, *, strict: bool = False) -> bool:
-        return self._cache.exists(key)
-
     def set_bytes(self, key: str, data: bytes) -> None:
         if not isinstance(data, bytes):
             raise TypeError(f'data must be of type bytes. Found {type(data)}')
@@ -587,10 +549,6 @@ class GlobusStore(Store):
             os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, 'wb', buffering=0) as f:
             f.write(data)
-        # Manually set timestamp on file with nanosecond precision because some
-        # filesystems can have low default file modified precisions
-        timestamp = time.time_ns()
-        os.utime(path, ns=(timestamp, timestamp))
 
     def set(
         self,

--- a/proxystore/store/local.py
+++ b/proxystore/store/local.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import time
 
 from proxystore.store.base import Store
 
@@ -62,9 +61,5 @@ class LocalStore(Store):
     def get_bytes(self, key: str) -> bytes | None:
         return self._store.get(key, None)
 
-    def get_timestamp(self, key: str) -> float:
-        return float(self._store[key + '_timestamp'].decode())
-
     def set_bytes(self, key: str, data: bytes) -> None:
-        self._store[key + '_timestamp'] = str(time.time()).encode()
         self._store[key] = data

--- a/proxystore/store/redis.py
+++ b/proxystore/store/redis.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import time
 
 import redis
 
@@ -58,13 +57,5 @@ class RedisStore(Store):
     def get_bytes(self, key: str) -> bytes | None:
         return self._redis_client.get(key)
 
-    def get_timestamp(self, key: str) -> float:
-        value = self._redis_client.get(key + '_timestamp')
-        if value is None:
-            raise KeyError(f"Key='{key}' does not exist in Redis store")
-        return float(value.decode())
-
     def set_bytes(self, key: str, data: bytes) -> None:
-        # We store the creation time for the key as a separate redis key-value.
-        self._redis_client.set(key + '_timestamp', time.time())
         self._redis_client.set(key, data)

--- a/testing/store_utils.py
+++ b/testing/store_utils.py
@@ -131,10 +131,6 @@ class MockStrictRedis:
 
     def set(self, key: str, value: str | bytes | int | float) -> None:
         """Set value in MockStrictRedis."""
-        if isinstance(value, (int, float)):
-            value = str(value)
-        if isinstance(value, str):
-            value = value.encode()
         self.data[key] = value
 
 

--- a/tests/store/endpoint_test.py
+++ b/tests/store/endpoint_test.py
@@ -58,7 +58,7 @@ def test_bad_responses(endpoint_store) -> None:
     response.status_code = 400
 
     with mock.patch('requests.get', return_value=response):
-        key = store.set([1, 2, 3], key='key')
+        key = store.set([1, 2, 3])
         assert store.get(key) is None
 
     response.status_code = 401
@@ -75,7 +75,7 @@ def test_bad_responses(endpoint_store) -> None:
             store.evict(key)
 
         with pytest.raises(EndpointStoreError, match='401'):
-            store.set([1, 2, 3], key='key')
+            store.set([1, 2, 3])
 
 
 def test_key_parse() -> None:

--- a/tests/store/globus_test.py
+++ b/tests/store/globus_test.py
@@ -212,10 +212,6 @@ def test_globus_store_internals(globus_store) -> None:
     """Test GlobusStore internal mechanisms."""
     store = GlobusStore('globus', **globus_store.kwargs)
 
-    with pytest.warns(Warning):
-        # Check that warning for not supporting strict is raised
-        store.get('key', strict=True)
-
     class PatchedError(globus_sdk.TransferAPIError):
         def __init__(self, status: int):
             self.http_status = status

--- a/tests/store/globus_test.py
+++ b/tests/store/globus_test.py
@@ -237,6 +237,15 @@ def test_globus_store_internals(globus_store) -> None:
         store._wait_on_tasks('1234')
 
 
+def test_globus_store_set_batch_type_error(globus_store) -> None:
+    """Test GlobusStore internal mechanisms."""
+    store = GlobusStore('globus', **globus_store.kwargs)
+
+    objs = [1, 2, 3]
+    with pytest.raises(TypeError):
+        store.set_batch(objs, serialize=False)
+
+
 def test_get_filepath(globus_store) -> None:
     """Test GlobusStore filepath building."""
     endpoints = GlobusEndpoints(

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -121,64 +121,6 @@ def test_store_caching(store_fixture, request) -> None:
 
 
 @pytest.mark.parametrize('store_fixture', FIXTURE_LIST)
-def test_store_timestamps(store_fixture, request) -> None:
-    """Test Store Timestamps."""
-    store_config = request.getfixturevalue(store_fixture)
-
-    store = store_config.type(
-        store_config.name,
-        **store_config.kwargs,
-        cache_size=1,
-    )
-
-    missing_key = 'key12398908352'
-    with pytest.raises(KeyError):
-        store.get_timestamp(missing_key)
-
-    key = store.set('timestamp_test_value')
-    assert isinstance(store.get_timestamp(key), float)
-
-
-@pytest.mark.parametrize('store_fixture', FIXTURE_LIST)
-def test_store_strict(store_fixture, request) -> None:
-    """Test Store Strict Functionality."""
-    store_config = request.getfixturevalue(store_fixture)
-
-    if store_config.type.__name__ in ('GlobusStore', 'EndpointStore'):
-        # GlobusStore/EndpointStore do not support strict guarantees
-        return
-
-    store = store_config.type(
-        store_config.name,
-        **store_config.kwargs,
-        cache_size=1,
-    )
-
-    # Add our test value
-    value = 'test_value'
-    base_key = 'strict_key'
-    assert not store.exists(base_key)
-    key = store.set(value, key=base_key)
-
-    # Access key so value is cached locally
-    assert store.get(key) == value
-    assert store.is_cached(key)
-
-    # Change value in Store
-    key = store.set('new_value', key=base_key)
-    # Old value of key is still cached
-    assert store.get(key) == value
-    assert store.is_cached(key)
-    assert not store.is_cached(key, strict=True)
-
-    # Access with strict=True so now most recent version should be cached
-    assert store.get(key, strict=True) == 'new_value'
-    assert store.get(key) == 'new_value'
-    assert store.is_cached(key)
-    assert store.is_cached(key, strict=True)
-
-
-@pytest.mark.parametrize('store_fixture', FIXTURE_LIST)
 def test_store_custom_serialization(store_fixture, request) -> None:
     """Test Store Custom Serialization."""
     store_config = request.getfixturevalue(store_fixture)

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -108,16 +108,12 @@ def test_store_proxy(store_fixture, request) -> None:
     key = ps.proxy.get_key(p)
     assert key is not None and store.get(key) == [1, 2, 3]
 
-    p = store.proxy(key=key)
+    p = store.proxy_from_key(key)
     assert p == [1, 2, 3]
 
     p = store.proxy([2, 3, 4])
     key = ps.proxy.get_key(p)
     assert key is not None and store.get(key) == [2, 3, 4]
-
-    with pytest.raises(ValueError):
-        # At least one of key or object must be passed
-        store.proxy()
 
     with pytest.raises(Exception):
         # String will not be serialized and should raise error when putting
@@ -179,11 +175,7 @@ def test_proxy_batch(store_fixture, request) -> None:
         **store_config.kwargs,
     )
 
-    with pytest.raises(ValueError):
-        store.proxy_batch(None, keys=None)
-
     values1 = [b'test_value1', b'test_value2', b'test_value3']
-
     proxies1: list[Proxy[bytes]] = store.proxy_batch(values1, serialize=False)
     for p1, v1 in zip(proxies1, values1):
         assert p1 == v1
@@ -193,12 +185,6 @@ def test_proxy_batch(store_fixture, request) -> None:
     proxies2: list[Proxy[str]] = store.proxy_batch(values2)
     for p2, v2 in zip(proxies2, values2):
         assert p2 == v2
-
-    proxies3: list[Proxy[str]] = store.proxy_batch(
-        keys=[ps.proxy.get_key(p) for p in proxies2],  # type: ignore
-    )
-    for p3, v2 in zip(proxies3, values2):
-        assert p3 == v2
 
     store.close()
 
@@ -226,6 +212,6 @@ def test_raises_missing_key(store_fixture, request) -> None:
     with pytest.raises(ProxyResolveMissingKey):
         factory.resolve()
 
-    proxy: Proxy[Any] = store.proxy(key=key)
+    proxy: Proxy[Any] = store.proxy_from_key(key=key)
     with pytest.raises(ProxyResolveMissingKey):
         proxy()


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

As noted in #48, ProxyStore is designed around a write-once, read-many workflows (e.g., like ephemeral/intermediate task data) so supporting user-specified keys causes some headaches with consistency guarantees.

This PR removes user-specified keys such that key generation is done internally. This also sets us up for *better keys* (#49).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes: #48

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests pass and old tests removed/updated that used manual keys.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
