### PR TITLE
Reuse HTTP connections in endpoint clients

### DIFF
--- a/proxystore/endpoint/client.py
+++ b/proxystore/endpoint/client.py
@@ -14,6 +14,7 @@ def evict(
     address: str,
     key: str,
     endpoint: uuid.UUID | str | None = None,
+    session: requests.Session | None = None,
 ) -> None:
     """Evict the object associated with the key.
 
@@ -21,6 +22,9 @@ def evict(
         address: Address of endpoint.
         key: Key associated with object to evict.
         endpoint: Optional UUID of remote endpoint to forward operation to.
+        session: Session instance to use for making the request. Reusing the
+            same session across multiple requests to the same host can improve
+            performance.
 
     Raises:
         RequestException: If the endpoint request results in an unexpected
@@ -29,7 +33,8 @@ def evict(
     endpoint_str = (
         str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
     )
-    response = requests.post(
+    post = requests.post if session is None else session.post
+    response = post(
         f'{address}/evict',
         params={'key': key, 'endpoint': endpoint_str},
     )
@@ -45,6 +50,7 @@ def exists(
     address: str,
     key: str,
     endpoint: uuid.UUID | str | None = None,
+    session: requests.Session | None = None,
 ) -> bool:
     """Check if an object associated with the key exists.
 
@@ -52,6 +58,9 @@ def exists(
         address: Address of endpoint.
         key: Key potentially associated with stored object.
         endpoint: Optional UUID of remote endpoint to forward operation to.
+        session: Session instance to use for making the request. Reusing the
+            same session across multiple requests to the same host can improve
+            performance.
 
     Returns:
         If an object associated with the key exists.
@@ -63,7 +72,8 @@ def exists(
     endpoint_str = (
         str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
     )
-    response = requests.get(
+    get_ = requests.get if session is None else session.get
+    response = get_(
         f'{address}/exists',
         params={'key': key, 'endpoint': endpoint_str},
     )
@@ -80,6 +90,7 @@ def get(
     address: str,
     key: str,
     endpoint: uuid.UUID | str | None = None,
+    session: requests.Session | None = None,
 ) -> bytes | None:
     """Get the serialized object associated with the key.
 
@@ -87,6 +98,9 @@ def get(
         address: Address of endpoint.
         key: Key associated with object to retrieve.
         endpoint: Optional UUID of remote endpoint to forward operation to.
+        session: Session instance to use for making the request. Reusing the
+            same session across multiple requests to the same host can improve
+            performance.
 
     Returns:
         Serialized object or `None` if the object does not exist.
@@ -98,7 +112,8 @@ def get(
     endpoint_str = (
         str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
     )
-    response = requests.get(
+    get_ = requests.get if session is None else session.get
+    response = get_(
         f'{address}/get',
         params={'key': key, 'endpoint': endpoint_str},
         stream=True,
@@ -125,6 +140,7 @@ def put(
     key: str,
     data: bytes,
     endpoint: uuid.UUID | str | None = None,
+    session: requests.Session | None = None,
 ) -> None:
     """Put a serialized object in the store.
 
@@ -133,6 +149,9 @@ def put(
         key: Key associated with object to retrieve.
         data: Serialized data to put in the store.
         endpoint: Optional UUID of remote endpoint to forward operation to.
+        session: Session instance to use for making the request. Reusing the
+            same session across multiple requests to the same host can improve
+            performance.
 
     Raises:
         RequestException: If the endpoint request results in an unexpected
@@ -141,7 +160,8 @@ def put(
     endpoint_str = (
         str(endpoint) if isinstance(endpoint, uuid.UUID) else endpoint
     )
-    response = requests.post(
+    post = requests.post if session is None else session.post
+    response = post(
         f'{address}/set',
         headers={'Content-Type': 'application/octet-stream'},
         params={'key': key, 'endpoint': endpoint_str},

--- a/tests/connectors/endpoint_test.py
+++ b/tests/connectors/endpoint_test.py
@@ -30,7 +30,7 @@ def test_no_endpoints_accessible(endpoint_connector) -> None:
     response = requests.Response()
     response.status_code = 400
 
-    with mock.patch('requests.get', return_value=response):
+    with mock.patch('requests.Session.get', return_value=response):
         with pytest.raises(EndpointConnectorError, match='Failed to find'):
             EndpointConnector(**endpoint_connector.kwargs)
 
@@ -40,7 +40,7 @@ def test_endpoint_uuid_mismatch(endpoint_connector) -> None:
     response.status_code = 200
     response.json = lambda: {'uuid': str(uuid.uuid4())}  # type: ignore
 
-    with mock.patch('requests.get', return_value=response):
+    with mock.patch('requests.Session.get', return_value=response):
         with pytest.raises(EndpointConnectorError, match='Failed to find'):
             EndpointConnector(**endpoint_connector.kwargs)
 
@@ -52,20 +52,20 @@ def test_bad_responses(endpoint_connector) -> None:
     response = requests.Response()
     response.status_code = 400
 
-    with mock.patch('requests.get', return_value=response):
+    with mock.patch('requests.Session.get', return_value=response):
         key = connector.put(b'value')
         assert connector.get(key) is None
 
     response.status_code = 401
 
-    with mock.patch('requests.get', return_value=response):
+    with mock.patch('requests.Session.get', return_value=response):
         with pytest.raises(EndpointConnectorError, match='401'):
             connector.exists(key)
 
         with pytest.raises(EndpointConnectorError, match='401'):
             connector.get(key)
 
-    with mock.patch('requests.post', return_value=response):
+    with mock.patch('requests.Session.post', return_value=response):
         with pytest.raises(EndpointConnectorError, match='401'):
             connector.evict(key)
 

--- a/tests/endpoint/client_test.py
+++ b/tests/endpoint/client_test.py
@@ -24,6 +24,21 @@ def test_basic_client_interaction(endpoint: EndpointConfig) -> None:
     assert client.get(address, key) is None
 
 
+def test_client_interaction_with_session(endpoint: EndpointConfig) -> None:
+    address = f'http://{endpoint.host}:{endpoint.port}'
+    key = str(uuid.uuid4())
+    data = b'test'
+
+    with requests.Session() as session:
+        client.put(address, key, data, session=session)
+        assert client.exists(address, key, session=session)
+        assert client.get(address, key, session=session) == data
+
+        client.evict(address, key, session=session)
+        assert not client.exists(address, key, session=session)
+        assert client.get(address, key, session=session) is None
+
+
 def test_errors_raised() -> None:
     address = 'http://localhost:8539'
     key = 'abcd'


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Using the same `requests.Session` for HTTP requests by the `EndpointConnector` allows the underlying TCP connections managed by urlib3 to be reused which can speed up repeated requests to the same host (which is the case for the `EndpointConnector` which always communicates directly with it's local endpoint).

The enndpoint client functions have been updated to take an optional `requests.Session` object, and the `EndpointConnector` now maintains a single `requests.Session` which is closed when the connector is closed.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #289

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Update unit tests to test session usage, and tested that the `OSError: [Errno 99] Cannot assign requested address` error is less apparent in the `endpoint-qps` benchmark (it still happens sometimes because the OS can still be slow to release ports).

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
