### PR TITLE
Upgrade cryptography per CVE-2023-23931

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle>=1.6.0",
-    "cryptography<=38.04",
+    "cryptography>=39.0.1",
     "globus-sdk>=3.3.0",
     "lazy-object-proxy>=1.6.0",
     "redis>=3.4",


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Upgrades cryptography to `>=39.0.1` due to the below two security alerts. We previously had these pinned to `<=38.04` in #165 due to breaking changes in `39.0.0` on MacOS. Those issues are no longer present.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes https://github.com/proxystore/proxystore/security/dependabot/1
- Fixes https://github.com/proxystore/proxystore/security/dependabot/2

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [x] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests pass on MacOS on `39.0.1`.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
