### PR TITLE
Revert MacOS multiprocessing to default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,11 +51,6 @@ from testing.stores import multi_store
 from testing.stores import redis_store
 from testing.stores import store_implementation
 
-if platform.system() == 'Darwin':  # pragma: no cover
-    import multiprocessing
-
-    multiprocessing.set_start_method('fork')
-
 
 def pytest_addoption(parser):
     """Add custom command line options for tests."""


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Reverts MacOS multiprocessing to "spawn" (the default) in the test suite. This seems to be causing race conditions with coverage files (that manifest similar to https://github.com/nedbat/coveragepy/issues/1605) and bad file descriptor errors on the `ZMQServer` (https://stackoverflow.com/questions/45438323/).

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [x] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Test pass without errors on my Mac now (previously was <20% of time).

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
