### PR TITLE
Restore cwd after temporary change in test

### DIFF
--- a/tests/store/file_test.py
+++ b/tests/store/file_test.py
@@ -19,6 +19,8 @@ def test_file_store_close(tmp_dir: str) -> None:
 
 def test_cwd_change(tmp_dir: str) -> None:
     """Checks FileStore proxies still resolve when the CWD changes."""
+    current = os.getcwd()
+
     os.chdir(tmp_dir)
     store_dir = './store-dir'
 
@@ -29,3 +31,5 @@ def test_cwd_change(tmp_dir: str) -> None:
         p = store.proxy('data')
         os.chdir(new_working_dir)
         assert p == 'data'
+
+    os.chdir(current)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This test erroneously changed the cwd but did not change it back. The side effect is that if coverage produces another coverage file after this test runs, that coverage file will end up in the wrong place and not be combined with the others that live in the original cwd.

This problem has not manifested because none of the tests that run after this one use multiprocessing (which would result in more coverage files being created).

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Unit tests pass. Tested the coverage issue locally with another tests that spawned subprocesses and ran after the file test.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
