### PR TITLE
Fix `StoreFactory` serialization `TypeError`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -101,18 +101,14 @@ class StoreFactory(Generic[ConnectorT, T]):
 
         return obj
 
-    def __getnewargs_ex__(
-        self,
-    ) -> tuple[tuple[ConnectorKeyT, dict[str, Any]], dict[str, Any]]:
-        # Pickle without possible futures.
-        return (
-            self.key,
-            self.store_config,
-        ), {
-            'evict': self.evict,
-            'deserializer': self.deserializer,
-            'metrics': self.metrics,
-        }
+    def __getstate__(self) -> dict[str, Any]:
+        # Override pickling behavior to not serialize a possible future
+        state = self.__dict__.copy()
+        state['_obj_future'] = None
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
 
     def get_store(self) -> Store[ConnectorT]:
         """Get store and reinitialize if necessary.

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -70,6 +70,33 @@ def test_store_factory(store_implementation: StoreFixtureType) -> None:
     unregister_store(store_info.name)
 
 
+def test_factory_serialization(store_implementation: StoreFixtureType) -> None:
+    store, store_info = store_implementation
+
+    register_store(store)
+
+    key = store.set([1, 2, 3])
+    f1: StoreFactory[Any, list[int]] = StoreFactory(
+        key,
+        store_config=store.config(),
+    )
+    f1_bytes = serialize(f1)
+    f2 = deserialize(f1_bytes)
+    assert f1() == f2() == [1, 2, 3]
+
+    # Check serialize after async resolve
+    f3: StoreFactory[Any, list[int]] = StoreFactory(
+        key,
+        store_config=store.config(),
+    )
+    f3.resolve_async()
+    f3_bytes = serialize(f3)
+    f4 = deserialize(f3_bytes)
+    assert f3() == f4() == [1, 2, 3]
+
+    unregister_store(store)
+
+
 def test_store_proxy(store_implementation: StoreFixtureType) -> None:
     """Test Store Proxy."""
     store, store_info = store_implementation


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The `StoreFactory` raises a `TypeError` that a lock type cannot be pickled when serialized after calling `.resolve_async()` of the factory. I switched from `__getnewargs_ex__` to `__getstate__`/`__setstate__` for adjusting pickling behavior and added new tests to verify.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new test to verify behavior.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
