### PR TITLE
Peering Performance Improvements

### DIFF
--- a/docs/source/proxystore.p2p.chunks.rst
+++ b/docs/source/proxystore.p2p.chunks.rst
@@ -1,0 +1,7 @@
+proxystore.p2p.chunks
+#####################
+
+.. automodule:: proxystore.p2p.chunks
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/proxystore.p2p.counter.rst
+++ b/docs/source/proxystore.p2p.counter.rst
@@ -1,0 +1,7 @@
+proxystore.p2p.counter
+######################
+
+.. automodule:: proxystore.p2p.counter
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/proxystore.p2p.rst
+++ b/docs/source/proxystore.p2p.rst
@@ -3,7 +3,9 @@ proxystore.p2p
 
 .. toctree::
 
+   proxystore.p2p.chunks
    proxystore.p2p.connection
+   proxystore.p2p.counter
    proxystore.p2p.exceptions
    proxystore.p2p.manager
    proxystore.p2p.messages

--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -102,6 +102,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         required='--max-memory' in sys.argv,
         help='optional directory to dump objects to if max_memory reached',
     )
+    parser_configure.add_argument(
+        '--peer-channels',
+        default=1,
+        type=int,
+        help='datachannels per peer connection',
+    )
 
     # Command: list
     subparsers.add_parser(

--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -31,6 +31,7 @@ def configure_endpoint(
     proxystore_dir: str | None = None,
     max_memory: int | None = None,
     dump_dir: str | None = None,
+    peer_channels: int = 1,
 ) -> int:
     """Configure a new endpoint.
 
@@ -47,6 +48,8 @@ def configure_endpoint(
             (default: None).
         dump_dir (str): optional directory to dump objects to if the
             memory limit is exceeded (default: None).
+        peer_channels (int): number of datachannels per peer connection
+            to another endpoint to communicate over (default: 1).
 
     Returns:
         Exit code where 0 is success and 1 is failure. Failure messages
@@ -61,6 +64,7 @@ def configure_endpoint(
             server=server,
             max_memory=max_memory,
             dump_dir=dump_dir,
+            peer_channels=peer_channels,
         )
     except ValueError as e:
         logger.error(str(e))
@@ -200,6 +204,7 @@ def start_endpoint(
         log_file=os.path.join(endpoint_dir, 'endpoint.log'),
         max_memory=cfg.max_memory,
         dump_dir=cfg.dump_dir,
+        peer_channels=cfg.peer_channels,
     )
 
     return 0

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -21,6 +21,7 @@ class EndpointConfig:
     server: str | None = None
     max_memory: int | None = None
     dump_dir: str | None = None
+    peer_channels: int = 1
 
     def __post_init__(self) -> None:
         """Validate config contains reasonable values.

--- a/proxystore/endpoint/endpoint.py
+++ b/proxystore/endpoint/endpoint.py
@@ -91,6 +91,7 @@ class Endpoint:
         peer_timeout: int = 30,
         max_memory: int | None = None,
         dump_dir: str | None = None,
+        peer_channels: int = 1,
     ) -> None:
         """Init Endpoint.
 
@@ -121,6 +122,8 @@ class Endpoint:
                 (default: None).
             dump_dir (str): optional directory to dump objects to if the
                 memory limit is exceeded (default: None).
+            peer_channels (int): number of datachannels per peer connection
+                to another endpoint to communicate over (default: 1).
         """
         # TODO(gpauloski): need to consider semantics of operations
         #   - can all ops be triggered on remote?
@@ -129,6 +132,7 @@ class Endpoint:
         self._uuid = uuid
         self._signaling_server = signaling_server
         self._peer_timeout = peer_timeout
+        self._peer_channels = peer_channels
 
         self._mode = (
             EndpointMode.SOLO
@@ -192,6 +196,7 @@ class Endpoint:
                 signaling_server=self._signaling_server,
                 name=self.name,
                 timeout=self._peer_timeout,
+                peer_channels=self._peer_channels,
             )
             self._peer_handler_task = spawn_guarded_background_task(
                 self._handle_peer_requests,

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -76,6 +76,7 @@ def serve(
     log_file: str | None = None,
     max_memory: int | None = None,
     dump_dir: str | None = None,
+    peer_channels: int = 1,
 ) -> None:
     """Initialize endpoint and serve Quart app.
 
@@ -98,6 +99,8 @@ def serve(
             (default: None).
         dump_dir (str): optional directory to dump objects to if the
             memory limit is exceeded (default: None).
+        peer_channels (int): number of datachannels per peer connection
+            to another endpoint to communicate over (default: 1).
     """
     if log_file is not None:
         parent_dir = os.path.dirname(log_file)
@@ -121,6 +124,7 @@ def serve(
         signaling_server=server,
         max_memory=max_memory,
         dump_dir=dump_dir,
+        peer_channels=peer_channels,
     )
     app = create_app(endpoint)
 

--- a/proxystore/p2p/chunks.py
+++ b/proxystore/p2p/chunks.py
@@ -1,0 +1,156 @@
+"""Message chunking utilities."""
+from __future__ import annotations
+
+import enum
+import math
+from struct import pack
+from struct import unpack_from
+from typing import Generator
+
+CHUNK_HEADER_LENGTH = 2 + (4 * 4)
+CHUNK_HEADER_FORMAT = '!HLLLL'
+
+
+class ChunkDType(enum.Enum):
+    """Data type contained in a Chunk."""
+
+    BYTES = 1
+    """Data is bytes."""
+    STRING = 2
+    """Data is a string."""
+
+
+class Chunk:
+    """Representation of a chunk of a message."""
+
+    def __init__(
+        self,
+        stream_id: int,
+        seq_id: int,
+        seq_len: int,
+        data: bytes | str,
+        dtype: ChunkDType | None = None,
+    ) -> None:
+        """Init Chunk.
+
+        Args:
+            stream_id (int): unique ID for the stream of chunks.
+            seq_id (int): sequence number for this chunk in the stream.
+            seq_len (int): length of the stream.
+            data (bytes, str): data for this chunk.
+            dtype (ChunkDType): optionally specify data type otherwise inferred
+                from data (default: None).
+
+        Raises:
+            ValueError:
+                if the sequence ID is not less than the sequence length.
+        """
+        if seq_len <= seq_id:
+            raise ValueError(
+                f'seq_id ({seq_id}) must be less than seq_len ({seq_len}).',
+            )
+        self.stream_id = stream_id
+        self.seq_id = seq_id
+        self.seq_len = seq_len
+        self.data = data
+        if dtype is None:
+            self.dtype = (
+                ChunkDType.BYTES
+                if isinstance(data, bytes)
+                else ChunkDType.STRING
+            )
+        else:
+            self.dtype = dtype
+
+    def __bytes__(self) -> bytes:
+        """Pack the chunk into bytes."""
+        length = CHUNK_HEADER_LENGTH + len(self.data)
+        header = pack(
+            CHUNK_HEADER_FORMAT,
+            self.dtype.value,
+            length,
+            self.stream_id,
+            self.seq_id,
+            self.seq_len,
+        )
+        data = (
+            self.data.encode('utf8')
+            if isinstance(self.data, str)
+            else self.data
+        )
+        chunk = header + data
+
+        data += b'\x00' * (len(chunk) % 4)
+        return chunk
+
+    @classmethod
+    def from_bytes(cls, chunk: bytes) -> Chunk:
+        """Decode bytes into a Chunk."""
+        (dtype_value, length, stream_id, seq_id, seq_len) = unpack_from(
+            CHUNK_HEADER_FORMAT,
+            chunk,
+        )
+        dtype = ChunkDType(dtype_value)
+        chunk_data = chunk[CHUNK_HEADER_LENGTH:length]
+        data: bytes | str
+        if dtype is ChunkDType.STRING:
+            data = chunk_data.decode('utf8')
+        else:
+            data = chunk_data
+        return cls(
+            stream_id=stream_id,
+            seq_id=seq_id,
+            seq_len=seq_len,
+            data=data,
+            dtype=dtype,
+        )
+
+
+def chunkify(
+    data: bytes | str,
+    size: int,
+    stream_id: int,
+) -> Generator[Chunk, None, None]:
+    """Generate chunks from data.
+
+    Args:
+        data (bytes, str): data to chunk.
+        size (int): size of each chunk.
+        stream_id: unique ID for the stream of chunks.
+
+    Yields:
+        :class:`~proxystore.p2p.chunks.Chunk`
+    """
+    seq_len = math.ceil(len(data) / size)
+
+    for i, x in enumerate(range(0, len(data), size)):
+        chunk_data = data[x : min(x + size, len(data))]
+        yield Chunk(
+            stream_id=stream_id,
+            seq_id=i,
+            seq_len=seq_len,
+            data=chunk_data,
+        )
+
+
+def reconstruct(chunks: list[Chunk]) -> bytes | str:
+    """Reconstructs data from list of chunks.
+
+    Args:
+        chunks: (list[Chunk]): list of chunks to order and join.
+
+    Returns:
+        reconstructed bytes or string.
+    """
+    if len(chunks) == 0:
+        raise ValueError('Chunks list cannot be empty.')
+    seq_len = chunks[0].seq_len
+    if len(chunks) != seq_len:
+        raise ValueError(f'Got {len(chunks)} but expected {seq_len}.')
+    chunks = sorted(chunks, key=lambda c: c.seq_id)
+    if isinstance(chunks[0].data, bytes):
+        return b''.join(c.data for c in chunks)  # type: ignore
+    elif isinstance(chunks[0].data, str):
+        return ''.join(c.data for c in chunks)  # type: ignore
+    else:
+        raise AssertionError('Unreachable.')

--- a/proxystore/p2p/counter.py
+++ b/proxystore/p2p/counter.py
@@ -1,0 +1,36 @@
+"""Atomic counting utilities."""
+from __future__ import annotations
+
+import threading
+
+
+class AtomicCounter:
+    """Thread-safe counter."""
+
+    def __init__(self, size: int | None = None) -> None:
+        """Init AtomicCounter.
+
+        Args:
+            size (int): optional max count upon which an exception will be
+                raised (default: None).
+        """
+        self._size = size
+        self._value = 0
+        self._lock = threading.Lock()
+
+    def increment(self) -> int:
+        """Get current count and increment value.
+
+        Returns:
+            current count (int).
+
+        Raises:
+            ValueError:
+                if current count is equal to or greater than size.
+        """
+        with self._lock:
+            value = self._value
+            if self._size is not None and value >= self._size:
+                raise ValueError(f'Max counter size exceeded ({self._size}).')
+            self._value += 1
+            return value

--- a/proxystore/p2p/manager.py
+++ b/proxystore/p2p/manager.py
@@ -68,7 +68,9 @@ class PeerManager:
         uuid: UUID,
         signaling_server: str,
         name: str | None = None,
+        *,
         timeout: int = 30,
+        peer_channels: int = 1,
     ) -> None:
         """Init PeerManager.
 
@@ -91,11 +93,14 @@ class PeerManager:
                 logging. If unspecified, the hostname will be used.
             timeout (int): timeout in seconds when waiting for a peer
                 or signaling server connection to be established (default: 30).
+            peer_channels (int): number of datachannels to split message
+                sending over between each peer (default: 1).
         """
         self._uuid = uuid
         self._signaling_server = signaling_server
         self._name = name if name is not None else socket.gethostname()
         self._timeout = timeout
+        self._peer_channels = peer_channels
 
         self._peers_lock = asyncio.Lock()
         self._peers: dict[frozenset[UUID], PeerConnection] = {}
@@ -256,6 +261,7 @@ class PeerManager:
                         uuid=self._uuid,
                         name=self._name,
                         websocket=self._websocket,
+                        channels=self._peer_channels,
                     )
                     async with self._peers_lock:
                         self._peers[peers] = connection
@@ -347,6 +353,7 @@ class PeerManager:
                 self._uuid,
                 self._name,
                 self._websocket,
+                channels=self._peer_channels,
             )
             self._peers[peers] = connection
 

--- a/testing/scripts/peer_endpoint_bandwidth.py
+++ b/testing/scripts/peer_endpoint_bandwidth.py
@@ -54,14 +54,14 @@ async def amain(
         await endpoint.set('key', data, target_uuid)
         end = time.perf_counter_ns()
         print(f'Elapsed time: {(end - start) / 1e6:.3f} ms')
-        print(f'Mbps: {(size / 1e6) / ((end - start) / 1e9)}')
+        print(f'Mbps: {(size * 8 / 1e6) / ((end - start) / 1e9)}')
 
         print(f'Retrieving {size} bytes to remote')
         start = time.perf_counter_ns()
         await endpoint.get('key', target_uuid)
         end = time.perf_counter_ns()
         print(f'Elapsed time: {(end - start) / 1e6:.3f} ms')
-        print(f'Mbps: {(size / 1e6) / ((end - start) / 1e9)}')
+        print(f'Mbps: {(size * 8 / 1e6) / ((end - start) / 1e9)}')
 
         await endpoint.evict('key', target_uuid)
     elif actor == 'remote':

--- a/tests/p2p/chunks_test.py
+++ b/tests/p2p/chunks_test.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from proxystore.p2p.chunks import Chunk
+from proxystore.p2p.chunks import ChunkDType
+from proxystore.p2p.chunks import chunkify
+from proxystore.p2p.chunks import reconstruct
+from testing.compat import randbytes
+
+
+@pytest.mark.parametrize('dtype', (bytes, str))
+def test_chunk_to_bytes(dtype: bytes | str) -> None:
+    data: bytes | str = randbytes(100) if dtype is bytes else 'abcdefghijkl'
+
+    chunk = Chunk(1, 0, 1, data)
+
+    if dtype is bytes:
+        assert chunk.dtype is ChunkDType.BYTES
+    elif dtype is str:
+        assert chunk.dtype is ChunkDType.STRING
+    else:
+        raise AssertionError('Unreachable.')
+
+    chunk_bytes = bytes(chunk)
+
+    new_chunk = Chunk.from_bytes(chunk_bytes)
+
+    assert chunk.stream_id == new_chunk.stream_id
+    assert chunk.seq_id == new_chunk.seq_id
+    assert chunk.seq_len == new_chunk.seq_len
+    assert chunk.data == new_chunk.data
+    assert chunk.dtype == new_chunk.dtype
+
+
+def test_chunk_validation() -> None:
+    with pytest.raises(ValueError):
+        Chunk(0, 2, 1, '')
+
+
+@pytest.mark.parametrize('dtype', (bytes, str))
+def test_chunk_and_reconstruct(dtype: bytes | str) -> None:
+    data: bytes | str = randbytes(1000) if dtype is bytes else 'x' * 1000
+
+    chunks = [c for c in chunkify(data, 100, 1)]
+    new_data = reconstruct(chunks)
+
+    assert data == new_data
+
+
+def test_reconstruct_validation() -> None:
+    with pytest.raises(ValueError, match='empty'):
+        reconstruct([])
+
+    with pytest.raises(ValueError, match='expected'):
+        reconstruct([Chunk(0, 0, 1, ''), Chunk(0, 0, 1, '')])

--- a/tests/p2p/counter_test.py
+++ b/tests/p2p/counter_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from proxystore.p2p.counter import AtomicCounter
+
+
+def test_counter() -> None:
+    counter = AtomicCounter()
+
+    values = [counter.increment() for _ in range(100)]
+    assert len(set(values)) == len(values)
+
+    diffs = [values[i + 1] - values[i] for i in range(len(values) - 1)]
+    assert all(d == 1 for d in diffs)
+
+
+def test_counter_max_size() -> None:
+    counter = AtomicCounter(size=2)
+
+    counter.increment()
+    counter.increment()
+
+    with pytest.raises(ValueError):
+        counter.increment()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Changes:
- Fix Mbps calculation error in `peer_endpoint_bandwidth.py` test script.
- Improve chunking of peer messages to allow out-of-order delivery and removing send lock.
- Add support for sending messages over multiple data channels.

The endpoint-endpoint performance between UC and TACC is about 75 Mbps with 2 channels. The aiortc filexfer script gets 93 Mbps so we are still off but there is additional overhead in the endpoint and peer manager to enable other features.

Since our performance is not that far off from the upper bound, it seems that switching the endpoint to a multi-threaded model will not yield the order of magnitude improvements we are looking for. I think the next step forward will be building our own hole-punching solution.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #117 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Unit tests pass. Testing with peer connection and endpoint test scripts in `testing/scripts` locally and between two remote systems.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
