### PR TITLE
Change store keys to named tuples

### DIFF
--- a/examples/funcx/mapreduce_funcx.py
+++ b/examples/funcx/mapreduce_funcx.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import sys
 import time
+from typing import Any
 
 import numpy as np
 from funcx.sdk.client import FuncXClient
@@ -100,7 +101,7 @@ if __name__ == '__main__':
     double_uuid = fxc.register_function(app_double)
     sum_uuid = fxc.register_function(app_sum)
 
-    store: ps.store.base.Store | None = None
+    store: ps.store.base.Store[Any] | None = None
     if args.ps_file:
         store = ps.store.init_store(
             'file',

--- a/proxystore/proxy.py
+++ b/proxystore/proxy.py
@@ -136,24 +136,6 @@ def extract(proxy: proxystore.proxy.Proxy[T]) -> T:
     return proxy.__wrapped__
 
 
-def get_key(proxy: proxystore.proxy.Proxy[T]) -> str | None:
-    """Return key associated object wrapped by proxy.
-
-    Keys are stored in the `factory` passed to the
-    :class:`Proxy <proxystore.proxy.Proxy>` constructor; however, not all
-    :mod:`Factory <proxystore.factory>` classes use a key.
-
-    Args:
-        proxy (Proxy): proxy instance to get key from.
-
-    Returns:
-        key (`str`) if it exists otherwise `None`.
-    """
-    if hasattr(proxy.__factory__, 'key'):
-        return proxy.__factory__.key
-    return None
-
-
 def is_resolved(proxy: proxystore.proxy.Proxy[T]) -> bool:
     """Check if a proxy is resolved.
 

--- a/proxystore/store/cache.py
+++ b/proxystore/store/cache.py
@@ -1,10 +1,14 @@
 """Simple Cache Implementation."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Generic
+from typing import TypeVar
+
+KeyT = TypeVar('KeyT')
+ValueT = TypeVar('ValueT')
 
 
-class LRUCache:
+class LRUCache(Generic[KeyT, ValueT]):
     """Simple LRU Cache."""
 
     def __init__(self, maxsize: int = 16) -> None:
@@ -20,24 +24,24 @@ class LRUCache:
         if maxsize < 0:
             raise ValueError('Cache size must by >= 0')
         self.maxsize = maxsize
-        self.data: dict[Any, Any] = {}
-        self.lru: list[Any] = []
+        self.data: dict[KeyT, ValueT] = {}
+        self.lru: list[KeyT] = []
 
         # Count hits/misses
         self.hits = 0
         self.misses = 0
 
-    def evict(self, key: Any) -> None:
+    def evict(self, key: KeyT) -> None:
         """Evict key from cache."""
-        if self.exists(key):
-            self.data.pop(key, None)
+        if key in self.data:
+            del self.data[key]
             self.lru.remove(key)
 
-    def exists(self, key: Any) -> bool:
+    def exists(self, key: KeyT) -> bool:
         """Check if key is in cache."""
         return key in self.data
 
-    def get(self, key: Any, default: object | None = None) -> Any:
+    def get(self, key: KeyT, default: ValueT | None = None) -> ValueT | None:
         """Get value for key if it exists else returns default."""
         if self.exists(key):
             # Move to front b/c most recently used
@@ -49,7 +53,7 @@ class LRUCache:
             self.misses += 1
             return default
 
-    def set(self, key: Any, value: Any) -> None:
+    def set(self, key: KeyT, value: ValueT) -> None:
         """Set key to value."""
         if self.maxsize == 0:
             return

--- a/proxystore/store/exceptions.py
+++ b/proxystore/store/exceptions.py
@@ -1,7 +1,33 @@
 """Exceptions for Stores."""
 from __future__ import annotations
 
-from proxystore import store
+from typing import NamedTuple
+
+from proxystore.store import base
+
+
+class StoreError(Exception):
+    """Base exception class for store errors."""
+
+    pass
+
+
+class StoreExistsError(StoreError):
+    """Exception raised when a store with the same name already exists."""
+
+    pass
+
+
+class UnknownStoreError(StoreError):
+    """Exception raised when the type of store to initialize is unknown."""
+
+    pass
+
+
+class ProxyStoreFactoryError(StoreError):
+    """Exception raised when a proxy was not created by a Store."""
+
+    pass
 
 
 class ProxyResolveMissingKey(Exception):
@@ -9,14 +35,14 @@ class ProxyResolveMissingKey(Exception):
 
     def __init__(
         self,
-        key: str,
-        store_type: type[store.base.Store],
+        key: NamedTuple,
+        store_type: type[base.Store[base.KeyT]],
         store_name: str,
     ) -> None:
         """Init ProxyResolveMissingKey.
 
         Args:
-            key (str): key associated with target object that could not be
+            key (tuple): key associated with target object that could not be
                 found in the store.
             store_type (Store): type of store that the key could not be found
                 in.

--- a/proxystore/store/redis.py
+++ b/proxystore/store/redis.py
@@ -2,15 +2,24 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
+from typing import NamedTuple
 
 import redis
 
+import proxystore.utils as utils
 from proxystore.store.base import Store
 
 logger = logging.getLogger(__name__)
 
 
-class RedisStore(Store):
+class RedisStoreKey(NamedTuple):
+    """Key to objects in a RedisStore."""
+
+    redis_key: str
+
+
+class RedisStore(Store[RedisStoreKey]):
     """Redis backend class."""
 
     def __init__(
@@ -43,19 +52,22 @@ class RedisStore(Store):
             kwargs={'hostname': self.hostname, 'port': self.port},
         )
 
-    def evict(self, key: str) -> None:
-        self._redis_client.delete(key)
+    def create_key(self, obj: Any) -> RedisStoreKey:
+        return RedisStoreKey(redis_key=utils.create_key(obj))
+
+    def evict(self, key: RedisStoreKey) -> None:
+        self._redis_client.delete(key.redis_key)
         self._cache.evict(key)
         logger.debug(
             f"EVICT key='{key}' FROM {self.__class__.__name__}"
             f"(name='{self.name}')",
         )
 
-    def exists(self, key: str) -> bool:
-        return bool(self._redis_client.exists(key))
+    def exists(self, key: RedisStoreKey) -> bool:
+        return bool(self._redis_client.exists(key.redis_key))
 
-    def get_bytes(self, key: str) -> bytes | None:
-        return self._redis_client.get(key)
+    def get_bytes(self, key: RedisStoreKey) -> bytes | None:
+        return self._redis_client.get(key.redis_key)
 
-    def set_bytes(self, key: str, data: bytes) -> None:
-        self._redis_client.set(key, data)
+    def set_bytes(self, key: RedisStoreKey, data: bytes) -> None:
+        self._redis_client.set(key.redis_key, data)

--- a/proxystore/store/stats.py
+++ b/proxystore/store/stats.py
@@ -14,11 +14,10 @@ from typing import KeysView
 from typing import NamedTuple
 from typing import TypeVar
 
-import proxystore as ps
-import proxystore.proxy
+from proxystore.proxy import Proxy
+from proxystore.store.utils import get_key
 
 GenericCallable = TypeVar('GenericCallable', bound=Callable[..., Any])
-
 
 STORE_METHOD_KEY_IS_RESULT = {
     'evict': False,
@@ -36,7 +35,7 @@ class Event(NamedTuple):
     """Event corresponding to a function called with a specific key."""
 
     function: str
-    key: str | None
+    key: NamedTuple | None
 
 
 @dataclass
@@ -149,7 +148,7 @@ class FunctionEventStats(MutableMapping):  # type: ignore
         self,
         function: GenericCallable,
         key_is_result: bool,
-        preset_key: str | None,
+        preset_key: NamedTuple | None,
         *args: Any,
         **kwargs: Any,
     ) -> Any:
@@ -159,8 +158,8 @@ class FunctionEventStats(MutableMapping):  # type: ignore
             function (callable): function to wrap.
             key_is_result (bool): if `True`, the key is the return value of
                 `function` rather than the first argument. (default: False).
-            preset_key (str): optionally preset the key associated with
-                any calls to `function`. This overrides `key_is_returned`.
+            preset_key (NamedTuple): optionally preset the key associated
+                with any calls to `function`. This overrides `key_is_returned`.
             args: Arguments passed to `function`
             kwargs: Keywords arguments passed to `function`.
 
@@ -172,8 +171,8 @@ class FunctionEventStats(MutableMapping):  # type: ignore
         time_ns = perf_counter_ns() - start_ns
 
         if key_is_result:
-            if isinstance(result, ps.proxy.Proxy):
-                key = ps.proxy.get_key(result)
+            if isinstance(result, Proxy):
+                key = get_key(result)
             else:
                 key = result
         elif preset_key is not None:
@@ -193,7 +192,7 @@ class FunctionEventStats(MutableMapping):  # type: ignore
         function: GenericCallable,
         *,
         key_is_result: bool = False,
-        preset_key: str | None = None,
+        preset_key: NamedTuple | None = None,
     ) -> GenericCallable:
         """Wraps a method to log stats on calls to the function.
 
@@ -201,8 +200,8 @@ class FunctionEventStats(MutableMapping):  # type: ignore
             function (callable): function to wrap.
             key_is_result (bool): if `True`, the key is the return value of
                 `function` rather than the first argument. (default: False).
-            preset_key (str): optionally preset the key associated with
-                any calls to `function`. This overrides `key_is_returned`.
+            preset_key (NamedTuple): optionally preset the key associated
+                with any calls to `function`. This overrides `key_is_returned`.
 
         Returns:
             callable with same interface as `function`.

--- a/proxystore/store/utils.py
+++ b/proxystore/store/utils.py
@@ -1,0 +1,37 @@
+"""Store utilities."""
+from __future__ import annotations
+
+from typing import NamedTuple
+from typing import TypeVar
+
+from proxystore.proxy import Proxy
+from proxystore.store import base
+from proxystore.store.exceptions import ProxyStoreFactoryError
+
+T = TypeVar('T')
+
+
+def get_key(proxy: Proxy[T]) -> NamedTuple:
+    """Extract the key from the proxy's factory.
+
+    Args:
+        proxy (Proxy): proxy instance to get key from.
+
+    Returns:
+        The key, a NamedTuple unique to the
+        :class:`~proxystore.store.base.Store` that created the proxy..
+
+    Raises:
+        ProxyStoreFactoryError:
+            if the proxy's factory is not an instance of
+            :class:`~proxystore.store.base.StoreFactory`.
+    """
+    factory = proxy.__factory__
+    if isinstance(factory, base.StoreFactory):
+        return factory.key
+    else:
+        raise ProxyStoreFactoryError(
+            'The proxy must contain a factory with type '
+            f'{type(base.StoreFactory).__name__}. {type(factory).__name__} '
+            'is not supported.',
+        )

--- a/tests/proxy_test.py
+++ b/tests/proxy_test.py
@@ -22,8 +22,6 @@ def test_proxy() -> None:
     p = Proxy(f)
 
     assert not ps.proxy.is_resolved(p)
-    # BaseFactory does not use a key like KeyFactory or RedisFactory
-    assert ps.proxy.get_key(p) is None
 
     # Test pickleable
     p_pkl = pkl.dumps(p)

--- a/tests/store/cache_test.py
+++ b/tests/store/cache_test.py
@@ -14,7 +14,7 @@ def test_lru_raises() -> None:
 
 def test_lru_cache() -> None:
     """Test LRU Cache."""
-    c = LRUCache(4)
+    c: LRUCache[str, int] = LRUCache(4)
     # Put 1, 2, 3, 4 in cache
     for i in range(1, 5):
         c.set(str(i), i)

--- a/tests/store/endpoint_test.py
+++ b/tests/store/endpoint_test.py
@@ -78,11 +78,6 @@ def test_bad_responses(endpoint_store) -> None:
             store.set([1, 2, 3])
 
 
-def test_key_parse() -> None:
-    with pytest.raises(ValueError, match='key'):
-        EndpointStore._parse_key('a:b:c')
-
-
 def test_chunked_requests(endpoint_store) -> None:
     store = EndpointStore(
         endpoint_store.name,

--- a/tests/store/globus_test.py
+++ b/tests/store/globus_test.py
@@ -15,6 +15,7 @@ from proxystore.globus import GlobusAuthFileError
 from proxystore.store.globus import GlobusEndpoint
 from proxystore.store.globus import GlobusEndpoints
 from proxystore.store.globus import GlobusStore
+from proxystore.store.globus import GlobusStoreKey
 
 
 EP1 = GlobusEndpoint(
@@ -223,11 +224,12 @@ def test_globus_store_internals(globus_store) -> None:
         return _error
 
     store._transfer_client.get_task = _http_error(400)  # type: ignore
-    assert not store._validate_key('uuid:filename')
+    assert not store._validate_task_id('uuid')
+    assert not store.exists(GlobusStoreKey('fake', 'fake'))
 
     store._transfer_client.get_task = _http_error(401)  # type: ignore
     with pytest.raises(globus_sdk.TransferAPIError):
-        store._validate_key('uuid:filename')
+        store._validate_task_id('uuid')
 
     def _fail_wait(*args, **kwargs) -> bool:
         return False

--- a/tests/store/init_test.py
+++ b/tests/store/init_test.py
@@ -1,15 +1,17 @@
 """Store Imports and Initialization Unit Tests."""
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import proxystore as ps
 from proxystore.factory import SimpleFactory
 from proxystore.proxy import Proxy
-from proxystore.store import ProxyStoreFactoryError
-from proxystore.store import StoreExistsError
 from proxystore.store import STORES
-from proxystore.store import UnknownStoreError
+from proxystore.store.exceptions import ProxyStoreFactoryError
+from proxystore.store.exceptions import StoreExistsError
+from proxystore.store.exceptions import UnknownStoreError
 from proxystore.store.local import LocalStore
 
 
@@ -101,7 +103,7 @@ def test_get_enum_by_type() -> None:
     assert isinstance(t, str)
     assert STORES[t].value == ps.store.local.LocalStore
 
-    class FakeStore(ps.store.base.Store):
+    class FakeStore(ps.store.base.Store[Any]):
         """FakeStore type."""
 
         pass

--- a/tests/store/local_test.py
+++ b/tests/store/local_test.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from proxystore.store.local import LocalStore
+from proxystore.store.local import LocalStoreKey
 
 
 def test_store_dict() -> None:
     """Test LocalStore reusable dict."""
-    d: dict[str, bytes] = {}
+    d: dict[LocalStoreKey, bytes] = {}
     store1 = LocalStore('local1', store_dict=d)
     key = store1.set(123)
 

--- a/tests/store/stats_test.py
+++ b/tests/store/stats_test.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+from typing import NamedTuple
 
 from pytest import raises
 
@@ -10,23 +11,29 @@ from proxystore.store.stats import FunctionEventStats
 from proxystore.store.stats import TimeStats
 
 
-class TestClass:
+class _TestKey(NamedTuple):
+    """Test key. Store keys are all NamedTuples."""
+
+    key: str
+
+
+class _TestClass:
     """Test Class."""
 
-    def get_value(self, key: str, value: int = 0) -> int:
+    def get_value(self, key: _TestKey, value: int = 0) -> int:
         """Returns value."""
         return value
 
-    def key_arg(self, key: str) -> None:
+    def key_arg(self, key: _TestKey) -> None:
         """Function where key in arg."""
         pass
 
-    def key_return(self, *, key: str) -> str:
+    def key_return(self, *, key: _TestKey) -> _TestKey:
         """Function where key is kwarg."""
         return key
 
 
-def sleep(key: str, seconds: float) -> None:
+def sleep(key: _TestKey, seconds: float) -> None:
     """Sleep function."""
     time.sleep(seconds)
 
@@ -48,43 +55,45 @@ def test_time_stats() -> None:
 
 def test_event_hashes() -> None:
     """Test Event hashes."""
-    d = {Event(function='f', key='k'): 1}
-    assert d[Event(function='f', key='k')] == 1
+    d = {Event(function='f', key=_TestKey('k')): 1}
+    assert d[Event(function='f', key=_TestKey('k'))] == 1
 
 
 def test_wrapper_emulates_function() -> None:
     """Test wrapper emulates function."""
     stats = FunctionEventStats()
-    obj = TestClass()
+    obj = _TestClass()
     wrapped = stats.wrap(obj.get_value)
-    assert obj.get_value('key', 5) == wrapped('key', 5)
+    assert obj.get_value(_TestKey('key'), 5) == wrapped(_TestKey('key'), 5)
 
 
 def test_key_args_vs_return() -> None:
     """Test handling of different key argument positions."""
     stats = FunctionEventStats()
-    obj = TestClass()
+    obj = _TestClass()
 
+    key = _TestKey('key')
+    missing_key = _TestKey('missing_key')
     wrapped_arg = stats.wrap(obj.key_arg)
-    wrapped_arg('key')
-    assert stats[Event(function='key_arg', key='key')].calls == 1
+    wrapped_arg(key)
+    assert stats[Event(function='key_arg', key=key)].calls == 1
 
     wrapped_return = stats.wrap(obj.key_return, key_is_result=True)
-    wrapped_return(key='key')
-    assert stats[Event(function='key_return', key='key')].calls == 1
+    wrapped_return(key=key)
+    assert stats[Event(function='key_return', key=key)].calls == 1
 
     # Set key_is_result to True even though it is not to test default key
     # of None.
     wrapped_arg = stats.wrap(obj.key_arg, key_is_result=True)
-    wrapped_arg('missing_key')
-    assert stats[Event(function='key_arg', key='missing_key')].calls == 0
+    wrapped_arg(missing_key)
+    assert stats[Event(function='key_arg', key=missing_key)].calls == 0
     assert stats[Event(function='key_arg', key=None)].calls == 1
 
     # Set key_is_result to False even though it is not to test default key
     # of None
     wrapped_return = stats.wrap(obj.key_return, key_is_result=False)
-    wrapped_return(key='missing_key')
-    assert stats[Event(function='key_return', key='missing_keykey')].calls == 0
+    wrapped_return(key=missing_key)
+    assert stats[Event(function='key_return', key=missing_key)].calls == 0
     assert stats[Event(function='key_return', key=None)].calls == 1
 
 
@@ -92,10 +101,11 @@ def test_function_timing() -> None:
     """Test function timing."""
     stats = FunctionEventStats()
 
+    key = _TestKey('key')
     wrapped = stats.wrap(sleep)
 
-    event = Event(function='sleep', key='key')
-    wrapped('key', 0.01)
+    event = Event(function='sleep', key=key)
+    wrapped(key, 0.01)
 
     assert event in stats
     assert stats[event].calls == 1
@@ -104,12 +114,12 @@ def test_function_timing() -> None:
     assert stats[event].min_time_ms == stats[event].max_time_ms
 
     old_max = stats[event].max_time_ms
-    wrapped('key', 1)
+    wrapped(key, 1)
     assert stats[event].calls == 2
     assert stats[event].max_time_ms > old_max
 
     old_min = stats[event].min_time_ms
-    wrapped('key', 0)
+    wrapped(key, 0)
     assert stats[event].calls == 3
     assert stats[event].min_time_ms < old_min
 
@@ -119,31 +129,32 @@ def test_default_times() -> None:
     stats = FunctionEventStats()
     assert len(stats) == 0
 
-    event = Event(function='fake', key='fake')
+    event = Event(function='fake', key=_TestKey('fake'))
     assert stats[event].calls == 0
 
 
 def test_enforces_types() -> None:
     """Test FunctionEventStats enforces types of keys and values."""
     stats = FunctionEventStats()
+    key = _TestKey('key')
 
     with raises(TypeError):
-        stats['key']  # type: ignore
+        stats[key]  # type: ignore
 
     with raises(TypeError):
-        stats[Event(function='function', key='key')] = 'value'  # type: ignore
+        stats[Event(function='function', key=key)] = 'value'  # type: ignore
 
     with raises(TypeError):
-        stats['key'] = TimeStats()  # type: ignore
+        stats[key] = TimeStats()  # type: ignore
 
     with raises(TypeError):
-        stats.update([('key', 'value')])
+        stats.update([(key, 'value')])
 
 
 def test_behaves_like_mapping() -> None:
     """Test FunctionEventStats behaves like a mapping."""
     stats = FunctionEventStats()
-    event = Event(function='f', key='k')
+    event = Event(function='f', key=_TestKey('k'))
 
     # __setitem__
     stats[event] = TimeStats(calls=0)
@@ -163,8 +174,10 @@ def test_update() -> None:
     """Test FunctionEventStats.update()."""
     stats = FunctionEventStats()
 
-    stats.update({Event(function='f', key='k'): TimeStats(calls=1)})
-    assert stats[Event(function='f', key='k')].calls == 1
+    stats.update({Event(function='f', key=_TestKey('k')): TimeStats(calls=1)})
+    assert stats[Event(function='f', key=_TestKey('k'))].calls == 1
 
-    stats.update([(Event(function='f', key='k'), TimeStats(calls=2))])
-    assert stats[Event(function='f', key='k')].calls == 3
+    stats.update(
+        [(Event(function='f', key=_TestKey('k')), TimeStats(calls=2))],
+    )
+    assert stats[Event(function='f', key=_TestKey('k'))].calls == 3

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -1,12 +1,15 @@
 """Store Base Functionality Tests."""
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
 import proxystore as ps
 from proxystore.store.base import Store
 from testing.store_utils import FIXTURE_LIST
+from testing.store_utils import missing_key
 
 
 @pytest.mark.parametrize('store_fixture', FIXTURE_LIST)
@@ -38,12 +41,12 @@ def test_store_base(store_fixture, request) -> None:
     """Test Store Base Functionality."""
     store_config = request.getfixturevalue(store_fixture)
 
-    store: Store = store_config.type(
+    store: Store[Any] = store_config.type(
         store_config.name,
         **store_config.kwargs,
     )
 
-    key_fake = 'key_fake'
+    key_fake = missing_key(store)
     value = 'test_value'
 
     # Store.set()
@@ -81,7 +84,7 @@ def test_store_caching(store_fixture, request) -> None:
     """Test Store Caching Functionality."""
     store_config = request.getfixturevalue(store_fixture)
 
-    store: Store = store_config.type(
+    store: Store[Any] = store_config.type(
         store_config.name,
         **store_config.kwargs,
         cache_size=1,
@@ -124,7 +127,7 @@ def test_store_custom_serialization(store_fixture, request) -> None:
     """Test Store Custom Serialization."""
     store_config = request.getfixturevalue(store_fixture)
 
-    store: Store = store_config.type(
+    store: Store[Any] = store_config.type(
         store_config.name,
         **store_config.kwargs,
     )
@@ -143,7 +146,7 @@ def test_store_batch_ops(store_fixture, request) -> None:
     """Test Batch Operations."""
     store_config = request.getfixturevalue(store_fixture)
 
-    store: Store = store_config.type(
+    store: Store[Any] = store_config.type(
         store_config.name,
         **store_config.kwargs,
     )
@@ -163,7 +166,7 @@ def test_store_batch_ops_remote(store_fixture, request) -> None:
     """Test Batch Operations for Remote Stores."""
     store_config = request.getfixturevalue(store_fixture)
 
-    store: Store = store_config.type(
+    store: Store[Any] = store_config.type(
         store_config.name,
         **store_config.kwargs,
     )

--- a/tests/store/utils_test.py
+++ b/tests/store/utils_test.py
@@ -1,0 +1,26 @@
+"""Unit tests for proxystore.store.utils."""
+from __future__ import annotations
+
+import pytest
+
+from proxystore.factory import SimpleFactory
+from proxystore.proxy import Proxy
+from proxystore.store.exceptions import ProxyStoreFactoryError
+from proxystore.store.local import LocalStore
+from proxystore.store.utils import get_key
+
+
+def test_get_key_from_proxy() -> None:
+    store = LocalStore('store')
+
+    key = store.set('value')
+    proxy: Proxy[str] = store.proxy_from_key(key)
+
+    assert get_key(proxy) == key
+
+
+def test_get_key_from_proxy_not_created_by_store() -> None:
+    p = Proxy(SimpleFactory('value'))
+
+    with pytest.raises(ProxyStoreFactoryError):
+        get_key(p)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This PR addresses the difficulties raised in #49 about storing additional metadata about an object in a proxy returned by a `Store`. Many store backend may require more than just a string key to correctly retrieve an object. For example, `EndpointStore` needs an object ID and endpoint ID.

To resolve this limitation, this PR changes the keys used by `Store`s to be instances of NamedTuple rather than strings. Each `Store` type has a corresponding `StoreKey` type. For example:

```Python
from typing import NamedTuple
from proxystore.store.base import Store

class MyKey(NamedTuple):
    name: str
    size: int
    ...

class MyStore(Store[MyKey]):
    ...
```

A number of changes were necessary to make this happen:
- `Store` is now a generic type with respect to the key.
- `StoreFactory` is now generic with respect to both the key and the target object (previously it was just the target object as all subclasses of `Factory` are).
- `LRUCache` is now a generic type so we can specify the keys of the cache are of the same type as the keys of the `Store`.
- Moved `get_key` from `proxystore.proxy` to `proxystore.store.utils` as the functionality of "extracting a key from a proxy" is specific to the store module which requires all factories to have a key attribute.
- Moved the exception declarations from `proxystore.store` to `proxystore.store.exceptions` for consistency within the module.

*Notes:*
- The changes to keys should not be breaking changes because #90 removed the ability for users to specify their own keys; however, some functions/classes changed modules so the import changes result in this being a breaking change.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #49 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

All unit tests pass.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
