### PR TITLE
Fix fixture timeouts in tests

### DIFF
--- a/testing/endpoint.py
+++ b/testing/endpoint.py
@@ -49,7 +49,8 @@ def wait_for_endpoint(host: str, port: int, max_time_s: float = 5) -> None:
         except requests.exceptions.ConnectionError as e:
             if waited_s >= max_time_s:  # pragma: no cover
                 raise RuntimeError(
-                    'Unable to connect to endpoint with {max_time_s} seconds.',
+                    'Unable to connect to endpoint within the timeout '
+                    f'({max_time_s} seconds).',
                 ) from e
             time.sleep(sleep_s)
             waited_s += sleep_s

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -3,15 +3,23 @@ from __future__ import annotations
 
 import socket
 
+_used_ports: set[int] = set()
+
 
 def open_port() -> int:
     """Return open port.
 
     Source: https://stackoverflow.com/questions/2838244
     """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(('', 0))
-    s.listen(1)
-    port = s.getsockname()[1]
-    s.close()
-    return port
+    global _used_ports
+
+    while True:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(('', 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+        s.close()
+        if port not in _used_ports:  # pragma: no branch
+            _used_ports.add(port)
+            return port

--- a/tests/integration/endpoints_test.py
+++ b/tests/integration/endpoints_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import pathlib
+import tempfile
 import uuid
 from multiprocessing import Process
 from multiprocessing import Queue
@@ -42,12 +43,14 @@ def serve_relay_server(host: str, port: int) -> None:
     asyncio.run(serve(host, port))
 
 
-@pytest.fixture()
+@pytest.fixture(scope='module')
 def endpoints(
     relay_server,
-    tmp_path: pathlib.Path,
 ) -> Generator[tuple[list[uuid.UUID], list[str]], None, None]:
     """Launch the relay server and two endpoints."""
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_path = pathlib.Path(tmp_dir.name)
+
     ss_host = 'localhost'
     ss_port = open_port()
 
@@ -97,6 +100,8 @@ def endpoints(
 
     ss.terminate()
     ss.join()
+
+    tmp_dir.cleanup()
 
 
 @pytest.mark.integration()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

I've noticed some increased random timeouts/port binding issues with some tests. The issues only seem to happen on very fast single-threaded machines like my 7800x3d. It seems this was a result of the the OS not releasing the ports temporarily bound to in `open_port` fast enough.

As a bonus, the test suite is ~0.5 seconds faster now :). 

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Ran the test suite ~20 times without failure. Previously would fail every few runs.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
