### PR TITLE
Make asynchronous resolve functionality unique to `Store`s

### DIFF
--- a/docs/source/proxystore.proxy.rst
+++ b/docs/source/proxystore.proxy.rst
@@ -1,17 +1,27 @@
 proxystore.proxy
 ################
 
-.. class:: proxystore.proxy.Proxy(factory: proxystore.factory.Factory)
+.. class:: proxystore.proxy.Proxy(factory: Callable[[], T])
 
-   Lazy Object Proxy
+   Bases: :class:`Generic`\[:class:`T`\]
 
-   An extension of the Proxy from `lazy-object-proxy <https://github.com/ionelmc/python-lazy-object-proxy>`_ with modified pickling behavior.
+   Lazy Object Proxy.
 
-   An object proxy acts as a thin wrapper around a Python object, i.e. the proxy behaves identically to the underlying object.
-   The proxy is initialized with a callable factory object.
-   The factory returns the underlying object when called, i.e. ‘resolves’ the proxy. The proxy does just-in-time resolution, i.e., the proxy does not call the factory until the first access to the proxy (hence, the lazy aspect of the proxy).
+   An extension of the Proxy from
+   `lazy-object-proxy <https://github.com/ionelmc/python-lazy-object-proxy>`_
+   with modified pickling behavior.
 
-   The factory contains the mechanisms to appropriately resolve the object, e.g., which in the case for ProxyStore means requesting the correct object from the backend store.
+   An object proxy acts as a thin wrapper around a Python object, i.e.
+   the proxy behaves identically to the underlying object. The proxy is
+   initialized with a callable factory object. The factory returns the
+   underlying object when called, i.e. 'resolves' the proxy. The does
+   just-in-time resolution, i.e., the proxy
+   does not call the factory until the first access to the proxy (hence, the
+   lazy aspect of the proxy).
+
+   The factory contains the mechanisms to appropriately resolve the object,
+   e.g., which in the case for ProxyStore means requesting the correct
+   object from the backend store.
 
    .. code-block:: python
 
@@ -22,18 +32,19 @@ proxystore.proxy
       >>> assert np.array_equal(p, [1, 2, 3])
 
    .. note::
-
-      The `factory`, by default, is only ever called once during the lifetime of a proxy instance.
+      The `factory`, by default, is only ever called once during the
+      lifetime of a proxy instance.
 
    .. note::
-
-      When a proxy instance is pickled, only the `factory` is pickled, not the wrapped object.
-      Thus, proxy instances can be pickled and passed around cheaply, and once the proxy is unpickled and used, the `factory` will be called again to resolve the object.
+      When a proxy instance is pickled, only the `factory` is pickled, not
+      the wrapped object. Thus, proxy instances can be pickled and passed
+      around cheaply, and once the proxy is unpickled and used, the `factory`
+      will be called again to resolve the object.
 
    :param factory: callable object that returns the underlying object when called.
-   :type factory: :class:`Factory <proxystore.factory.Factory>`
+   :type factory: :class:`Callable[[], T]`
 
-   :raises TypeError: if `factory` is not an instance of :class:`Factory <proxystore.factory.Factory>`.
+   :raises TypeError: if `factory` is not callable.
 
 .. automodule:: proxystore.proxy
    :members:

--- a/proxystore/proxy.py
+++ b/proxystore/proxy.py
@@ -156,29 +156,3 @@ def resolve(proxy: proxystore.proxy.Proxy[T]) -> None:
         proxy (Proxy): proxy instance to force resolve.
     """
     proxy.__wrapped__
-
-
-def resolve_async(proxy: proxystore.proxy.Proxy[T]) -> None:
-    """Begin resolving proxy asynchronously.
-
-    Useful if the user knows a proxy will be needed soon and wants to
-    resolve the proxy concurrently with other computation.
-
-    >>> ps.proxy.resolve_async(my_proxy)
-    >>> computation_without_proxy(...)
-    >>> # p is hopefully resolved
-    >>> computation_with_proxy(my_proxy, ...)
-
-    Note:
-        The asynchronous resolving functionality is implemented
-        in :func:`Factory.resolve_async()
-        <proxystore.factory.Factory.resolve_async()>`.
-        Most :mod:`Factory <proxystore.factory>` implementations will store a
-        future to the result and wait on that future the next
-        time the proxy is used.
-
-    Args:
-        proxy (Proxy): proxy instance to begin asynchronously resolving.
-    """
-    if not is_resolved(proxy):
-        proxy.__factory__.resolve_async()

--- a/proxystore/store/utils.py
+++ b/proxystore/store/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import NamedTuple
 from typing import TypeVar
 
+from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.store import base
 from proxystore.store.exceptions import ProxyStoreFactoryError
@@ -35,3 +36,26 @@ def get_key(proxy: Proxy[T]) -> NamedTuple:
             f'{type(base.StoreFactory).__name__}. {type(factory).__name__} '
             'is not supported.',
         )
+
+
+def resolve_async(proxy: Proxy[T]) -> None:
+    """Begin resolving proxy asynchronously.
+
+    Useful if the user knows a proxy will be needed soon and wants to
+    resolve the proxy concurrently with other computation.
+
+    >>> ps.proxy.resolve_async(my_proxy)
+    >>> computation_without_proxy(...)
+    >>> # p is hopefully resolved
+    >>> computation_with_proxy(my_proxy, ...)
+
+    Note:
+        The asynchronous resolving functionality is implemented
+        by :class:`~proxystore.store.base.StoreFactory`. Factories that are not
+        of this type will error when used with this function.
+
+    Args:
+        proxy (Proxy): proxy instance to begin asynchronously resolving.
+    """
+    if not is_resolved(proxy):
+        proxy.__factory__.resolve_async()

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -18,10 +18,6 @@ def test_simple_factory() -> None:
     f = ps.serialize.deserialize(f_pkl)
     assert f() == [1, 2, 3]
 
-    # Test async resolve
-    f.resolve_async()
-    assert f() == [1, 2, 3]
-
 
 def test_lambda_factory() -> None:
     """Test LambdaFactory."""
@@ -33,10 +29,6 @@ def test_lambda_factory() -> None:
     # Test pickleable
     f1_pkl = ps.serialize.serialize(f1)
     f1 = ps.serialize.deserialize(f1_pkl)
-    assert f1() == [1, 2, 3]
-
-    # Test async resolve
-    f1.resolve_async()
     assert f1() == [1, 2, 3]
 
     # Test with function

--- a/tests/proxy_test.py
+++ b/tests/proxy_test.py
@@ -29,13 +29,6 @@ def test_proxy() -> None:
 
     assert not ps.proxy.is_resolved(p)
 
-    # Test async
-    ps.proxy.resolve_async(p)
-    assert p[0] == 1
-    # Now async resolve should be a no-op
-    ps.proxy.resolve_async(p)
-    assert p[1] == 2
-
     assert isinstance(p, Proxy)
     assert isinstance(p, np.ndarray)
     assert ps.proxy.is_resolved(p)

--- a/tests/store/utils_test.py
+++ b/tests/store/utils_test.py
@@ -4,19 +4,20 @@ from __future__ import annotations
 import pytest
 
 from proxystore.factory import SimpleFactory
+from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.local import LocalStore
 from proxystore.store.utils import get_key
+from proxystore.store.utils import resolve_async
 
 
 def test_get_key_from_proxy() -> None:
-    store = LocalStore('store')
+    with LocalStore('store') as store:
+        key = store.set('value')
+        proxy: Proxy[str] = store.proxy_from_key(key)
 
-    key = store.set('value')
-    proxy: Proxy[str] = store.proxy_from_key(key)
-
-    assert get_key(proxy) == key
+        assert get_key(proxy) == key
 
 
 def test_get_key_from_proxy_not_created_by_store() -> None:
@@ -24,3 +25,20 @@ def test_get_key_from_proxy_not_created_by_store() -> None:
 
     with pytest.raises(ProxyStoreFactoryError):
         get_key(p)
+
+
+def test_async_resolve() -> None:
+    with LocalStore('store') as store:
+        value = 'value'
+        p = store.proxy(value)
+
+        assert not is_resolved(p)
+
+        resolve_async(p)
+        assert p == value
+
+        assert is_resolved(p)
+
+        # Now async resolve should be a no-op
+        resolve_async(p)
+        assert p == value


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Moves the asynchronous resolve of proxies from `proxystore.factory.Factory` to `proxystore.store.base.StoreFactory`. This change is motivated by the fact that `Proxy` no longer requires and instance of `Factory` so we cannot assert that `async_resolve` works on every proxy, but it will work on every proxy created by a `Store`.

Also update the `Proxy` docstring which was out of date.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #102 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests pass.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
