### PR TITLE
Pin UCX and Margo versions in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ commands =
 deps =
     pkgconfig
     pybind11
-    git+https://github.com/rapidsai/ucx-py.git
+    git+https://github.com/rapidsai/ucx-py.git@v0.30.00
 commands_pre =
-    python -m pip install git+https://github.com/mochi-hpc/py-mochi-margo.git
+    python -m pip install git+https://github.com/mochi-hpc/py-mochi-margo.git@v0.5.2
 commands =
     pytest -k "margo or ucx" {posargs}
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

UCX upgraded to Python >=3.8 so CI for 3.7 will fail until we remove 3.7 support in June (at EOL). This pins UCX to the previous released version and goes ahead an puns Margo to prevent similar issue.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [x] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
