### PR TITLE
[BREAKING] Remove `init_store()`

### DIFF
--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -74,26 +74,8 @@ in stores and creating proxies that will resolve to the associated object in
 the store.
 
 ProxyStore provides many :class:`~proxystore.store.base.Store`
-implementations and more can be added by extending the
-:class:`~proxystore.store.base.Store` class.
-
-.. list-table::
-   :widths: 15 50
-   :header-rows: 1
-   :align: center
-
-   * - Type
-     - Use Case
-   * - :class:`~proxystore.store.local.LocalStore`
-     - In-memory object store local to the process. Useful for development.
-   * - :class:`~proxystore.store.redis.RedisStore`
-     - Store objects in a preconfigured Redis server.
-   * - :class:`~proxystore.store.file.FileStore`
-     - Use a globally accessible file system for storing objects.
-   * - :class:`~proxystore.store.globus.GlobusStore`
-     - Transfer objects between two Globus endpoints.
-   * - :class:`~proxystore.store.endpoint.EndpointStore`
-     - [*Experimental*] P2P object stores for multi-site applications.
+implementations (list :py:mod:`here <proxystore.store>`) and more can be
+added by extending the :class:`~proxystore.store.base.Store` class.
 
 The following example uses the
 :class:`~proxystore.store.redis.RedisStore` to interface with a

--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -101,14 +101,15 @@ running Redis server using proxies.
 
 .. code-block:: python
 
-   import proxystore.store
+   from proxystore.store import get_store
+   from proxystore.store import register_store
+   from proxystore.store.redis import RedisStore
 
-   store = proxystore.store.init_store(
-       'redis', name='my-store', hostname=REDIS_HOST, port=REDIS_PORT
-   )
+   store = RedisStore(name='my-store', hostname='localhost', port=1234)
+   register_store(store)
 
-   # An already initialized store can be retrieved
-   store = proxystore.store.get_store('my-store')
+   # A registered store can be retrieved by name
+   store = get_store('my-store')
 
    # Stores have basic get/set functionality
    key = store.set(my_object)
@@ -125,7 +126,7 @@ arbitrary Python process as if it were the target object itself. Once the
 proxy is used on the remote process, the underlying factory function will
 be executed to retrieve the target object from the Redis server.
 
-Using the :class:`~proxystore.store.base.Store~` store interface allows
+Using the :class:`~proxystore.store.base.Store` store interface allows
 developers to write code without needing to worry about how data communication
 is handled and reduces the number of lines of code that need to be changed
 when adding or changing the communication methods.

--- a/docs/guides/endpoints.rst
+++ b/docs/guides/endpoints.rst
@@ -119,10 +119,9 @@ The primary interface to endpoints is the
 
 .. code-block:: python
 
-   import proxystore as ps
+   from proxystore.store.endpoint import EndpointStore
 
-   store = ps.store.init_store(
-       'endpoint',
+   store = EndpointStore(
        name='default',
        endpoints=[
            '5349ffce-edeb-4a8b-94a6-ab16ade1c1a1',

--- a/docs/guides/performance.rst
+++ b/docs/guides/performance.rst
@@ -2,17 +2,16 @@ Performance Tracking
 ####################
 
 The ProxyStore :class:`~proxystore.store.base.Store` interface provides low-level performance tracking on store operations (e.g., `get` and `set`).
-Performance tracking is disable by default and can be enabled by passing :code:`stats=True` to either the :class:`~proxystore.store.base.Store` constructor or :py:func:`~proxystore.store.init_store`.
+Performance tracking is disable by default and can be enabled by passing :code:`stats=True` to a :class:`~proxystore.store.base.Store` constructor.
 
 .. code-block:: python
 
-   import proxystore.store
+   from proxystore.store.file import FileStore
 
-   store = proxystore.store.init_store(
-       "file",
+   store = FileStore(
        name="default",
        store_dir="/tmp/proxystore-dump",
-       stats=True
+       stats=True,
     )
 
 Performance statistics are aggregated on a per-`key` level and can be accessed via the :py:meth:`~proxystore.store.base.Store.stats` method.

--- a/examples/parsl/mapreduce_parsl.py
+++ b/examples/parsl/mapreduce_parsl.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import argparse
+from typing import Any
 
 import numpy as np
 import parsl
 from parsl import python_app
 
-import proxystore as ps
-import proxystore.store
+from proxystore.store import register_store
+from proxystore.store.base import Store
+from proxystore.store.local import LocalStore
+from proxystore.store.redis import RedisStore
 
 
 @python_app
@@ -60,15 +63,16 @@ if __name__ == '__main__':
     parsl.load()
 
     if args.proxy:
+        store: Store[Any]
         if args.redis_port is None:
-            store = ps.store.init_store('local', name='local')
+            store = LocalStore('local')
         else:
-            store = ps.store.init_store(
+            store = RedisStore(
                 'redis',
-                name='redis',
-                hostname='127.0.0.1',
+                hostname='localhost',
                 port=args.redis_port,
             )
+        register_store(store)
 
     mapped_results = []
     for _ in range(args.num_arrays):

--- a/examples/store_stats.py
+++ b/examples/store_stats.py
@@ -5,16 +5,16 @@ Source code for:
 """
 from __future__ import annotations
 
+import tempfile
 from typing import Any
 
-import proxystore.store
+from proxystore.proxy import Proxy
+from proxystore.store.file import FileStore
 
-store = proxystore.store.init_store(
-    'file',
-    name='default',
-    store_dir='/tmp/proxystore-dump',
-    stats=True,
-)
+
+fp = tempfile.TemporaryDirectory()
+
+store = FileStore(name='default', store_dir=fp.name, stats=True)
 
 target = list(range(0, 100))
 key1 = store.set(target)
@@ -76,7 +76,7 @@ store = store.stats(key1)
 """,
 )
 
-target_proxy: proxystore.proxy.Proxy[Any] = store.proxy(target)
+target_proxy: Proxy[Any] = store.proxy(target)
 stats = store.stats(target_proxy)
 print(
     f"""\
@@ -102,3 +102,4 @@ store = store.stats(target_proxy)
 )
 
 store.close()
+fp.cleanup()

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -143,11 +143,8 @@ class StoreFactory(Factory[T], Generic[KeyT, T]):
         """
         store = ps.store.get_store(self.store_name)
         if store is None:
-            store = ps.store.init_store(
-                self.store_type,
-                self.store_name,
-                **self.store_kwargs,
-            )
+            store = self.store_type(self.store_name, **self.store_kwargs)
+            ps.store.register_store(store)
 
         if not isinstance(store, self.store_type):
             raise ValueError(

--- a/proxystore/store/dim/websockets.py
+++ b/proxystore/store/dim/websockets.py
@@ -213,6 +213,7 @@ class WebsocketStore(Store[WebsocketStoreKey]):
 
         if server_process is not None:
             server_process.terminate()
+            server_process.join()
             server_process = None
 
         logger.debug('Clean up completed')

--- a/proxystore/store/exceptions.py
+++ b/proxystore/store/exceptions.py
@@ -18,12 +18,6 @@ class StoreExistsError(StoreError):
     pass
 
 
-class UnknownStoreError(StoreError):
-    """Exception raised when the type of store to initialize is unknown."""
-
-    pass
-
-
 class ProxyStoreFactoryError(StoreError):
     """Exception raised when a proxy was not created by a Store."""
 

--- a/tests/store/globus_test.py
+++ b/tests/store/globus_test.py
@@ -10,7 +10,6 @@ from unittest import mock
 import globus_sdk
 import pytest
 
-import proxystore as ps
 from proxystore.globus import GlobusAuthFileError
 from proxystore.store.globus import GlobusEndpoint
 from proxystore.store.globus import GlobusEndpoints
@@ -171,46 +170,22 @@ def test_globus_store_init(globus_store) -> None:
 
     GlobusStore('globus', endpoints=[EP1, EP2])
 
-    s1 = ps.store.init_store(
-        ps.store.STORES.GLOBUS,
-        'globus1',
-        endpoints=[EP1, EP2],
-    )
-    s2 = ps.store.init_store(ps.store.STORES.GLOBUS, 'globus2', endpoints=eps)
-    s3 = ps.store.init_store(
-        ps.store.STORES.GLOBUS,
-        'globus3',
-        endpoints=eps.dict(),
-    )
+    s1 = GlobusStore('globus1', endpoints=[EP1, EP2])
+    s2 = GlobusStore('globus2', endpoints=eps)
+    s3 = GlobusStore('globus3', endpoints=eps.dict())
     assert s1.kwargs == s2.kwargs == s3.kwargs
-
-    ps.store.unregister_store(s1.name)
-    ps.store.unregister_store(s2.name)
-    ps.store.unregister_store(s3.name)
 
     with pytest.raises(ValueError):
         # Invalid endpoint type
-        ps.store.init_store(
-            ps.store.STORES.GLOBUS,
-            'globus',
-            endpoints=None,
-        )
+        GlobusStore('globus', endpoints=None)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError):
         # Too many endpoints
-        ps.store.init_store(
-            ps.store.STORES.GLOBUS,
-            'globus',
-            endpoints=[EP1, EP2, EP3],
-        )
+        GlobusStore('globus', endpoints=[EP1, EP2, EP3])
 
     with pytest.raises(ValueError):
         # Not enough endpoints
-        ps.store.init_store(
-            ps.store.STORES.GLOBUS,
-            'globus',
-            endpoints=[EP1],
-        )
+        GlobusStore('globus', endpoints=[EP1])
 
 
 def test_globus_store_internals(globus_store) -> None:

--- a/tests/store/init_test.py
+++ b/tests/store/init_test.py
@@ -1,174 +1,54 @@
 """Store Imports and Initialization Unit Tests."""
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
-import proxystore as ps
 from proxystore.factory import SimpleFactory
 from proxystore.proxy import Proxy
-from proxystore.store import STORES
+from proxystore.store import get_store
+from proxystore.store import register_store
+from proxystore.store import unregister_store
 from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.exceptions import StoreExistsError
-from proxystore.store.exceptions import UnknownStoreError
 from proxystore.store.local import LocalStore
+from proxystore.store.redis import RedisStore
 
 
-def test_imports() -> None:
-    """Test imports."""
-    import proxystore.store as store
-
-    assert callable(store.get_store)
-    assert callable(store.init_store)
-
-    from proxystore.store import get_store, init_store
-
-    assert callable(get_store)
-    assert callable(init_store)
-
-    from proxystore.store.local import LocalStore
-
-    LocalStore(name='local')
-    ps.store.local.LocalStore(name='local')
-
-    assert callable(ps.store.init_store)
-
-
-def test_init_store(local_store, redis_store) -> None:
-    """Test init_store/get_store."""
-    # Init by str name
-    local = ps.store.init_store(
-        local_store.type,
-        name='local',
-        **local_store.kwargs,
-    )
-    assert isinstance(local, ps.store.local.LocalStore)
-    redis = ps.store.init_store(
-        'redis',
-        name='redis',
-        **redis_store.kwargs,
-    )
-    assert isinstance(redis, ps.store.redis.RedisStore)
-
-    assert local == ps.store.get_store('local')
-    assert redis == ps.store.get_store('redis')
-
-    ps.store._stores = {}
-
-    # Init by enum
-    local = ps.store.init_store(
-        STORES.LOCAL,
-        name='local',
-        **local_store.kwargs,
-    )
-    assert isinstance(local, ps.store.local.LocalStore)
-    redis = ps.store.init_store(
-        STORES.REDIS,
-        name='redis',
-        **redis_store.kwargs,
-    )
-    assert isinstance(redis, ps.store.redis.RedisStore)
-
-    assert local == ps.store.get_store('local')
-    assert redis == ps.store.get_store('redis')
-
-    # Init by class type
-    local = ps.store.init_store(
-        ps.store.local.LocalStore,
-        name='local',
-        **local_store.kwargs,
-    )
-    assert isinstance(local, ps.store.local.LocalStore)
-
-    ps.store._stores = {}
-
-    # Specify name to have multiple stores of same type
-    local1 = ps.store.init_store(STORES.LOCAL, 'l1', **local_store.kwargs)
-    ps.store.init_store(STORES.LOCAL, 'l2', **local_store.kwargs)
-
-    assert ps.store.get_store('l1') is not ps.store.get_store('l2')
-
-    # Should overwrite old store
-    ps.store.init_store(STORES.LOCAL, 'l1', **local_store.kwargs)
-    assert local1 is not ps.store.get_store('l1')
-
-    # Return None if store with name does not exist
-    assert ps.store.get_store('unknown') is None
-
-    ps.store._stores = {}
-
-
-def test_get_enum_by_type() -> None:
-    """Test getting enum with type."""
-    t = STORES.get_str_by_type(ps.store.local.LocalStore)
-    assert isinstance(t, str)
-    assert STORES[t].value == ps.store.local.LocalStore
-
-    class FakeStore(ps.store.base.Store[Any]):
-        """FakeStore type."""
-
-        pass
-
-    with pytest.raises(KeyError):
-        STORES.get_str_by_type(FakeStore)  # type: ignore
-
-
-def test_init_store_raises() -> None:
-    """Test init_store raises."""
-    with pytest.raises(UnknownStoreError):
-        # Raise error because name cannot be found in STORES
-        ps.store.init_store('unknown', name='')
-
-    with pytest.raises(UnknownStoreError):
-        # Raises error because type is not a subclass of Store
-        class TestStore:
-            pass
-
-        ps.store.init_store(TestStore, name='')  # type: ignore
-
-
-def test_register_unregister_store() -> None:
+def test_store_registration() -> None:
     """Test registering and unregistering stores directly."""
     store = LocalStore(name='test')
 
-    ps.store.register_store(store)
-    assert ps.store.get_store('test') == store
+    register_store(store)
+    assert get_store('test') == store
 
     with pytest.raises(StoreExistsError):
-        ps.store.register_store(store)
-    ps.store.register_store(store, exist_ok=True)
+        register_store(store)
+    register_store(store, exist_ok=True)
 
-    ps.store.unregister_store(store.name)
-    assert ps.store.get_store('test') is None
+    unregister_store(store.name)
+    assert get_store('test') is None
 
     # does not raise error
-    ps.store.unregister_store('not a valid store name')
+    unregister_store('not a valid store name')
 
 
 def test_lookup_by_proxy(local_store, redis_store) -> None:
     """Make sure get_store works with a proxy."""
     # Init by enum
-    local = ps.store.init_store(
-        STORES.LOCAL,
-        name='local',
-        **local_store.kwargs,
-    )
-    redis = ps.store.init_store(
-        STORES.REDIS,
-        name='redis',
-        **redis_store.kwargs,
-    )
+    local = LocalStore('local', **local_store.kwargs)
+    redis = RedisStore('redis', **redis_store.kwargs)
+    register_store(local)
+    register_store(redis)
 
     # Make a proxy with both
     local_proxy: Proxy[list[int]] = local.proxy([1, 2, 3])
     redis_proxy: Proxy[list[int]] = redis.proxy([1, 2, 3])
 
     # Make sure both look up correctly
-    sr = ps.store.get_store(redis_proxy)
+    sr = get_store(redis_proxy)
     assert sr is not None
     assert sr.name == redis.name
-    sl = ps.store.get_store(local_proxy)
+    sl = get_store(local_proxy)
     assert sl is not None
     assert sl.name == local.name
 
@@ -176,6 +56,7 @@ def test_lookup_by_proxy(local_store, redis_store) -> None:
     f = SimpleFactory([1, 2, 3])
     p = Proxy(f)
     with pytest.raises(ProxyStoreFactoryError):
-        ps.store.get_store(p)
+        get_store(p)
 
-    ps.store._stores = {}
+    unregister_store('local')
+    unregister_store('redis')

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 
-import proxystore as ps
 from proxystore.store.cache import LRUCache
 from testing.stores import missing_key
 from testing.stores import StoreFixtureType
@@ -18,12 +17,7 @@ def test_store_init(store_implementation: StoreFixtureType) -> None:
 
     with pytest.raises(ValueError):
         # Negative Cache Size Error
-        ps.store.init_store(
-            store_info.type,
-            store_info.name,
-            **store_info.kwargs,
-            cache_size=-1,
-        )
+        store_info.type(store_info.name, **store_info.kwargs, cache_size=-1)
 
 
 def test_store_base(store_implementation: StoreFixtureType) -> None:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The `STORES` enum causes a lot of problems (https://github.com/proxystore/proxystore/issues/147) with imports because every `Store` type must be imported when `proxystore.store` is imported. Additionally, having the `STORES` enum gave the appearance that it was an exhaustive list of available `Store` types (but it is not because some require additional packages and user can build their own).

After removing `STORES`, having `init_store()` did not make sense as almost all of the logic in `init_store()` was converting the enum type or string (using the `STORES` enum) to the class used to initialize the store with. Thus, `init_store()` was basically a wrapper around initializing the store and calling `register_store()`.

Since `init_store()` returns `Store[Any]`, it has the additional downside of losing the specific type information on the `Store`. So the decision is made to remove `init_store()` entirely in favour of `register_store()`.

This change will prevent a lot of import errors, (I think) force users to use proxystore in a manner where it is explicit what is happening, and help with static analysis.

This is a breaking change, but 0.4.0 is already breaking because `resolve_async()`/`get_key()` changed modules.

Minor: fixed a few bugs exposed by slow MacOS CI runners.
- Wait for `WebsocketServer` process to fully terminate using `join()`.
- Increase delta between slow and fast functions in stats tests.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #147 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests pass. Some code removed but no remaining code changed in its logic.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
