### PR TITLE
Fix relative path bug in `FileStore`

### DIFF
--- a/proxystore/store/file.py
+++ b/proxystore/store/file.py
@@ -41,7 +41,7 @@ class FileStore(Store[FileStoreKey]):
                 process (default: 16).
             stats (bool): collect stats on store operations (default: False).
         """
-        self.store_dir = store_dir
+        self.store_dir = os.path.abspath(store_dir)
 
         if not os.path.exists(self.store_dir):
             os.makedirs(self.store_dir, exist_ok=True)
@@ -50,7 +50,7 @@ class FileStore(Store[FileStoreKey]):
             name,
             cache_size=cache_size,
             stats=stats,
-            kwargs={'store_dir': store_dir},
+            kwargs={'store_dir': self.store_dir},
         )
 
     def close(self) -> None:

--- a/testing/store_utils.py
+++ b/testing/store_utils.py
@@ -249,6 +249,7 @@ def endpoint_store(tmp_dir: str) -> Generator[StoreInfo, None, None]:
     )
 
     server_handle.terminate()
+    server_handle.join()
 
 
 def missing_key(store: Store[KeyT]) -> NamedTuple:

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -1,22 +1,17 @@
 """Fixtures and utilities for testing."""
 from __future__ import annotations
 
-import os
-import shutil
+import pathlib
 import socket
-import uuid
 from typing import Generator
 
 import pytest
 
 
 @pytest.fixture()
-def tmp_dir() -> Generator[str, None, None]:
+def tmp_dir(tmp_path: pathlib.Path) -> Generator[str, None, None]:
     """Yields unique path to directory and cleans up after."""
-    path = f'/tmp/{uuid.uuid4()}'
-    yield path
-    if os.path.exists(path):
-        shutil.rmtree(path)
+    yield str(tmp_path)
 
 
 def open_port() -> int:

--- a/tests/endpoint/config_test.py
+++ b/tests/endpoint/config_test.py
@@ -15,6 +15,7 @@ from proxystore.endpoint.config import write_config
 
 
 def test_write_read_config(tmp_dir) -> None:
+    tmp_dir = os.path.join(tmp_dir, 'config-dir')
     assert not os.path.exists(tmp_dir)
 
     cfg = EndpointConfig(
@@ -42,6 +43,7 @@ def test_read_config_missing_file(tmp_dir) -> None:
 
 
 def test_get_configs(tmp_dir) -> None:
+    tmp_dir = os.path.join(tmp_dir, 'config-dir')
     assert not os.path.exists(tmp_dir)
     # dir does not exists so empty list should be returned
     assert len(get_configs(tmp_dir)) == 0

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -342,6 +342,9 @@ def test_serve() -> None:
 
 
 def test_serve_logging(tmp_dir) -> None:
+    # Make a sub dir that should not exist to check serve makes the dir
+    tmp_dir = os.path.join(tmp_dir, 'log-dir')
+
     def _serve(log_file: str) -> None:
         # serve() calls asyncio.run() but the pytest environment does not have
         # a usable event loop so we need to manually create on.

--- a/tests/p2p/server_cli_test.py
+++ b/tests/p2p/server_cli_test.py
@@ -21,6 +21,7 @@ else:  # pragma: <3.8 cover
 
 
 def test_logging_dir(tmp_dir) -> None:
+    tmp_dir = os.path.join(tmp_dir, 'log-dir')
     assert not os.path.isdir(tmp_dir)
     with mock.patch('proxystore.p2p.server.serve', AsyncMock()):
         main(['--log-dir', tmp_dir])

--- a/tests/store/file_test.py
+++ b/tests/store/file_test.py
@@ -15,3 +15,17 @@ def test_file_store_close(tmp_dir: str) -> None:
     store.close()
 
     assert not os.path.exists(tmp_dir)
+
+
+def test_cwd_change(tmp_dir: str) -> None:
+    """Checks FileStore proxies still resolve when the CWD changes."""
+    os.chdir(tmp_dir)
+    store_dir = './store-dir'
+
+    new_working_dir = os.path.join(tmp_dir, 'new-working-dir')
+    os.makedirs(new_working_dir, exist_ok=True)
+
+    with FileStore('store', store_dir=store_dir, cache_size=0) as store:
+        p = store.proxy('data')
+        os.chdir(new_working_dir)
+        assert p == 'data'

--- a/tests/store/file_test.py
+++ b/tests/store/file_test.py
@@ -2,18 +2,16 @@
 from __future__ import annotations
 
 import os
-import uuid
 
 from proxystore.store.file import FileStore
 
 
-def test_file_store_close() -> None:
+def test_file_store_close(tmp_dir: str) -> None:
     """Test FileStore Cleanup."""
-    store_dir = f'/tmp/proxystore-test-{uuid.uuid4()}'
-    store = FileStore('files', store_dir=store_dir)
+    store = FileStore('files', store_dir=tmp_dir)
 
-    assert os.path.exists(store_dir)
+    assert os.path.exists(tmp_dir)
 
     store.close()
 
-    assert not os.path.exists(store_dir)
+    assert not os.path.exists(tmp_dir)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Fixes a bug where proxies would not resolve from a `FileStore` if the `store_dir` was a relative path and the current working directory changes.

Also update the `tmp_dir` fixture to be more reliable across OS types.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #97 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a new test that verifies `FileStore` proxies still resolve when the `FileStore` is initialized with a relative path and the current working directory changes.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
