### PR TITLE
Return configs instead of instances in `MultiConnector.config()` (#252)

### DIFF
--- a/tests/connectors/multi_test.py
+++ b/tests/connectors/multi_test.py
@@ -135,3 +135,12 @@ def test_multi_connector_policy_no_valid() -> None:
     with pytest.raises(RuntimeError, match='policy'):
         connector.put(b'value')
     connector.close()
+
+
+def test_multi_connector_from_config() -> None:
+    with multi_connector_from_policies(
+        Policy(priority=1, subset_tags=['a', 'b']),
+        Policy(priority=2, superset_tags=['x', 'y']),
+    ) as (multi_connector, connector1, connector2):
+        config = multi_connector.config()
+        MultiConnector.from_config(config)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Change `MultiConnector.config()` to return the configs of each connector instance rather than the connector instances themselves. Returning the connector instances, as it was previously, was a bug that violated the guarentee that `.config()`/`.from_config()` would create entirely new connector instances.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #252

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new test form `MultiConnector.from_config()`.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
