### PR TITLE
Default 1GB max object size for Endpoints

### DIFF
--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -198,17 +198,9 @@ def start_endpoint(
 
     # TODO: handle sigterm/sigkill exit codes/graceful shutdown.
     serve(
-        name=cfg.name,
-        uuid=cfg.uuid,
-        host=cfg.host,
-        port=cfg.port,
-        server=cfg.server,
+        cfg,
         log_level=log_level,
         log_file=os.path.join(endpoint_dir, 'endpoint.log'),
-        max_memory=cfg.max_memory,
-        dump_dir=cfg.dump_dir,
-        peer_channels=cfg.peer_channels,
-        verify_certificate=cfg.verify_certificate,
     )
 
     return 0

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -7,6 +7,8 @@ import os
 import re
 import uuid
 
+from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
+
 _ENDPOINT_CONFIG_FILE = 'endpoint.json'
 
 
@@ -20,6 +22,7 @@ class EndpointConfig:
     port: int
     server: str | None = None
     max_memory: int | None = None
+    max_object_size: int | None = MAX_OBJECT_SIZE_DEFAULT
     dump_dir: str | None = None
     peer_channels: int = 1
     verify_certificate: bool = True
@@ -52,7 +55,11 @@ class EndpointConfig:
                 'Server must start with ws:// or wss://.',
             )
         if self.max_memory is not None and self.max_memory < 1:
-            raise ValueError('Max memory must be None or positive.')
+            raise ValueError('Max memory must be None or greater than zero.')
+        if self.max_object_size is not None and self.max_object_size < 1:
+            raise ValueError(
+                'Max object size must be None or greater than zero.',
+            )
         if self.peer_channels < 1:
             raise ValueError('Peer channels must be >= 1.')
 

--- a/proxystore/endpoint/constants.py
+++ b/proxystore/endpoint/constants.py
@@ -4,3 +4,6 @@ from __future__ import annotations
 
 MAX_CHUNK_LENGTH = 16 * 1000 * 1000
 """Maximum chunk length (bytes) for GET/SET requests to/from the endpoint."""
+
+MAX_OBJECT_SIZE_DEFAULT = int(1e9)
+"""Default maximum endpoint object size in bytes."""

--- a/proxystore/endpoint/endpoint.py
+++ b/proxystore/endpoint/endpoint.py
@@ -23,6 +23,9 @@ from proxystore.serialize import serialize
 
 logger = logging.getLogger(__name__)
 
+# Default to 1 GB
+_MAX_OBJECT_SIZE_DEFAULT = int(1e9)
+
 
 class EndpointMode(enum.Enum):
     """Endpoint mode."""
@@ -90,6 +93,7 @@ class Endpoint:
         signaling_server: str | None = None,
         peer_timeout: int = 30,
         max_memory: int | None = None,
+        max_object_size: int | None = _MAX_OBJECT_SIZE_DEFAULT,
         dump_dir: str | None = None,
         peer_channels: int = 1,
         verify_certificate: bool = True,
@@ -121,6 +125,9 @@ class Endpoint:
             max_memory (int): optional max memory in bytes to use for storing
                 objects. If exceeded, LRU objects will be dumped to `dump_dir`
                 (default: None).
+            max_object_size (int): optional max size in bytes for any single
+                object stored by the endpoint. If exceeded, an error is
+                raised (default: 1 GB).
             dump_dir (str): optional directory to dump objects to if the
                 memory limit is exceeded (default: None).
             peer_channels (int): number of datachannels per peer connection
@@ -147,7 +154,11 @@ class Endpoint:
 
         self._peer_manager: PeerManager | None = None
 
-        self._data = EndpointStorage(max_size=max_memory, dump_dir=dump_dir)
+        self._data = EndpointStorage(
+            max_size=max_memory,
+            max_object_size=max_object_size,
+            dump_dir=dump_dir,
+        )
         self._pending_requests: dict[
             str,
             asyncio.Future[EndpointRequest],
@@ -439,6 +450,9 @@ class Endpoint:
                 will be performed on the local endpoint.
 
         Raises:
+            ObjectSizeExceededError:
+                if the max object size is configured and the data exceeds that
+                size.
             PeerRequestError:
                 if request to a peer endpoint fails.
         """

--- a/proxystore/endpoint/endpoint.py
+++ b/proxystore/endpoint/endpoint.py
@@ -10,6 +10,7 @@ from typing import Generator
 from uuid import UUID
 from uuid import uuid4
 
+from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
 from proxystore.endpoint.exceptions import PeeringNotAvailableError
 from proxystore.endpoint.exceptions import PeerRequestError
 from proxystore.endpoint.messages import EndpointRequest
@@ -22,9 +23,6 @@ from proxystore.serialize import SerializationError
 from proxystore.serialize import serialize
 
 logger = logging.getLogger(__name__)
-
-# Default to 1 GB
-_MAX_OBJECT_SIZE_DEFAULT = int(1e9)
 
 
 class EndpointMode(enum.Enum):
@@ -93,7 +91,7 @@ class Endpoint:
         signaling_server: str | None = None,
         peer_timeout: int = 30,
         max_memory: int | None = None,
-        max_object_size: int | None = _MAX_OBJECT_SIZE_DEFAULT,
+        max_object_size: int | None = MAX_OBJECT_SIZE_DEFAULT,
         dump_dir: str | None = None,
         peer_channels: int = 1,
         verify_certificate: bool = True,

--- a/proxystore/endpoint/exceptions.py
+++ b/proxystore/endpoint/exceptions.py
@@ -2,6 +2,18 @@
 from __future__ import annotations
 
 
+class FileDumpNotAvailableError(Exception):
+    """Error raised when dumping objects to file is not available."""
+
+    pass
+
+
+class ObjectSizeExceededError(Exception):
+    """Exception raised when an object exceeds the max allowable size."""
+
+    pass
+
+
 class PeeringNotAvailableError(Exception):
     """Exception when a peer request is made but peering is not available."""
 

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -22,6 +22,7 @@ except ImportError as e:  # pragma: no cover
     )
 
 from proxystore.endpoint.constants import MAX_CHUNK_LENGTH
+from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.endpoint import Endpoint
 from proxystore.endpoint.exceptions import PeerRequestError
 from proxystore.utils import chunk_bytes
@@ -66,18 +67,10 @@ def create_app(
 
 
 def serve(
-    name: str,
-    uuid: uuid.UUID,
-    host: str,
-    port: int,
+    config: EndpointConfig,
     *,
-    server: str | None = None,
     log_level: int | str = logging.INFO,
     log_file: str | None = None,
-    max_memory: int | None = None,
-    dump_dir: str | None = None,
-    peer_channels: int = 1,
-    verify_certificate: bool = True,
 ) -> None:
     """Initialize endpoint and serve Quart app.
 
@@ -85,26 +78,13 @@ def serve(
         This function does not return until the Quart app is terminated.
 
     Args:
-        name (str): name of endpoint.
-        uuid (str): uuid of endpoint.
-        host (str): host address to server Quart app on.
-        port (int): port to serve Quart app on.
-        server (str): address of signaling server that endpoint
-            will register with and use for establishing peer to peer
-            connections. If None, endpoint will operate in solo mode (no
-            peering) (default: None).
+        config (EndpointConfig): configuration object.
         log_level (int): logging level of endpoint (default: INFO).
         log_file (str): optional file path to append log to.
-        max_memory (int): optional max memory in bytes to use for storing
-            objects. If exceeded, LRU objects will be dumped to `dump_dir`
-            (default: None).
-        dump_dir (str): optional directory to dump objects to if the
-            memory limit is exceeded (default: None).
-        peer_channels (int): number of datachannels per peer connection
-            to another endpoint to communicate over (default: 1).
-        verify_certificate (bool): verify the signaling server's SSL
-            certificate (default: True).
     """
+    if config.host is None:
+        raise ValueError('EndpointConfig has NoneType as host.')
+
     if log_file is not None:
         parent_dir = os.path.dirname(log_file)
         if not os.path.isdir(parent_dir):
@@ -122,28 +102,29 @@ def serve(
     logging.getLogger().setLevel(log_level)
 
     endpoint = Endpoint(
-        name=name,
-        uuid=uuid,
-        signaling_server=server,
-        max_memory=max_memory,
-        dump_dir=dump_dir,
-        peer_channels=peer_channels,
-        verify_certificate=verify_certificate,
+        name=config.name,
+        uuid=config.uuid,
+        signaling_server=config.server,
+        max_memory=config.max_memory,
+        dump_dir=config.dump_dir,
+        peer_channels=config.peer_channels,
+        verify_certificate=config.verify_certificate,
     )
     app = create_app(endpoint)
 
-    config = hypercorn.config.Config()
-    config.bind = [f'{host}:{port}']
-    config.accesslog = logging.getLogger('hypercorn.access')
-    config.errorlog = logging.getLogger('hypercorn.error')
+    serve_config = hypercorn.config.Config()
+    serve_config.bind = [f'{config.host}:{config.port}']
+    serve_config.accesslog = logging.getLogger('hypercorn.access')
+    serve_config.errorlog = logging.getLogger('hypercorn.error')
 
     logger.debug('installing uvloop as default event loop')
     uvloop.install()
 
     logger.info(
-        f'serving endpoint {endpoint.uuid} ({endpoint.name}) on {host}:{port}',
+        f'serving endpoint {endpoint.uuid} ({endpoint.name}) on '
+        f'{config.host}:{config.port}',
     )
-    asyncio.run(hypercorn.asyncio.serve(app, config))
+    asyncio.run(hypercorn.asyncio.serve(app, serve_config))
 
 
 @routes_blueprint.before_app_serving

--- a/testing/endpoint.py
+++ b/testing/endpoint.py
@@ -10,6 +10,7 @@ from multiprocessing import Process
 
 import requests
 
+from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.serve import serve
 
 
@@ -28,7 +29,14 @@ def serve_endpoint_silent(
         # https://stackoverflow.com/questions/66583461
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        serve(name, uuid, host, port, server=server)
+        config = EndpointConfig(
+            name=name,
+            uuid=uuid,
+            host=host,
+            port=port,
+            server=server,
+        )
+        serve(config)
         loop.close()
 
 

--- a/tests/endpoint/config_test.py
+++ b/tests/endpoint/config_test.py
@@ -117,6 +117,9 @@ def test_validate_name(name: str, valid: bool) -> None:
         ({'max_memory': -1}, False),
         ({'peer_channels': 1}, True),
         ({'peer_channels': 0}, False),
+        ({'max_object_size': 0}, False),
+        ({'max_object_size': 1}, True),
+        ({'max_object_size': -1}, False),
     ),
 )
 def test_validate_config(bad_cfg: Any, valid: bool) -> None:

--- a/tests/endpoint/endpoint_solo_test.py
+++ b/tests/endpoint/endpoint_solo_test.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 
 from proxystore.endpoint.endpoint import Endpoint
+from proxystore.endpoint.exceptions import ObjectSizeExceededError
 from testing.compat import randbytes
 
 _NAME = 'test-endpoint'
@@ -33,6 +34,18 @@ async def test_set() -> None:
         data = randbytes(100)
         await endpoint.set('key', data)
         assert (await endpoint.get('key')) == data
+
+
+@pytest.mark.asyncio
+async def test_set_exceeds_size() -> None:
+    async with Endpoint(
+        name=_NAME,
+        uuid=_UUID,
+        max_object_size=10,
+    ) as endpoint:
+        data = randbytes(100)
+        with pytest.raises(ObjectSizeExceededError):
+            await endpoint.set('key', data)
 
 
 @pytest.mark.asyncio

--- a/tests/endpoint/storage_test.py
+++ b/tests/endpoint/storage_test.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+from proxystore.endpoint.exceptions import ObjectSizeExceededError
 from proxystore.endpoint.storage import Blob
 from proxystore.endpoint.storage import BlobLocation
 from proxystore.endpoint.storage import EndpointStorage
@@ -134,7 +135,13 @@ def test_endpoint_storage_dumping(tmp_dir: str) -> None:
     assert not os.path.isdir(tmp_dir)
 
 
-def test_object_too_large(tmp_dir: str) -> None:
+def test_object_exceeds_memory(tmp_dir: str) -> None:
     storage = EndpointStorage(max_size=100, dump_dir=tmp_dir)
-    with pytest.raises(ValueError, match='too large'):
+    with pytest.raises(ObjectSizeExceededError, match='memory limit'):
+        storage['key'] = randbytes(200)
+
+
+def test_object_exceeds_object_size(tmp_dir: str) -> None:
+    storage = EndpointStorage(max_object_size=100)
+    with pytest.raises(ObjectSizeExceededError, match='object limit'):
         storage['key'] = randbytes(200)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -7,8 +7,10 @@ import pytest
 
 from proxystore import utils
 from proxystore.factory import SimpleFactory
+from proxystore.utils import bytes_to_readable
 from proxystore.utils import chunk_bytes
 from proxystore.utils import home_dir
+from proxystore.utils import readable_to_bytes
 
 
 @pytest.mark.parametrize(
@@ -41,3 +43,75 @@ def test_fullname() -> None:
 def test_home_dir() -> None:
     assert isinstance(home_dir(), str)
     assert os.path.isabs(home_dir())
+
+
+@pytest.mark.parametrize(
+    'value,precision,expected',
+    (
+        (0, 3, '0 B'),
+        (1, 3, '1 B'),
+        (int(1e3), 3, '1 KB'),
+        (int(1e6), 3, '1 MB'),
+        (int(1e9), 3, '1 GB'),
+        (int(1e12), 3, '1 TB'),
+        (int(1e15), 3, '1000 TB'),
+        (1001, 3, '1.001 KB'),
+        (1001, 1, '1 KB'),
+        (1001, 0, '1 KB'),
+        (123456789, 3, '123.457 MB'),
+        (int(4e13), 3, '40 TB'),
+    ),
+)
+def test_bytes_to_readable(value: int, precision: int, expected: str) -> None:
+    assert bytes_to_readable(value, precision) == expected
+
+
+def test_bytes_to_readable_exceptions() -> None:
+    with pytest.raises(ValueError, match='negative'):
+        bytes_to_readable(-1)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('0 B', 0),
+        ('1 B', 1),
+        ('1 KB', int(1e3)),
+        ('1 MB', int(1e6)),
+        ('1 GB', int(1e9)),
+        ('1 TB', int(1e12)),
+        ('1KB', int(1e3)),
+        ('1MB', int(1e6)),
+        ('1GB', int(1e9)),
+        ('1TB', int(1e12)),
+        ('1000 TB', int(1e15)),
+        ('1.001 KB', 1001),
+        ('1.0001 KB', 1000),
+        ('123.457 MB', 123457000),
+        ('40 TB', 40000000000000),
+        ('0', 0),
+        ('1', 1),
+        ('1000000000', 1000000000),
+    ),
+)
+def test_readable_to_bytes(value: str, expected: int) -> None:
+    assert readable_to_bytes(value) == expected
+
+
+def test_readable_to_bytes_too_many_parts() -> None:
+    with pytest.raises(ValueError, match='value and a unit'):
+        readable_to_bytes('1 B GB')
+
+    with pytest.raises(ValueError, match='value and a unit'):
+        readable_to_bytes('GB')
+
+
+def test_readable_to_bytes_unknown_unit() -> None:
+    with pytest.raises(ValueError, match='Unknown unit'):
+        readable_to_bytes('1 XB')
+
+
+def test_readable_to_bytes_value_cast_failure() -> None:
+    with pytest.raises(ValueError, match='float'):
+        # Note that is letter o rather than zero
+        readable_to_bytes('O B')


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds a default maximum object size of 1GB to the Endpoint which can changed or disabled by setting to None/null.

In the process of adding this, I refactored how the `EndpointConfig` is used by the serving methods so it is easier to add new fields to `EndpointConfig` without needing to modify a bunch a function definitions.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #119 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

All unit tests pass. Added new ones for new features. Tested endpoint configuration locally.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [] Docs have been updated and reviewed if relevant.
