### PR TITLE
Allow detaching an endpoint from the CLI

### DIFF
--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -7,20 +7,91 @@ Subsequently, all commands log errors and results and return status codes
 """
 from __future__ import annotations
 
+import contextlib
+import enum
 import logging
 import os
 import shutil
+import signal
 import socket
 import uuid
+from typing import Generator
+
+import daemon.pidfile
+import psutil
 
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
+from proxystore.endpoint.config import get_log_filepath
+from proxystore.endpoint.config import get_pid_filepath
 from proxystore.endpoint.config import read_config
 from proxystore.endpoint.config import write_config
 from proxystore.endpoint.serve import serve
 from proxystore.utils import home_dir
 
 logger = logging.getLogger(__name__)
+
+
+class EndpointStatus(enum.Enum):
+    """Endpoint status."""
+
+    RUNNING = enum.auto()
+    """Endpoint is running on this host."""
+    STOPPED = enum.auto()
+    """Endpoint is stopped."""
+    UNKNOWN = enum.auto()
+    """Endpoint cannot be found (missing/corrupted directory)."""
+    HANGING = enum.auto()
+    """Endpoint PID file exists but process is not active.
+
+    This is either because the process died unexpectedly or the endpoint
+    is running on another host.
+    """
+
+
+def get_status(name: str, proxystore_dir: str | None = None) -> EndpointStatus:
+    """Check status of endpoint.
+
+    Args:
+        name (str): name of endpoint to check.
+        proxystore_dir (str): optionally specify the directory where the
+            endpoint configuration is. Defaults to :code:`$HOME/.proxystore`.
+
+    Returns:
+        :py:attr:`.EndpointStatus.RUNNING` if the endpoint has a valid
+        directory and the PID file points to a running process.
+        :py:attr:`.EndpointStatus.STOPPED` if the endpoint has a valid
+        directory and no PID file.
+        :py:attr:`.EndpointStatus.UNKNOWN` if the endpoint directory is
+        missing or the config file is missing/unreadable.
+        :py:attr:`.EndpointStatus.HANGING` if the endpoint has a valid
+        directory but the PID file does not point to a running process. This
+        can be due to the endpoint process dying unexpectedly or the endpoint
+        process is on a different host.
+    """
+    if proxystore_dir is None:
+        proxystore_dir = home_dir()
+
+    endpoint_dir = os.path.join(proxystore_dir, name)
+    if not os.path.isdir(endpoint_dir):
+        return EndpointStatus.UNKNOWN
+
+    try:
+        read_config(endpoint_dir)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error(e)
+        return EndpointStatus.UNKNOWN
+
+    pid_file = get_pid_filepath(endpoint_dir)
+    if not os.path.isfile(pid_file):
+        return EndpointStatus.STOPPED
+
+    pid = int(open(pid_file).read().strip())
+
+    if psutil.pid_exists(pid):
+        return EndpointStatus.RUNNING
+    else:
+        return EndpointStatus.HANGING
 
 
 def configure_endpoint(
@@ -74,15 +145,13 @@ def configure_endpoint(
     endpoint_dir = os.path.join(proxystore_dir, name)
 
     if os.path.exists(endpoint_dir):
-        logger.error(f'An endpoint named {name} already exists. ')
-        logger.error('To reconfigure the endpoint, remove and try again.')
+        logger.error(f'An endpoint named {name} already exists.')
+        logger.info('To reconfigure the endpoint, remove and try again.')
         return 1
 
     write_config(cfg, endpoint_dir)
 
-    logger.info(f'Configured endpoint {cfg.name} <{cfg.uuid}>.')
-    logger.info('')
-    logger.info('To start the endpoint:')
+    logger.info(f'Configured endpoint {cfg.name} <{cfg.uuid}>. Start with:')
     logger.info(f'  $ proxystore-endpoint start {cfg.name}')
 
     return 0
@@ -112,10 +181,14 @@ def list_endpoints(
     else:
         eps = [(e.name, str(e.uuid)) for e in endpoints]
         eps = sorted(eps, key=lambda x: x[0])
-        logger.info(f'{"NAME":<18} UUID')
-        logger.info('=' * (18 + 1 + len(eps[0][1])))
+        logger.info(f'{"NAME":<18} {"STATUS":<8} UUID', extra={'simple': True})
+        logger.info('=' * (19 + 9 + len(eps[0][1])), extra={'simple': True})
         for name, uuid_ in eps:
-            logger.info(f'{name:<18} {uuid_}')
+            status = get_status(name, proxystore_dir)
+            logger.info(
+                f'{name:18.18} {status.name:<8.8} {uuid_}',
+                extra={'simple': True},
+            )
 
     return 0
 
@@ -144,6 +217,12 @@ def remove_endpoint(
         logger.error(f'An endpoint named {name} does not exist.')
         return 1
 
+    status = get_status(name, proxystore_dir)
+    if status in (EndpointStatus.RUNNING, EndpointStatus.HANGING):
+        logger.error('Endpoint must be stopped before removing.')
+        logger.error(f'  $ proxystore-endpoint stop {name}')
+        return 1
+
     shutil.rmtree(endpoint_dir)
 
     logger.info(f'Removed endpoint named {name}.')
@@ -154,6 +233,7 @@ def remove_endpoint(
 def start_endpoint(
     name: str,
     *,
+    detach: bool = False,
     log_level: str = 'INFO',
     proxystore_dir: str | None = None,
 ) -> int:
@@ -161,6 +241,7 @@ def start_endpoint(
 
     Args:
         name (str): name of endpoint to start.
+        detach (bool): start the endpoint as a daemon process.
         log_level (str): set logging level of endpoint.
         proxystore_dir (str): optionally specify the directory where the
             endpoint configuration is. Defaults to :code:`$HOME/.proxystore`.
@@ -172,35 +253,142 @@ def start_endpoint(
     if proxystore_dir is None:
         proxystore_dir = home_dir()
 
-    endpoint_dir = os.path.join(proxystore_dir, name)
-    if not os.path.exists(endpoint_dir):
-        logger.error(f'An endpoint named {name} does not exist.')
+    status = get_status(name, proxystore_dir)
+    if status == EndpointStatus.RUNNING:
+        logger.error(f'Endpoint {name} is already running.')
+        return 1
+    elif status == EndpointStatus.UNKNOWN:
+        logger.error(f'A valid endpoint named {name} does not exist.')
         logger.error('Use `list` to see available endpoints.')
         return 1
 
-    try:
-        cfg = read_config(endpoint_dir)
-    except FileNotFoundError:
-        logger.error(
-            f'{os.path.join(proxystore_dir, name)} does not have a '
-            'config file.',
-        )
-        logger.error('Try removing the endpoint and configuring it again.')
-        return 1
-    except ValueError as e:
-        logger.error(str(e))
-        logger.error('Correct the endpoint config and try again.')
-        return 1
+    endpoint_dir = os.path.join(proxystore_dir, name)
+    cfg = read_config(endpoint_dir)
+    hostname = socket.gethostbyname(socket.gethostname())
 
-    cfg.host = socket.gethostbyname(socket.gethostname())
+    pid_file = get_pid_filepath(endpoint_dir)
+
+    if (
+        status == EndpointStatus.HANGING
+        and cfg.host is not None
+        and hostname != cfg.host
+    ):
+        logger.error(
+            'A PID file exists for the endpoint, but the config indicates the '
+            f'endpoint is running on a host named {cfg.host}. Try stopping '
+            f'the endpoint on {cfg.host}. Otherwise, delete the PID file at '
+            f'{pid_file} and try again.',
+        )
+        return 1
+    elif status == EndpointStatus.HANGING:
+        logger.debug(f'Removing invalid PID file ({pid_file}).')
+        os.remove(pid_file)
+
     # Write out new config with host so clients can see the current host
+    cfg.host = hostname
     write_config(cfg, endpoint_dir)
 
+    log_file = get_log_filepath(endpoint_dir)
+
+    if detach:
+        logger.info('Starting endpoint process as daemon.')
+        logger.info(f'Logs will be written to {log_file}')
+
+        context = daemon.DaemonContext(
+            working_directory=endpoint_dir,
+            umask=0o002,
+            pidfile=daemon.pidfile.PIDLockFile(pid_file),
+            detach_process=True,
+            # Note: stdin, stdout, stderr left as None which binds to /dev/null
+        )
+    else:
+        context = _attached_pid_manager(pid_file)
+
     # TODO: handle sigterm/sigkill exit codes/graceful shutdown.
-    serve(
-        cfg,
-        log_level=log_level,
-        log_file=os.path.join(endpoint_dir, 'endpoint.log'),
-    )
+    with context:
+        serve(cfg, log_level=log_level, log_file=log_file)
 
     return 0
+
+
+def stop_endpoint(name: str, *, proxystore_dir: str | None = None) -> int:
+    """Stop endpoint.
+
+    Args:
+        name (str): name of endpoint to start.
+        proxystore_dir (str): optionally specify the directory where the
+            endpoint configuration is. Defaults to :code:`$HOME/.proxystore`.
+
+    Returns:
+        Exit code where 0 is success and 1 is failure. Failure messages
+        are logged to the default logger.
+    """
+    if proxystore_dir is None:
+        proxystore_dir = home_dir()
+
+    status = get_status(name, proxystore_dir)
+    if status == EndpointStatus.UNKNOWN:
+        logger.error(f'A valid endpoint named {name} does not exist.')
+        logger.error('Use `list` to see available endpoints.')
+        return 1
+    elif status == EndpointStatus.STOPPED:
+        logger.info(f'Endpoint {name} is not running.')
+        return 0
+
+    endpoint_dir = os.path.join(proxystore_dir, name)
+    cfg = read_config(endpoint_dir)
+    hostname = socket.gethostbyname(socket.gethostname())
+    pid_file = get_pid_filepath(endpoint_dir)
+
+    if (
+        status == EndpointStatus.HANGING
+        and cfg.host is not None
+        and hostname != cfg.host
+    ):
+        logger.error(
+            'A PID file exists for the endpoint, but the config indicates the '
+            f'endpoint is running on a host named {cfg.host}. Try stopping '
+            f'the endpoint on {cfg.host}. Otherwise, delete the PID file at '
+            f'{pid_file} and try again.',
+        )
+        return 1
+    elif status == EndpointStatus.HANGING:
+        logger.debug(f'Removing invalid PID file ({pid_file}).')
+        os.remove(pid_file)
+        logger.info(f'Endpoint {name} is not running.')
+        return 0
+
+    assert status == EndpointStatus.RUNNING
+    with open(pid_file) as f:
+        pid = int(f.read().strip())
+
+    logger.debug(f'Terminating endpoint process (PID: {pid}).')
+    # Source: https://github.com/funcx-faas/funcX/blob/facf37348f9a9eb4e1a0572793d7b6819be5754d/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py#L360  # noqa: E501
+    parent = psutil.Process(pid)
+    processes = parent.children(recursive=True)
+    processes.append(parent)
+    for p in processes:
+        p.send_signal(signal.SIGTERM)
+
+    terminated, alive = psutil.wait_procs(processes, timeout=1)
+    for p in alive:  # pragma: no cover
+        try:
+            p.send_signal(signal.SIGKILL)
+        except psutil.NoSuchProcess:
+            pass
+
+    if os.path.isfile(pid_file):  # pragma: no branch
+        logger.debug(f'Cleaning up PID file ({pid_file}).')
+        os.remove(pid_file)
+
+    logger.info(f'Endpoint {name} has been stopped.')
+    return 0
+
+
+@contextlib.contextmanager
+def _attached_pid_manager(pid_file: str) -> Generator[None, None, None]:
+    """Context manager that writes and cleans up a PID file."""
+    with open(pid_file, 'w') as f:
+        f.write(str(os.getpid()))
+    yield
+    os.remove(pid_file)

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -10,6 +10,8 @@ import uuid
 from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
 
 _ENDPOINT_CONFIG_FILE = 'endpoint.json'
+_ENDPOINT_LOG_FILE = 'endpoint.log'
+_ENDPOINT_PID_FILE = 'daemon.pid'
 
 
 @dataclasses.dataclass
@@ -92,6 +94,30 @@ def get_configs(proxystore_dir: str) -> list[EndpointConfig]:
             endpoints.append(cfg)
 
     return endpoints
+
+
+def get_log_filepath(endpoint_dir: str) -> str:
+    """Returns path to log file for endpoint.
+
+    Args:
+        endpoint_dir (str): directory for the endpoint.
+
+    Returns:
+        path to log file.
+    """
+    return os.path.join(endpoint_dir, _ENDPOINT_LOG_FILE)
+
+
+def get_pid_filepath(endpoint_dir: str) -> str:
+    """Returns path to PID file for endpoint.
+
+    Args:
+        endpoint_dir (str): directory for the endpoint.
+
+    Returns:
+        path to PID file.
+    """
+    return os.path.join(endpoint_dir, _ENDPOINT_PID_FILE)
 
 
 def read_config(endpoint_dir: str) -> EndpointConfig:

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ console_scripts =
 endpoints =
     aiortc>=1.3.2
     hypercorn[uvloop]>=0.13.0
+    psutil
+    python-daemon
     quart>=0.18.0
     websockets>=10.0
 

--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -91,10 +91,20 @@ def test_remove(home_dir, caplog) -> None:
     )
 
 
-def test_serve(home_dir, caplog) -> None:
+def test_start(home_dir, caplog) -> None:
     # Note: similar to test_list()
     caplog.set_level(logging.ERROR)
     main(['start', 'my-endpoint'])
+    assert len(caplog.records) == 2
+    assert any(
+        ['does not exist' in record.message for record in caplog.records],
+    )
+
+
+def test_stop(home_dir, caplog) -> None:
+    # Note: similar to test_list()
+    caplog.set_level(logging.ERROR)
+    main(['stop', 'my-endpoint'])
     assert len(caplog.records) == 2
     assert any(
         ['does not exist' in record.message for record in caplog.records],

--- a/tests/endpoint/commands_test.py
+++ b/tests/endpoint/commands_test.py
@@ -3,19 +3,67 @@ from __future__ import annotations
 
 import logging
 import os
+import time
+import uuid
+from multiprocessing import Process
 from unittest import mock
 
+import pytest
+
 from proxystore.endpoint.commands import configure_endpoint
+from proxystore.endpoint.commands import EndpointStatus
+from proxystore.endpoint.commands import get_status
 from proxystore.endpoint.commands import list_endpoints
 from proxystore.endpoint.commands import remove_endpoint
 from proxystore.endpoint.commands import start_endpoint
+from proxystore.endpoint.commands import stop_endpoint
+from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
+from proxystore.endpoint.config import get_pid_filepath
 from proxystore.endpoint.config import read_config
+from proxystore.endpoint.config import write_config
 
 _NAME = 'default'
-_UUID = 'a128eee9-bcf8-44eb-b4ec-ce725b1e5167'
+_UUID = uuid.uuid4()
 _PORT = 1234
 _SERVER = None
+
+
+def test_get_status(tmp_dir, caplog) -> None:
+    endpoint_dir = os.path.join(tmp_dir, _NAME)
+    assert not os.path.isdir(endpoint_dir)
+
+    # Returns UNKNOWN if directory does not exist
+    assert get_status(_NAME, tmp_dir) == EndpointStatus.UNKNOWN
+    with mock.patch(
+        'proxystore.endpoint.commands.home_dir',
+        return_value=tmp_dir,
+    ):
+        assert get_status(_NAME) == EndpointStatus.UNKNOWN
+
+    os.makedirs(endpoint_dir, exist_ok=True)
+
+    # Returns UNKNOWN if config is not readable
+    assert get_status(_NAME, tmp_dir) == EndpointStatus.UNKNOWN
+
+    with mock.patch(
+        'proxystore.endpoint.commands.read_config',
+        return_value=None,
+    ):
+        # Returns STOPPED if PID file does not exist
+        assert get_status(_NAME, tmp_dir) == EndpointStatus.STOPPED
+
+        with open(get_pid_filepath(endpoint_dir), 'w') as f:
+            f.write('0')
+
+        with mock.patch('psutil.pid_exists') as mock_exists:
+            # Return RUNNING if PID exists
+            mock_exists.return_value = True
+            assert get_status(_NAME, tmp_dir) == EndpointStatus.RUNNING
+
+            # Return HANGING if PID does not exists
+            mock_exists.return_value = False
+            assert get_status(_NAME, tmp_dir) == EndpointStatus.HANGING
 
 
 def test_configure_endpoint_basic(tmp_dir, caplog) -> None:
@@ -170,6 +218,28 @@ def test_remove_endpoints_does_not_exist(tmp_dir, caplog) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    'status',
+    (EndpointStatus.RUNNING, EndpointStatus.HANGING),
+)
+def test_remove_endpoint_running(status, tmp_dir, caplog) -> None:
+    os.makedirs(os.path.join(tmp_dir, _NAME), exist_ok=True)
+
+    with mock.patch(
+        'proxystore.endpoint.commands.home_dir',
+        return_value=tmp_dir,
+    ), mock.patch(
+        'proxystore.endpoint.commands.get_status',
+        return_value=status,
+    ):
+        rv = remove_endpoint(_NAME)
+    assert rv == 1
+
+    assert any(
+        ['must be stopped' in record.message for record in caplog.records],
+    )
+
+
 def test_start_endpoint(tmp_dir) -> None:
     configure_endpoint(
         name=_NAME,
@@ -180,6 +250,43 @@ def test_start_endpoint(tmp_dir) -> None:
     with mock.patch('proxystore.endpoint.commands.serve', autospec=True):
         rv = start_endpoint(_NAME, proxystore_dir=tmp_dir)
     assert rv == 0
+
+
+def test_start_endpoint_detached(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    configure_endpoint(
+        name=_NAME,
+        port=_PORT,
+        server=_SERVER,
+        proxystore_dir=tmp_dir,
+    )
+    with mock.patch(
+        'proxystore.endpoint.commands.serve',
+        autospec=True,
+    ), mock.patch('daemon.DaemonContext', autospec=True):
+        rv = start_endpoint(_NAME, detach=True, proxystore_dir=tmp_dir)
+    assert rv == 0
+
+    assert any(['daemon' in record.message for record in caplog.records])
+
+
+def test_start_endpoint_running(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.ERROR)
+
+    with mock.patch(
+        'proxystore.endpoint.commands.home_dir',
+        return_value=tmp_dir,
+    ), mock.patch(
+        'proxystore.endpoint.commands.get_status',
+        return_value=EndpointStatus.RUNNING,
+    ):
+        rv = start_endpoint(_NAME)
+    assert rv == 1
+
+    assert any(
+        ['already running' in record.message for record in caplog.records],
+    )
 
 
 def test_start_endpoint_does_not_exist(tmp_dir, caplog) -> None:
@@ -206,7 +313,7 @@ def test_start_endpoint_missing_config(tmp_dir, caplog) -> None:
 
     assert any(
         [
-            'does not have a config file' in record.message
+            'does not contain a valid configuration' in record.message
             for record in caplog.records
         ],
     )
@@ -225,4 +332,168 @@ def test_start_endpoint_bad_config(tmp_dir, caplog) -> None:
 
     assert any(
         ['Unable to parse' in record.message for record in caplog.records],
+    )
+
+
+def test_start_endpoint_hanging_different_host(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.ERROR)
+
+    endpoint_dir = os.path.join(tmp_dir, _NAME)
+
+    config = EndpointConfig(name=_NAME, uuid=_UUID, host='abcd', port=1234)
+    write_config(config, endpoint_dir)
+
+    pid_file = get_pid_filepath(endpoint_dir)
+    with open(pid_file, 'w') as f:
+        f.write('1')
+
+    with mock.patch('psutil.pid_exists', return_value=False):
+        rv = start_endpoint(_NAME, proxystore_dir=tmp_dir)
+    assert rv == 1
+
+    assert any(
+        [
+            'on a host named abcd' in record.message
+            for record in caplog.records
+        ],
+    )
+
+
+def test_start_endpoint_old_pid_file(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    endpoint_dir = os.path.join(tmp_dir, _NAME)
+
+    config = EndpointConfig(name=_NAME, uuid=_UUID, host=None, port=1234)
+    write_config(config, endpoint_dir)
+
+    pid_file = get_pid_filepath(endpoint_dir)
+    with open(pid_file, 'w') as f:
+        f.write('1')
+
+    with mock.patch('psutil.pid_exists', return_value=False), mock.patch(
+        'proxystore.endpoint.commands.serve',
+        autospec=True,
+    ):
+        rv = start_endpoint(_NAME, proxystore_dir=tmp_dir)
+    assert rv == 0
+
+    assert any(
+        [
+            'Removing invalid PID file' in record.message
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+        ],
+    )
+
+
+@pytest.mark.timeout(2)
+def test_stop_endpoint(tmp_dir) -> None:
+    endpoint_dir = os.path.join(tmp_dir, _NAME)
+    configure_endpoint(
+        name=_NAME,
+        port=_PORT,
+        server=_SERVER,
+        proxystore_dir=tmp_dir,
+    )
+
+    # Create a fake process to kill
+    p = Process(target=time.sleep, args=(1000,))
+    p.start()
+
+    pid_file = get_pid_filepath(endpoint_dir)
+    with open(pid_file, 'w') as f:
+        f.write(str(p.pid))
+
+    with mock.patch(
+        'proxystore.endpoint.commands.home_dir',
+        return_value=tmp_dir,
+    ):
+        rv = stop_endpoint(_NAME)
+    assert rv == 0
+    assert not os.path.exists(pid_file)
+
+    # Process was terminated so this should happen immediately
+    p.join()
+
+
+def test_stop_endpoint_unknown(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.INFO)
+    with mock.patch(
+        'proxystore.endpoint.commands.get_status',
+        return_value=EndpointStatus.UNKNOWN,
+    ):
+        rv = stop_endpoint(_NAME, proxystore_dir=tmp_dir)
+    assert rv == 1
+
+    assert any(
+        ['does not exist' in record.message for record in caplog.records],
+    )
+
+
+def test_stop_endpoint_not_running(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.INFO)
+    with mock.patch(
+        'proxystore.endpoint.commands.get_status',
+        return_value=EndpointStatus.STOPPED,
+    ):
+        rv = stop_endpoint(_NAME, proxystore_dir=tmp_dir)
+    assert rv == 0
+
+    assert any(['not running' in record.message for record in caplog.records])
+
+
+def test_stop_endpoint_hanging_different_host(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.ERROR)
+    endpoint_dir = os.path.join(tmp_dir, _NAME)
+
+    config = EndpointConfig(name=_NAME, uuid=_UUID, host='abcd', port=1234)
+    write_config(config, endpoint_dir)
+
+    pid_file = get_pid_filepath(endpoint_dir)
+    with open(pid_file, 'w') as f:
+        f.write('1')
+
+    with mock.patch('psutil.pid_exists', return_value=False):
+        rv = stop_endpoint(_NAME, proxystore_dir=tmp_dir)
+    assert rv == 1
+
+    assert any(
+        [
+            'on a host named abcd' in record.message
+            for record in caplog.records
+        ],
+    )
+
+
+def test_stop_endpoint_dangling_pid_file(tmp_dir, caplog) -> None:
+    caplog.set_level(logging.DEBUG)
+    endpoint_dir = os.path.join(tmp_dir, _NAME)
+
+    config = EndpointConfig(name=_NAME, uuid=_UUID, host=None, port=1234)
+    write_config(config, endpoint_dir)
+
+    pid_file = get_pid_filepath(endpoint_dir)
+    with open(pid_file, 'w') as f:
+        f.write('1')
+
+    with mock.patch('psutil.pid_exists', return_value=False):
+        rv = stop_endpoint(_NAME, proxystore_dir=tmp_dir)
+    assert rv == 0
+
+    assert not os.path.exists(pid_file)
+
+    assert any(
+        [
+            'Removing invalid PID file' in record.message
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+        ],
+    )
+    assert any(
+        [
+            'not running' in record.message
+            for record in caplog.records
+            if record.levelno == logging.INFO
+        ],
     )

--- a/tests/endpoint/config_test.py
+++ b/tests/endpoint/config_test.py
@@ -9,6 +9,8 @@ import pytest
 
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import get_configs
+from proxystore.endpoint.config import get_log_filepath
+from proxystore.endpoint.config import get_pid_filepath
 from proxystore.endpoint.config import read_config
 from proxystore.endpoint.config import validate_name
 from proxystore.endpoint.config import write_config
@@ -137,3 +139,15 @@ def test_validate_config(bad_cfg: Any, valid: bool) -> None:
     else:
         with pytest.raises(ValueError):
             EndpointConfig(**options)  # type: ignore
+
+
+def test_get_pid_filepath() -> None:
+    fp = get_pid_filepath('/tmp')
+    assert isinstance(fp, str)
+    assert not os.path.exists(fp)
+
+
+def test_get_log_filepath() -> None:
+    fp = get_log_filepath('/tmp')
+    assert isinstance(fp, str)
+    assert not os.path.exists(fp)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

- `proxystore-endpoint start` now defaults to spawning the endpoint as a detached process with its PID recorded to a PID file in the endpoint directory. The `--no-detach` flag can be used to run the endpoint directly in the commands process.
- `proxystore-endpoint stop` has been added.
- `proxystore-endpoint list` now shows the status of each endpoint.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #128 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a lot of new unit tests and testing the new CLI features locally.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
