### PR TITLE
Support "dormant" connectors in `MultiConnector" (#253)

### DIFF
--- a/proxystore/connectors/dim/zmq.py
+++ b/proxystore/connectors/dim/zmq.py
@@ -403,7 +403,7 @@ class ZeroMQServer:
             except zmq.ZMQError as e:  # pragma: no cover
                 logger.exception(e)
                 await asyncio.sleep(0.01)
-            except asyncio.exceptions.CancelledError:  # pragma: no cover
+            except asyncio.CancelledError:  # pragma: no cover
                 logger.debug('loop terminated')
 
     async def launch(self) -> None:

--- a/proxystore/utils.py
+++ b/proxystore/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import decimal
 import importlib
 import os
-import random
 import re
 import socket
 from typing import Any
@@ -27,33 +26,6 @@ def chunk_bytes(
     length = len(data)
     for index in range(0, length, chunk_size):
         yield data[index : min(index + chunk_size, length)]
-
-
-def create_key(obj: Any) -> str:
-    """Generate key for the object.
-
-    Args:
-        obj: Object to create key for.
-
-    Returns:
-        A random 128 bit string.
-    """
-    return str(random.getrandbits(128))
-
-
-def fullname(obj: Any) -> str:
-    """Return full name of object."""
-    if hasattr(obj, '__module__'):
-        module = obj.__module__
-    else:
-        module = obj.__class__.__module__
-    if hasattr(obj, '__name__'):
-        name = obj.__name__
-    else:
-        name = obj.__class__.__name__
-    if module is None or module == str.__module__:
-        return name
-    return f'{module}.{name}'
 
 
 def get_class_path(cls: type[Any]) -> str:

--- a/tests/connectors/multi_test.py
+++ b/tests/connectors/multi_test.py
@@ -11,6 +11,7 @@ import pytest
 from proxystore.connectors.connector import Connector
 from proxystore.connectors.local import LocalConnector
 from proxystore.connectors.multi import MultiConnector
+from proxystore.connectors.multi import MultiConnectorError
 from proxystore.connectors.multi import Policy
 
 
@@ -151,7 +152,7 @@ def test_multi_connector_policy_no_valid() -> None:
     }
 
     connector = MultiConnector(connectors)
-    with pytest.raises(RuntimeError, match='policy'):
+    with pytest.raises(MultiConnectorError, match='policy'):
         connector.put(b'value')
     connector.close()
 
@@ -160,7 +161,7 @@ def test_multi_connector_bad_key() -> None:
     connector = MultiConnector({'connector': (LocalConnector(), Policy())})
     key = connector.put(b'value')
     key = key._replace(connector_name='missing')
-    with pytest.raises(RuntimeError, match='does not exist'):
+    with pytest.raises(MultiConnectorError, match='does not exist'):
         connector.exists(key)
 
 
@@ -194,7 +195,7 @@ def test_dormant_connectors() -> None:
             assert remote_connector.dormant_connectors is not None
             assert len(remote_connector.dormant_connectors) == 1
 
-            with pytest.raises(RuntimeError, match='constraints'):
+            with pytest.raises(MultiConnectorError, match='constraints'):
                 remote_connector.put(b'data', subset_tags=['b'])
-            with pytest.raises(RuntimeError, match='dormant'):
+            with pytest.raises(MultiConnectorError, match='dormant'):
                 remote_connector.get(key2)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -7,10 +7,8 @@ from unittest import mock
 
 import pytest
 
-from proxystore import utils
 from proxystore.connectors.file import FileConnector
 from proxystore.connectors.local import LocalConnector
-from proxystore.factory import SimpleFactory
 from proxystore.utils import bytes_to_readable
 from proxystore.utils import chunk_bytes
 from proxystore.utils import get_class_path
@@ -29,21 +27,6 @@ def test_chunk_bytes(data_size: int, chunk_size: int) -> None:
     for chunk in chunk_bytes(data, chunk_size):
         result += chunk
     assert data == result
-
-
-def test_create_key() -> None:
-    """Test create_key()."""
-    assert isinstance(utils.create_key(42), str)
-
-
-def test_fullname() -> None:
-    """Test fullname()."""
-    assert utils.fullname(SimpleFactory) == 'proxystore.factory.SimpleFactory'
-    assert (
-        utils.fullname(SimpleFactory('string'))
-        == 'proxystore.factory.SimpleFactory'
-    )
-    assert utils.fullname('string') == 'str'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

A dormant connector is a connector maintained by a `MultiConnector` instance, but the dormant connector itself is not initialized because it is not "valid" on that processes. Validity is determined by the `host_pattern` of the connector's corresponding policy.

This allows one to use a `MultiConnector` object on many processes across multiple machines even though not all of the individual connectors may be valid or initializable on any specific machine.

For example, consider a `MultiConnector` managing a `RedisConnector` available a site A and an `EndpointConnector` available at sites A and B. If the `MultiConnector` gets initialized on site B, it needs to skip the initialization of the `RedisConnector` because it is not available at this site. Thus, the `RedisConnector` is determined dormant.

Additionally, this PR:
- Removes some unused functions in `proxystore.utils`
- Adds a `MultiConnectorError` to replace the previously raised `RuntimeError`s.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #253

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
