### PR TITLE
Store payload size in `TimeStats`

### DIFF
--- a/docs/guides/performance.rst
+++ b/docs/guides/performance.rst
@@ -6,9 +6,9 @@ Performance tracking is disable by default and can be enabled by passing :code:`
 
 .. code-block:: python
 
-   import proxystore as ps
+   import proxystore.store
 
-   store = ps.store.init_store(
+   store = proxystore.store.init_store(
        "file",
        name="default",
        store_dir="/tmp/proxystore-dump",
@@ -41,11 +41,23 @@ In the following block, we add an object to the store and see that there are now
    stats['set']
    # >>> TimeStats(
    # >>>     calls=1,
-   # >>>     avg_time_ms=0.0755,
-   # >>>     min_time_ms=0.0755,
-   # >>>     max_time_ms=0.0755
+   # >>>     avg_time_ms=0.0686,
+   # >>>     min_time_ms=0.0686,
+   # >>>     max_time_ms=0.0686,
+   # >>>     size_bytes=None,
+   # >>> )
+   stats['set_bytes']
+   # >>> TimeStats(
+   # >>>     calls=1,
+   # >>>     avg_time_ms=0.0339,
+   # >>>     min_time_ms=0.0339,
+   # >>>     max_time_ms=0.0339,
+   # >>>     size_bytes=219,
    # >>> )
 
+Operations that work directly on bytes (i.e., :code:`get_bytes` and
+:code:`set_bytes`) will also note the size of the byte array used in the
+operation in the :code:`TimeStats.size_bytes` attribute.
 As more operations are performed on the store, more statistics will be accumulated.
 
 .. code-block:: python

--- a/examples/store_stats.py
+++ b/examples/store_stats.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import proxystore as ps
 import proxystore.store
 
-store = ps.store.init_store(
+store = proxystore.store.init_store(
     'file',
     name='default',
     store_dir='/tmp/proxystore-dump',
@@ -31,6 +30,7 @@ stats1 = store.stats(key1)
   stats1['set'] = {stats1['set']}
   stats1['set'].calls = {stats1['set'].calls}
   stats1['set'].avg_time_ms = {stats1['set'].avg_time_ms}
+  stats1['set_bytes'].size_bytes = {stats1['set_bytes'].size_bytes}
 """,
 )
 print(
@@ -41,8 +41,11 @@ store2 = store.stats(key2)
   stats2['set'] = {stats2['set']}
   stats2['set'].calls = {stats2['set'].calls}
   stats2['set'].avg_time_ms = {stats2['set'].avg_time_ms}
+  stats2['set_bytes'].size_bytes = {stats2['set_bytes'].size_bytes}
 """,
 )
+
+print(stats1['set'], stats1['set_bytes'])
 
 print('Call store.get(key1)')
 store.get(key1)
@@ -55,6 +58,7 @@ store = store.stats(key1)
   stats['get'] = {stats['get']}
   stats['get'].calls = {stats['get'].calls}
   stats['get'].avg_time_ms = {stats['get'].avg_time_ms}
+  stats['get_bytes'].size_bytes = {stats['get_bytes'].size_bytes}
 """,
 )
 
@@ -72,7 +76,7 @@ store = store.stats(key1)
 """,
 )
 
-target_proxy: ps.proxy.Proxy[Any] = store.proxy(target)
+target_proxy: proxystore.proxy.Proxy[Any] = store.proxy(target)
 stats = store.stats(target_proxy)
 print(
     f"""\

--- a/proxystore/store/globus.py
+++ b/proxystore/store/globus.py
@@ -244,6 +244,21 @@ class GlobusStoreKey(NamedTuple):
     filename: str
     task_id: str
 
+    def __eq__(self, other: Any) -> bool:
+        """Match keys by filename only.
+
+        This is a hack around the fact that the task_id is not created until
+        after the filename is so there can be a state where the task_id
+        is empty.
+        """
+        if isinstance(other, tuple):
+            return self[0] == other[0]
+        return False
+
+    def __ne__(self, other: Any) -> bool:
+        """Match keys by filename only."""
+        return not self == other
+
 
 class GlobusStore(Store[GlobusStoreKey]):
     """Globus backend class.

--- a/tests/store/globus_test.py
+++ b/tests/store/globus_test.py
@@ -309,3 +309,13 @@ def test_globus_auth_not_done(tmp_dir: str) -> None:
     with mock.patch('proxystore.globus.home_dir', return_value=tmp_dir):
         with pytest.raises(GlobusAuthFileError):
             GlobusStore('store', endpoints=[EP1, EP2])
+
+
+def test_globus_store_key_equality() -> None:
+    """Test GlobusStoreKey custom equality."""
+    key = GlobusStoreKey('a', 'b')
+    assert key == GlobusStoreKey('a', 'b')
+    assert key == ('a', 'b')
+    assert key != ('b', 'b')
+    assert key == ('a', 'c')
+    assert key != 'a'

--- a/tests/store/store_stats_test.py
+++ b/tests/store/store_stats_test.py
@@ -57,9 +57,15 @@ def test_stat_tracking(store_fixture, request) -> None:
 
     assert 'get' in stats
     assert 'set' in stats
+    assert 'get_bytes' in stats
+    assert 'set_bytes' in stats
 
     assert stats['get'].calls == 1
     assert stats['set'].calls == 1
+    size = stats['get_bytes'].size_bytes
+    assert size is not None and size > 0
+    size = stats['set_bytes'].size_bytes
+    assert size is not None and size > 0
 
     # stats should return a copy of the stats, not the internal data
     # structures so calling get again should not effect anything.


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Byte-level operations (i.e., `get_bytes` and `set_bytes`) of `Store`s now log the size in bytes of the payload with the `TaskStats` when stat logging is enabled on the `Store`.

```python
stats = store.stats(key)
stats.keys()
# >>> TimeStats(
# >>>     calls=1,
# >>>     avg_time_ms=0.0686,
# >>>     min_time_ms=0.0686,
# >>>     max_time_ms=0.0686,
# >>>     size_bytes=None,
# >>> )
stats['set_bytes']
# >>> TimeStats(
# >>>     calls=1,
# >>>     avg_time_ms=0.0339,
# >>>     min_time_ms=0.0339,
# >>>     max_time_ms=0.0339,
# >>>     size_bytes=219,
# >>> )
```

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #115 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated unit tests to verify size. Also updated example and code in docs.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
