### PR TITLE
Improve logging throughout the package

### DIFF
--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -13,10 +13,10 @@ compliance.
 * Prefer f-strings (`#!python f'name: {name}`) over string format
   (`#!python 'name: {}'.format(name)`). Never use the `%` operator.
 * Prefer [typing.NamedTuple][] over [collections.namedtuple][].
-* Use lower-case and no punctuation for log messages, but use upper-case and
-  punctuation for exception values.
+* Exception messages should read as complete sentences with punctuation.
+  Logging messages can forgo trailing punctuation.
   ```python
-  logger.info(f'new connection opened to {address}')
   raise ValueError('Name must contain alphanumeric characters only.')
+  logger.info(f'New connection opened to {address}')
   ```
 * Document all exceptions that may be raised by a function in the docstring.

--- a/proxystore/connectors/endpoint.py
+++ b/proxystore/connectors/endpoint.py
@@ -77,7 +77,7 @@ class EndpointConnector:
         found_endpoint: EndpointConfig | None = None
         for endpoint in available_endpoints:
             if endpoint.uuid in self.endpoints:
-                logger.debug(f'attempting connection to {endpoint.uuid}')
+                logger.debug(f'Attempting connection to {endpoint.uuid}')
                 response = requests.get(
                     f'http://{endpoint.host}:{endpoint.port}/endpoint',
                 )
@@ -85,15 +85,18 @@ class EndpointConnector:
                     uuid = response.json()['uuid']
                     if str(endpoint.uuid) == uuid:
                         logger.debug(
-                            f'connection to {endpoint.uuid} successful, using '
-                            'as home endpoint',
+                            f'Connection to {endpoint.uuid} successful, using '
+                            'as local endpoint',
                         )
                         found_endpoint = endpoint
                         break
                     else:
-                        logger.debug(f'{endpoint.uuid} has different UUID')
+                        logger.debug(
+                            f'Connection to {endpoint.uuid} returned '
+                            'different UUID',
+                        )
                 else:
-                    logger.debug(f'connection to {endpoint.uuid} unsuccessful')
+                    logger.debug(f'Connection to {endpoint.uuid} failed')
 
         if found_endpoint is None:
             raise EndpointConnectorError(
@@ -105,6 +108,12 @@ class EndpointConnector:
         self.endpoint_port = found_endpoint.port
 
         self.address = f'http://{self.endpoint_host}:{self.endpoint_port}'
+
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}(connected to {self.endpoint_uuid} '
+            f'@ {self.address})'
+        )
 
     def close(self) -> None:
         """Close the connector and clean up."""

--- a/proxystore/connectors/file.py
+++ b/proxystore/connectors/file.py
@@ -1,12 +1,15 @@
 """File system connector implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import uuid
 from typing import Any
 from typing import NamedTuple
 from typing import Sequence
+
+logger = logging.getLogger(__name__)
 
 
 class FileKey(NamedTuple):
@@ -29,6 +32,9 @@ class FileConnector:
 
         if not os.path.exists(self.store_dir):
             os.makedirs(self.store_dir, exist_ok=True)
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(directory={self.store_dir})'
 
     def close(self) -> None:
         """Close the connector and clean up.

--- a/proxystore/connectors/globus.py
+++ b/proxystore/connectors/globus.py
@@ -333,6 +333,9 @@ class GlobusConnector:
             authorizer=authorizer,
         )
 
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(endpoints={self.endpoints})'
+
     def _get_filepath(
         self,
         filename: str,
@@ -616,9 +619,19 @@ def _submit_transfer_action(
     """
     try:
         if isinstance(task, globus_sdk.DeleteData):
-            return client.submit_delete(task)
+            response = client.submit_delete(task)
+            logger.debug(
+                'Submitted DeleteData Globus task with ID '
+                f'{response["task_id"]}',
+            )
+            return response
         elif isinstance(task, globus_sdk.TransferData):
-            return client.submit_transfer(task)
+            response = client.submit_transfer(task)
+            logger.debug(
+                'Submitted TransferData Globus task with ID '
+                f'{response["task_id"]}',
+            )
+            return response
         else:
             raise AssertionError('Unreachable.')
     except globus_sdk.TransferAPIError as e:  # pragma: no cover

--- a/proxystore/connectors/local.py
+++ b/proxystore/connectors/local.py
@@ -1,10 +1,13 @@
 """In-process local storage connector implementation."""
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 from typing import NamedTuple
 from typing import Sequence
+
+logger = logging.getLogger(__name__)
 
 
 class LocalKey(NamedTuple):
@@ -32,6 +35,10 @@ class LocalConnector:
         self._store: dict[LocalKey, bytes] = {}
         if store_dict is not None:
             self._store = store_dict
+        logger.info(f'Initialized {self}')
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}()'
 
     def close(self) -> None:
         """Close the connector and clean up."""

--- a/proxystore/connectors/multi.py
+++ b/proxystore/connectors/multi.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 import sys
 import warnings
 from typing import Any
@@ -24,6 +25,7 @@ warnings.warn(
     stacklevel=2,
 )
 
+logger = logging.getLogger(__name__)
 KeyT = TypeVar('KeyT', bound=NamedTuple)
 
 
@@ -145,6 +147,9 @@ class MultiConnector:
             key=lambda name: self.connectors[name].policy.priority,
             reverse=True,
         )
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({self.connectors})'
 
     def close(self) -> None:
         """Close the connector and clean up.

--- a/proxystore/connectors/redis.py
+++ b/proxystore/connectors/redis.py
@@ -29,6 +29,12 @@ class RedisConnector:
         self.port = port
         self._redis_client = redis.StrictRedis(host=hostname, port=port)
 
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}(hostname={self.hostname}, '
+            f'port={self.port})'
+        )
+
     def close(self) -> None:
         """Close the connector and clean up."""
         pass

--- a/proxystore/endpoint/endpoint.py
+++ b/proxystore/endpoint/endpoint.py
@@ -477,4 +477,4 @@ class Endpoint:
         if self._peer_manager is not None:
             await self._peer_manager.close()
         self._data.cleanup()
-        logger.info(f'{self._log_prefix}: endpoint close')
+        logger.info(f'{self._log_prefix}: endpoint closed')

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -56,7 +56,7 @@ def create_app(
     app.register_blueprint(routes_blueprint, url_prefix='')
 
     logger.info(
-        'quart routes registered to endpoint '
+        'Quart routes registered to endpoint '
         f'{endpoint.uuid} ({endpoint.name})',
     )
 
@@ -118,14 +118,14 @@ def serve(
     serve_config.errorlog = logging.getLogger('hypercorn.error')
 
     if use_uvloop:  # pragma: no cover
-        logger.debug('installing uvloop as default event loop')
+        logger.info('Installing uvloop as default event loop')
         uvloop.install()
 
     logger.info(
-        f'serving endpoint {endpoint.uuid} ({endpoint.name}) on '
+        f'Serving endpoint {endpoint.uuid} ({endpoint.name}) on '
         f'{config.host}:{config.port}',
     )
-    logger.info(f'config: {config}')
+    logger.info(f'Config: {config}')
     asyncio.run(hypercorn.asyncio.serve(app, serve_config))
 
 

--- a/proxystore/globus.py
+++ b/proxystore/globus.py
@@ -100,9 +100,14 @@ def authenticate(
     )
 
     url = client.oauth2_get_authorize_url()
-    print(f'Please visit the following url to authenticate:\n{url}')
+    click.secho('Please visit the following url to authenticate:', fg='cyan')
+    click.echo(url)
 
-    auth_code = input('Enter the auth code: ').strip()
+    auth_code = click.prompt(
+        click.style('Enter the auth code:', fg='cyan'),
+        prompt_suffix=' ',
+    )
+    auth_code = auth_code.strip()
     return client.oauth2_exchange_code_for_tokens(auth_code)
 
 

--- a/proxystore/p2p/client.py
+++ b/proxystore/p2p/client.py
@@ -72,6 +72,11 @@ async def connect(
         )
     ssl_default = True if address.startswith('wss://') else None
 
+    logger.info(
+        'Attempting client connection to relay server at '
+        f'{address} with uuid={uuid} and name={name} (ssl: {ssl_default})',
+    )
+
     websocket = await websockets.client.connect(
         address,
         open_timeout=timeout,
@@ -104,7 +109,7 @@ async def connect(
     if isinstance(message, messages.ServerResponse):
         if message.success:
             logger.info(
-                'established client connection to relay server at '
+                'Established client connection to relay server at '
                 f'{address} with uuid={uuid} and name={name}',
             )
             return uuid, name, websocket

--- a/proxystore/p2p/relay.py
+++ b/proxystore/p2p/relay.py
@@ -98,13 +98,13 @@ class RelayServer:
         try:
             message_str = messages.encode(message)
         except messages.MessageEncodeError as e:
-            logger.error(f'failed to encode message: {e}')
+            logger.error(f'Failed to encode message: {e}')
             return
 
         try:
             await websocket.send(message_str)
         except websockets.exceptions.ConnectionClosed:
-            logger.error('connection closed while attempting to send message')
+            logger.error('Connection closed while attempting to send message')
 
     async def register(
         self,
@@ -122,7 +122,7 @@ class RelayServer:
             # old socket. Warning: could be a client impersontating another
             if request.uuid in self._uuid_to_client:
                 logger.info(
-                    f'previously registered client {request.uuid} attempting '
+                    f'Previously registered client {request.uuid} attempting '
                     'to reregister so old registration will be removed',
                 )
                 await self.unregister(
@@ -137,13 +137,13 @@ class RelayServer:
             self._websocket_to_client[websocket] = client
             self._uuid_to_client[client.uuid] = client
             logger.info(
-                f'registered {client.uuid} ({client.name} at '
+                f'Registered {client.uuid} ({client.name} at '
                 f'{websocket.remote_address})',
             )
         else:
             client = self._websocket_to_client[websocket]
             logger.info(
-                f'previously registered client {client.uuid} attempting to '
+                f'Previously registered client {client.uuid} attempting to '
                 'reregister so previous registration will be returned',
             )
 
@@ -167,7 +167,7 @@ class RelayServer:
             return
         reason = 'ok' if expected else 'unexpected'
         logger.info(
-            f'unregistering client {client.uuid} ({client.name}) '
+            f'Unregistering client {client.uuid} ({client.name}) '
             f'for {reason} reason',
         )
         self._uuid_to_client.pop(client.uuid, None)
@@ -188,7 +188,7 @@ class RelayServer:
         client = self._websocket_to_client[websocket]
         if message.peer_uuid not in self._uuid_to_client:
             logger.warning(
-                f'client {client.uuid} ({client.name}) attempting to send '
+                f'Client {client.uuid} ({client.name}) attempting to send '
                 f'message to unknown peer {message.peer_uuid}',
             )
             message.error = (
@@ -199,7 +199,7 @@ class RelayServer:
         else:
             peer_client = self._uuid_to_client[message.peer_uuid]
             logger.info(
-                f'transmitting message from {client.uuid} ({client.name}) '
+                f'Transmitting message from {client.uuid} ({client.name}) '
                 f'to {message.peer_uuid}',
             )
             await self.send(peer_client.websocket, message)
@@ -215,7 +215,7 @@ class RelayServer:
             websocket: Websocket message was received on.
             uri: URI message was sent to.
         """
-        logger.info('relay server listening for incoming connections')
+        logger.info('Relay server listening for incoming connections')
         while True:
             try:
                 message_str = await websocket.recv()
@@ -233,7 +233,7 @@ class RelayServer:
                 break
             except messages.MessageDecodeError as e:
                 logger.error(
-                    'caught deserialization error on message received from '
+                    'Caught deserialization error on message received from '
                     f'{websocket.remote_address}: {e} ...skipping message',
                 )
                 continue
@@ -247,7 +247,7 @@ class RelayServer:
                     # If message is not a registration request but this client
                     # has not yet registered, let them know
                     logger.info(
-                        'returning server error to message received from '
+                        'Returning server error to message received from '
                         f'unregistered client {message.source_uuid} '
                         f'({message.source_name})',
                     )
@@ -301,11 +301,11 @@ async def serve(
         logger=logger,
         ssl=ssl_context,
     ):
-        logger.info(f'serving relay server on {host}:{port}')
-        logger.info('use ctrl-C to stop')
+        logger.info(f'Serving relay server on {host}:{port}')
+        logger.info('Use ctrl-C to stop')
         await stop
 
-    logger.info('server closed')
+    logger.info('Server closed')
 
 
 @click.command()

--- a/proxystore/store/__init__.py
+++ b/proxystore/store/__init__.py
@@ -71,7 +71,7 @@ def register_store(store: Store[Any], exist_ok: bool = False) -> None:
         raise StoreExistsError(f'A store named {store.name} already exists.')
 
     _stores[store.name] = store
-    logger.debug(f'added {store.name} to global registry of stores')
+    logger.info(f'Registered a store named {store.name}')
 
 
 def unregister_store(name: str) -> None:
@@ -86,4 +86,4 @@ def unregister_store(name: str) -> None:
     """
     if name in _stores:
         del _stores[name]
-        logger.debug(f'removed {name} from global registry of stores')
+        logger.debug(f'Unregistered a store named {name}')

--- a/tests/globus_test.py
+++ b/tests/globus_test.py
@@ -1,13 +1,13 @@
 """Globus Auth Unit Tests."""
 from __future__ import annotations
 
-import contextlib
 import json
 import os
 import pathlib
 from unittest import mock
 
 import click
+import click.testing
 import globus_sdk
 import pytest
 
@@ -38,11 +38,9 @@ def test_save_load_tokens(tmp_path: pathlib.Path) -> None:
 def test_authenticate(capsys) -> None:
     # This test is heavily mocked so most just checks for simple errors
     with mock.patch('globus_sdk.NativeAppAuthClient'), mock.patch(
-        'builtins.input',
+        'click.prompt',
         return_value='123456789',
-    ), contextlib.redirect_stdout(
-        None,
-    ):
+    ), mock.patch('click.echo'), mock.patch('click.secho'):
         authenticate('1234', 'https://redirect')
 
 

--- a/tests/p2p/relay_cli_test.py
+++ b/tests/p2p/relay_cli_test.py
@@ -9,6 +9,7 @@ import sys
 from unittest import mock
 
 import click
+import click.testing
 import pytest
 import websockets
 
@@ -56,7 +57,7 @@ def test_logging_config(tmp_path: pathlib.Path) -> None:
         # Wait for server to log that it is listening
         assert server_handle.stdout is not None
         for line in server_handle.stdout:  # pragma: no cover
-            if 'serving' in line:
+            if 'Serving' in line:
                 break
 
         server_handle.terminate()
@@ -124,7 +125,7 @@ async def test_start_server_cli() -> None:
     # Wait for server to log that it is listening
     assert server_handle.stdout is not None
     for line in server_handle.stdout:  # pragma: no cover
-        if 'serving relay server' in line:
+        if 'Serving relay server' in line:
             break
 
     _, _, websocket = await connect(address)

--- a/tests/p2p/relay_test.py
+++ b/tests/p2p/relay_test.py
@@ -216,7 +216,7 @@ async def test_relay_server_send_encode_error(
 
     assert any(
         [
-            'failed to encode' in record.message
+            'Failed to encode' in record.message
             and record.levelname == 'ERROR'
             for record in caplog.records
         ],
@@ -237,7 +237,7 @@ async def test_relay_server_send_connection_closed(
 
     assert any(
         [
-            'connection closed' in record.message
+            'Connection closed' in record.message
             and record.levelname == 'ERROR'
             for record in caplog.records
         ],


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

This addresses #124 but does not implement all of the suggestions there. Namely, I've kept a logger for each module so its easy to find where log messages originated from.

Changes:
- Updated `proxystore-globus-auth` CLI to use `click`'s prompt/echo rather than standard print/input.
- Adjusted logging formats.
- Improved `repr(Store)` 
- Added `__repr__` to the `Connector` implementations
  - Note: I skipped adjusting the logging in `proxystore.connectors.dim` as that module will be totally refactored in #224.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #124

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Inspected log messages with `--log-cli-level DEBUG` in pytest.

Note that some of the `click` tools will cause pytest to fail with `--log-cli-level DEBUG`. This is a know issue: https://github.com/pallets/click/issues/824.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
