### PR TITLE
Add `test` subcommand to `proxystore-endpoint`

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,5 +1,5 @@
 <style>
-.md-typeset h2, h3 {
+.md-typeset h2, h3, h4 {
   font-weight: 400;
   font-family: var(--md-code-font-family);
 }
@@ -10,7 +10,7 @@
   border-width: 2px;
 }
 
-.md-typeset h3 {
+.md-typeset h3, h4 {
   border-bottom-style: dashed;
   border-color: var(--md-default-fg-color--lighter);
   border-width: 1px;

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,3 +1,22 @@
+<style>
+.md-typeset h2, h3 {
+  font-weight: 400;
+  font-family: var(--md-code-font-family);
+}
+
+.md-typeset h2 {
+  border-bottom-style: solid;
+  border-color: var(--md-default-fg-color--lighter);
+  border-width: 2px;
+}
+
+.md-typeset h3 {
+  border-bottom-style: dashed;
+  border-color: var(--md-default-fg-color--lighter);
+  border-width: 1px;
+}
+</style>
+
 # CLI Reference
 
 This page provides documentation for our command line tools.
@@ -6,13 +25,22 @@ This page provides documentation for our command line tools.
     :module: proxystore.globus
     :command: cli
     :prog_name: proxystore-globus-auth
+    :depth: 1
+    :list_subcommands: True
+    :style: table
 
 ::: mkdocs-click
     :module: proxystore.endpoint.cli
     :command: cli
     :prog_name: proxystore-endpoint
+    :depth: 1
+    :list_subcommands: True
+    :style: table
 
 ::: mkdocs-click
     :module: proxystore.p2p.relay
     :command: cli
     :prog_name: proxystore-relay
+    :depth: 1
+    :list_subcommands: True
+    :style: table

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ plugins:
             - https://aiortc.readthedocs.io/en/latest/objects.inv
             - https://globus-sdk-python.readthedocs.io/en/stable/objects.inv
             - https://websockets.readthedocs.io/en/stable/objects.inv
+            - https://requests.readthedocs.io/en/latest/objects.inv
           options:
             docstring_section_style: list
             docstring_style: google

--- a/proxystore/endpoint/client.py
+++ b/proxystore/endpoint/client.py
@@ -1,0 +1,136 @@
+"""Utilities for client interactions with endpoints."""
+from __future__ import annotations
+
+import uuid
+
+import requests
+from requests.exceptions import RequestException  # noqa: F401
+
+from proxystore.endpoint.constants import MAX_CHUNK_LENGTH
+from proxystore.utils import chunk_bytes
+
+
+def evict(
+    address: str,
+    key: str,
+    endpoint: uuid.UUID | str | None = None,
+) -> None:
+    """Evict the object associated with the key.
+
+    Args:
+        address: Address of endpoint.
+        key: Key associated with object to evict.
+        endpoint: Optional UUID of remote endpoint to forward operation to.
+
+    Raises:
+        RequestException: If the endpoint request results in an unexpected
+            error code.
+    """
+    endpoint_str = (
+        str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
+    )
+    response = requests.post(
+        f'{address}/evict',
+        params={'key': key, 'endpoint': endpoint_str},
+    )
+    response.raise_for_status()
+
+
+def exists(
+    address: str,
+    key: str,
+    endpoint: uuid.UUID | str | None = None,
+) -> bool:
+    """Check if an object associated with the key exists.
+
+    Args:
+        address: Address of endpoint.
+        key: Key potentially associated with stored object.
+        endpoint: Optional UUID of remote endpoint to forward operation to.
+
+    Returns:
+        If an object associated with the key exists.
+
+    Raises:
+        RequestException: If the endpoint request results in an unexpected
+            error code.
+    """
+    endpoint_str = (
+        str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
+    )
+    response = requests.get(
+        f'{address}/exists',
+        params={'key': key, 'endpoint': endpoint_str},
+    )
+    response.raise_for_status()
+    return response.json()['exists']
+
+
+def get(
+    address: str,
+    key: str,
+    endpoint: uuid.UUID | str | None = None,
+) -> bytes | None:
+    """Get the serialized object associated with the key.
+
+    Args:
+        address: Address of endpoint.
+        key: Key associated with object to retrieve.
+        endpoint: Optional UUID of remote endpoint to forward operation to.
+
+    Returns:
+        Serialized object or `None` if the object does not exist.
+
+    Raises:
+        RequestException: If the endpoint request results in an unexpected
+            error code.
+    """
+    endpoint_str = (
+        str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
+    )
+    response = requests.get(
+        f'{address}/get',
+        params={'key': key, 'endpoint': endpoint_str},
+        stream=True,
+    )
+
+    if response.status_code == 400:
+        return None
+
+    response.raise_for_status()
+
+    data = bytearray()
+    for chunk in response.iter_content(chunk_size=None):
+        data += chunk
+    return bytes(data)
+
+
+def put(
+    address: str,
+    key: str,
+    data: bytes,
+    endpoint: uuid.UUID | str | None = None,
+) -> None:
+    """Put a serialized object in the store.
+
+    Args:
+        address: Address of endpoint.
+        key: Key associated with object to retrieve.
+        data: Serialized data to put in the store.
+        endpoint: Optional UUID of remote endpoint to forward operation to.
+
+    Raises:
+        RequestException: If the endpoint request results in an unexpected
+            error code.
+    """
+    endpoint_str = (
+        str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
+    )
+    response = requests.post(
+        f'{address}/set',
+        headers={'Content-Type': 'application/octet-stream'},
+        params={'key': key, 'endpoint': endpoint_str},
+        data=chunk_bytes(data, MAX_CHUNK_LENGTH),
+        stream=True,
+    )
+    response.raise_for_status()

--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+import uuid
 from typing import Generator
 from unittest import mock
 
 import click
 import pytest
+import requests
 
 import proxystore
 from proxystore.endpoint.cli import cli
+from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import read_config
+from proxystore.endpoint.config import write_config
 
 
 @pytest.fixture()
@@ -112,3 +116,163 @@ def test_stop_command(home_dir, caplog) -> None:
     assert any(
         ['does not exist' in record.message for record in caplog.records],
     )
+
+
+def test_test_command_missing_endpoint(home_dir, caplog) -> None:
+    caplog.set_level(logging.ERROR)
+
+    with mock.patch('proxystore.endpoint.cli.home_dir', return_value=home_dir):
+        runner = click.testing.CliRunner()
+
+        result = runner.invoke(cli, ['test', 'fake-name', 'exists', 'key'])
+        assert result.exit_code == 1
+        assert (
+            'An endpoint named fake-name does not exist.'
+            in caplog.records[0].message
+        )
+
+
+def test_test_command(home_dir, caplog, endpoint: EndpointConfig) -> None:
+    caplog.set_level(logging.INFO)
+
+    with mock.patch('proxystore.endpoint.cli.home_dir', return_value=home_dir):
+        endpoint_dir = os.path.join(home_dir, endpoint.name)
+        write_config(endpoint, endpoint_dir)
+
+        runner = click.testing.CliRunner()
+
+        value = 'hello hello'
+        key_uuid = uuid.uuid4()
+        key = str(key_uuid)
+
+        with mock.patch('uuid.uuid4', return_value=key_uuid):
+            result = runner.invoke(cli, ['test', endpoint.name, 'put', value])
+        assert result.exit_code == 0
+        assert key in caplog.records[0].message
+        caplog.clear()
+
+        result = runner.invoke(cli, ['test', endpoint.name, 'exists', key])
+        assert result.exit_code == 0
+        assert 'True' in caplog.records[0].message
+        caplog.clear()
+
+        result = runner.invoke(cli, ['test', endpoint.name, 'get', key])
+        assert result.exit_code == 0
+        assert value in caplog.records[0].message
+        caplog.clear()
+
+        result = runner.invoke(cli, ['test', endpoint.name, 'evict', key])
+        assert result.exit_code == 0
+        caplog.clear()
+
+        result = runner.invoke(cli, ['test', endpoint.name, 'exists', key])
+        assert result.exit_code == 0
+        assert 'False' in caplog.records[0].message
+        caplog.clear()
+
+        result = runner.invoke(cli, ['test', endpoint.name, 'get', key])
+        assert result.exit_code == 0
+        assert 'does not exist' in caplog.records[0].message
+        caplog.clear()
+
+
+def test_test_command_connection_error(
+    home_dir,
+    caplog,
+    endpoint: EndpointConfig,
+) -> None:
+    caplog.set_level(logging.ERROR)
+
+    with mock.patch('proxystore.endpoint.cli.home_dir', return_value=home_dir):
+        endpoint_dir = os.path.join(home_dir, endpoint.name)
+        write_config(endpoint, endpoint_dir)
+
+        runner = click.testing.CliRunner()
+        key = 'fake-key'
+
+        with mock.patch(
+            'proxystore.endpoint.client.evict',
+            side_effect=requests.exceptions.ConnectionError,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'evict', key])
+        assert result.exit_code == 1
+        assert 'Unable to connect' in caplog.records[0].message
+        caplog.clear()
+
+        with mock.patch(
+            'proxystore.endpoint.client.exists',
+            side_effect=requests.exceptions.ConnectionError,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'exists', key])
+        assert 'Unable to connect' in caplog.records[0].message
+        assert result.exit_code == 1
+        caplog.clear()
+
+        with mock.patch(
+            'proxystore.endpoint.client.get',
+            side_effect=requests.exceptions.ConnectionError,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'get', key])
+        assert 'Unable to connect' in caplog.records[0].message
+        assert result.exit_code == 1
+        caplog.clear()
+
+        with mock.patch(
+            'proxystore.endpoint.client.put',
+            side_effect=requests.exceptions.ConnectionError,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'put', key])
+        assert 'Unable to connect' in caplog.records[0].message
+        assert result.exit_code == 1
+        caplog.clear()
+
+
+def test_test_command_unexpected_error(
+    home_dir,
+    caplog,
+    endpoint: EndpointConfig,
+) -> None:
+    caplog.set_level(logging.ERROR)
+
+    with mock.patch('proxystore.endpoint.cli.home_dir', return_value=home_dir):
+        endpoint_dir = os.path.join(home_dir, endpoint.name)
+        write_config(endpoint, endpoint_dir)
+
+        runner = click.testing.CliRunner()
+        key = 'fake-key'
+
+        with mock.patch(
+            'proxystore.endpoint.client.evict',
+            side_effect=requests.exceptions.RequestException,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'evict', key])
+        assert result.exit_code == 1
+        assert len(caplog.records) == 1
+        caplog.clear()
+
+        with mock.patch(
+            'proxystore.endpoint.client.exists',
+            side_effect=requests.exceptions.RequestException,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'exists', key])
+        assert result.exit_code == 1
+        assert len(caplog.records) == 1
+        caplog.clear()
+
+        with mock.patch(
+            'proxystore.endpoint.client.get',
+            side_effect=requests.exceptions.RequestException,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'get', key])
+        assert result.exit_code == 1
+        assert len(caplog.records) == 1
+        caplog.clear()
+
+        with mock.patch(
+            'proxystore.endpoint.client.put',
+            side_effect=requests.exceptions.RequestException,
+        ):
+            result = runner.invoke(cli, ['test', endpoint.name, 'put', key])
+        assert result.exit_code == 1
+        assert len(caplog.records) == 1
+        caplog.clear()

--- a/tests/endpoint/client_test.py
+++ b/tests/endpoint/client_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import uuid
+from unittest import mock
+
+import pytest
+import requests
+
+from proxystore.endpoint import client
+from proxystore.endpoint.config import EndpointConfig
+
+
+def test_basic_client_interaction(endpoint: EndpointConfig) -> None:
+    address = f'http://{endpoint.host}:{endpoint.port}'
+    key = str(uuid.uuid4())
+    data = b'test'
+
+    client.put(address, key, data)
+    assert client.exists(address, key)
+    assert client.get(address, key) == data
+
+    client.evict(address, key)
+    assert not client.exists(address, key)
+    assert client.get(address, key) is None
+
+
+def test_errors_raised() -> None:
+    address = 'http://localhost:8539'
+    key = 'abcd'
+
+    response = requests.Response()
+    response.status_code = 500
+
+    with mock.patch('requests.post', return_value=response):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.evict(address, key)
+
+        with pytest.raises(requests.exceptions.RequestException):
+            client.put(address, key, b'data')
+
+    with mock.patch('requests.get', return_value=response):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.exists(address, key)
+
+        with pytest.raises(requests.exceptions.RequestException):
+            client.get(address, key)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds the `test` subcommand to the `proxystore-endpoint` CLI which can be used to test operations on an endpoint (even peer endpoints) for easier debugging. Previously I would use curl which is a bit annoying.

In the process of implementing this, I was starting to duplicate much of the client code in `proxystore.connectors.endpoint` so I factored that out into a separate `proxystore.endpoint.client` module which can be reused.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #246

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests, and verified the CLI worked with two endpoints in peering mode.

```bash
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint configure ep1 --port 8765 --relay-server [redacted]
INFO: Configured endpoint ep1 <955074f2-8c79-457c-85c6-5dbd1f45d631>. Start with:
INFO:   $ proxystore-endpoint start ep1
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint configure ep2 --port 8766 --relay-server [redacted]
INFO: Configured endpoint ep2 <9659e86e-f21c-4658-b258-84f059a40d91>. Start with:
INFO:   $ proxystore-endpoint start ep2
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint start ep1
INFO: Starting endpoint process as daemon.
INFO: Logs will be written to /Users/jgpaul/.local/share/proxystore/ep1/endpoint.log
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint start ep2
INFO: Starting endpoint process as daemon.
INFO: Logs will be written to /Users/jgpaul/.local/share/proxystore/ep2/endpoint.log
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint test --remote 9659e86e-f21c-4658-b258-84f059a40d91 ep1 evict abcd
INFO: Evicted object from endpoint.
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint test --remote 9659e86e-f21c-4658-b258-84f059a40d91 ep1 put "hello hello"
INFO: Put object in endpoint with key 2bf6d6ee-df37-412b-ab70-fd8bb815b0d2
(venv) jgpaul@hoth:proxystore$ proxystore-endpoint test ep2 get 2bf6d6ee-df37-412b-ab70-fd8bb815b0d2
INFO: Result: hello hello
```

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
