### PR TITLE
Prevent `from_config()` from modifying caller's config copy

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -309,6 +309,7 @@ class Store(Generic[ConnectorT]):
         Returns:
             Store instance.
         """
+        config = config.copy()  # Avoid messing with callers version
         connector_type = config.pop('connector_type')
         connector_config = config.pop('connector_config')
         connector = import_class(connector_type)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

`Store.from_config()` modified keys in the provided config dictionary. Proxy factories store the config though, so when a factory reinitialized a `Store` with the `from_config()` static method, it's own config would get messed up. The fix is simply to do a shallow copy of the dict.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Discovered when update Colmena to v0.5 and tested with that Colmena code that manifested the error.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
