### PR TITLE
Move some dependencies to extras

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,8 +19,9 @@ ProxyStore provides many features with extra dependencies that can be installed 
 
 | Install | Purpose |
 | :------ | :------ |
+| `#!bash pip install proxystore[dev]` | Development dependencies |
+| `#!bash pip install proxystore[docs]` | Documentation dependencies |
 | `#!bash pip install proxystore[endpoints]` | Use [ProxyStore Endpoints](guides/endpoints.md) |
-| `#!bash pip install proxystore[globus]` | Use the [`GlobusConnector`][proxystore.connectors.globus.GlobusConnector] |
 | `#!bash pip install proxystore[redis]` | Use the [`RedisConnector`][proxystore.connectors.redis.RedisConnector] |
 | `#!bash pip install proxystore[zmq]` | Use the [`ZeroMQConnector`][proxystore.connectors.dim.zmq.ZeroMQConnector] |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ dependencies = [
     "cryptography>=39.0.1",
     "globus-sdk>=3.3.0",
     "lazy-object-proxy>=1.6.0",
-    "redis>=3.4",
-    "requests>=2.27.1",
     "typing-extensions>=4.3.0",
     "importlib-metadata; python_version<'3.8'",
 ]
@@ -72,7 +70,13 @@ endpoints = [
     "psutil",
     "python-daemon",
     "quart>=0.18.0",
+    "requests>=2.27.1",
     "websockets>=10.0",
+]
+redis = [
+    "redis>=3.4",
+]
+zmq = [
     "pyzmq",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{37,38,39,310,311},py{37,38,39,310,311}-dim, pre-commit, docs
 
 [testenv]
-extras = dev,endpoints
+extras = dev,endpoints,redis,zmq
 commands =
     coverage erase
     coverage run -m pytest {posargs}


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Moves Redis and ZMQ dependencies to their own extras options when installing.

Kept Globus as a core dependency because of ProxyStore's Globus auth tools.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #203

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)
- [x] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Testing extras work locally.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
