### PR TITLE
Made interface optional for DIMs and added `addr` arg for IP

### DIFF
--- a/proxystore/connectors/dim/margo.py
+++ b/proxystore/connectors/dim/margo.py
@@ -115,7 +115,7 @@ class MargoConnector:
 
         if self._address is not None:
             self.address = self._address
-        elif self._interface is not None:
+        elif self._interface is not None:  # pragma: darwin no cover
             self.address = get_ip_address(self._interface)
         else:
             eng_url = str(self.engine.addr())

--- a/proxystore/connectors/dim/margo.py
+++ b/proxystore/connectors/dim/margo.py
@@ -70,9 +70,12 @@ class MargoConnector:
         to that server.
 
     Args:
-        interface: The network interface to use.
         port: The desired port for the spawned server.
         protocol: The communication protocol to use.
+        address: The network IP to use for transfer. Has precedence over `interface`
+            if both are provided.
+        interface: The network interface to use. `addr` has precedence over
+            this attribute if both are provided.
         timeout: Timeout in seconds to try connecting to a local server before
             spawning one.
 
@@ -84,9 +87,10 @@ class MargoConnector:
 
     def __init__(
         self,
-        interface: str,
         port: int,
         protocol: Protocol | str,
+        address: str | None = None,
+        interface: str | None = None,
         timeout: float = 1,
     ) -> None:
         # Py-Mochi-Margo is not a required dependency and requires the user
@@ -94,21 +98,30 @@ class MargoConnector:
         if pymargo_import_error is not None:  # pragma: no cover
             raise pymargo_import_error
 
-        self.interface = interface
+        self._address = address
+        self._interface = interface
         self.port = port
         self.protocol = (
             protocol if isinstance(protocol, str) else protocol.value
         )
-        self.timeout = timeout
 
-        self.host = get_ip_address(interface)
-        self.addr = f'{self.protocol}://{self.host}:{port}'
+        self.timeout = timeout
 
         self.engine = Engine(
             self.protocol,
             mode=pymargo.client,
             use_progress_thread=True,
         )
+
+        if self._address is not None:
+            self.address = self._address
+        elif self._interface is not None:
+            self.address = get_ip_address(self._interface)
+        else:
+            eng_url = str(self.engine.addr())
+            self.address = eng_url.split(':')[1].split('/')[2]
+
+        self.url = f'{self.protocol}://{self.address}:{self.port}'
 
         self._rpcs = {
             'evict': self.engine.register('evict'),
@@ -120,24 +133,29 @@ class MargoConnector:
         self.server: multiprocessing.context.SpawnProcess | None
         try:
             logger.info(
-                f'Connecting to local server (address={self.addr})...',
+                f'Connecting to local server (address={self.url})...',
             )
-            wait_for_server(self.protocol, self.host, self.port, self.timeout)
+            wait_for_server(
+                self.protocol,
+                self.address,
+                self.port,
+                self.timeout,
+            )
             logger.info(
-                f'Connected to local server (address={self.addr})',
+                f'Connected to local server (address={self.url})',
             )
         except ServerTimeoutError:
             logger.info(
                 'Failed to connect to local server '
-                f'(address={self.addr}, timeout={self.timeout})',
+                f'(address={self.url}, timeout={self.timeout})',
             )
             self.server = spawn_server(
                 self.protocol,
-                self.host,
+                self.address,
                 self.port,
                 spawn_timeout=self.timeout,
             )
-            logger.info(f'Spawned local server (address={self.addr})')
+            logger.info(f'Spawned local server (address={self.url})')
         else:
             self.server = None
 
@@ -167,12 +185,12 @@ class MargoConnector:
         responses = []
 
         for rpc in rpcs:
-            addr = f'{self.protocol}://{rpc.key.peer_host}:{rpc.key.peer_port}'
-            server_addr = self.engine.lookup(addr)
+            url = f'{self.protocol}://{rpc.key.peer_host}:{rpc.key.peer_port}'
+            server_url = self.engine.lookup(url)
             logger.debug(
                 f'Sent {rpc.operation.upper()} RPC (key={rpc.key})',
             )
-            result = self._rpcs[rpc.operation].on(server_addr)(
+            result = self._rpcs[rpc.operation].on(server_url)(
                 rpc.data,
                 rpc.key.size,
                 rpc.key,
@@ -204,7 +222,7 @@ class MargoConnector:
                 no-op.
         """
         if kill_server and self.server is not None:
-            self.engine.lookup(self.addr).shutdown()
+            self.engine.lookup(self.url).shutdown()
             self.server.join()
             logger.info(
                 'Terminated local server on connector close '
@@ -221,7 +239,8 @@ class MargoConnector:
         the connector object.
         """
         return {
-            'interface': self.interface,
+            'address': self._address,
+            'interface': self._interface,
             'port': self.port,
             'protocol': self.protocol,
             'timeout': self.timeout,
@@ -318,7 +337,7 @@ class MargoConnector:
             dim_type='margo',
             obj_id=str(uuid.uuid4()),
             size=len(obj),
-            peer_host=self.host,
+            peer_host=self.address,
             peer_port=self.port,
         )
         blk = self.engine.create_bulk(obj, bulk.read_only)
@@ -342,7 +361,7 @@ class MargoConnector:
                 dim_type='margo',
                 obj_id=str(uuid.uuid4()),
                 size=len(obj),
-                peer_host=self.host,
+                peer_host=self.address,
                 peer_port=self.port,
             )
             for obj in objs
@@ -471,14 +490,14 @@ def _when_finalize() -> None:
     logger.info(f'Margo server finalized (pid={os.getpid()})')
 
 
-def start_server(address: str) -> None:
+def start_server(url: str) -> None:
     """Start and wait on a Margo server.
 
     Args:
-        address: Address of the engine that will be started. Should take
+        url: URL of the engine that will be started. Should take
             the form `{protocol}://{host}:{port}`.
     """
-    server_engine = Engine(address)
+    server_engine = Engine(url)
     server_engine.on_finalize(_when_finalize)
     server_engine.enable_remote_shutdown()
 
@@ -492,7 +511,7 @@ def start_server(address: str) -> None:
 
 def spawn_server(
     protocol: str,
-    host: str,
+    address: str,
     port: int,
     *,
     spawn_timeout: float = 5.0,
@@ -506,7 +525,7 @@ def spawn_server(
 
     Args:
         protocol: Communication protocol.
-        host: Host of the server to wait on.
+        address: Host IP of the server to wait on.
         port: Port of the server to wait on.
         spawn_timeout: Max time in seconds to wait for the server to start.
         kill_timeout: Max time in seconds to wait for the server to shutdown
@@ -515,12 +534,12 @@ def spawn_server(
     Returns:
         The process that the server is running in.
     """
-    address = f'{protocol}://{host}:{port}'
+    url = f'{protocol}://{address}:{port}'
 
     ctx = multiprocessing.get_context('spawn')
     server_process = ctx.Process(
         target=start_server,
-        args=(address,),
+        args=(url,),
     )
     server_process.start()
 
@@ -538,9 +557,9 @@ def spawn_server(
     atexit.register(_kill_on_exit)
     logger.debug('Registered server cleanup atexit callback')
 
-    wait_for_server(protocol, host, port, timeout=spawn_timeout)
+    wait_for_server(protocol, address, port, timeout=spawn_timeout)
     logger.debug(
-        f'Server started (address={address}, pid={server_process.pid})',
+        f'Server started (address={url}, pid={server_process.pid})',
     )
 
     return server_process
@@ -548,7 +567,7 @@ def spawn_server(
 
 def wait_for_server(
     protocol: str,
-    host: str,
+    address: str,
     port: int,
     timeout: float = 0.1,
 ) -> None:
@@ -559,7 +578,7 @@ def wait_for_server(
 
     Args:
         protocol: Communication protocol.
-        host: Host of the server to wait on.
+        address: Host IP of the server to wait on.
         port: Port of the server to wait on.
         timeout: The max time in seconds to wait for server response.
 
@@ -572,18 +591,18 @@ def wait_for_server(
         'margo',
         obj_id='ping',
         size=0,
-        peer_host=host,
+        peer_host=address,
         peer_port=port,
     )
     rpc = RPC('exists', key=key)
-    address = f'{protocol}://{host}:{port}'
+    url = f'{protocol}://{address}:{port}'
 
     sleep_time = 0.01
     start = time.time()
     while time.time() - start < timeout:
         try:
-            local_address = engine.lookup(address)
-            result = remote_function.on(local_address)(
+            local_url = engine.lookup(url)
+            result = remote_function.on(local_url)(
                 rpc.data,
                 rpc.key.size,
                 rpc.key,

--- a/proxystore/connectors/dim/utils.py
+++ b/proxystore/connectors/dim/utils.py
@@ -16,21 +16,13 @@ def get_ip_address(ifname: str) -> str:
         The IP address.
     """
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    try:
-        return socket.inet_ntoa(
-            fcntl.ioctl(
-                s.fileno(),
-                0x8915,
-                struct.pack(
-                    '256s',
-                    bytes(ifname[:15], 'utf-8'),
-                ),  # SIOCGIFADDR
-            )[20:24],
-        )
-    except OSError:
-        # Not a solution, but the above doesn't work with Macs
-        # need to provide IP rather than the interface name for the time being
-
-        if ifname == 'localhost':  # pragma: no cover
-            ifname = '127.0.0.1'
-        return ifname
+    return socket.inet_ntoa(
+        fcntl.ioctl(
+            s.fileno(),
+            0x8915,
+            struct.pack(
+                '256s',
+                bytes(ifname[:15], 'utf-8'),
+            ),  # SIOCGIFADDR
+        )[20:24],
+    )

--- a/proxystore/connectors/dim/utils.py
+++ b/proxystore/connectors/dim/utils.py
@@ -6,8 +6,11 @@ import socket
 import struct
 
 
-def get_ip_address(ifname: str) -> str:
+def get_ip_address(ifname: str) -> str:  # pragma: darwin no cover
     """Get ip address provided an interface name.
+
+    Warning:
+        This function does not work on MacOS/Darwin.
 
     Args:
         ifname: The interface name.

--- a/proxystore/connectors/dim/zmq.py
+++ b/proxystore/connectors/dim/zmq.py
@@ -90,7 +90,7 @@ class ZeroMQConnector:
 
         if self._address is not None:
             self.address = self._address
-        elif self._interface is not None:
+        elif self._interface is not None:  # pragma: darwin no cover
             self.address = get_ip_address(self._interface)
         else:
             host = socket.gethostname()

--- a/testing/connectors.py
+++ b/testing/connectors.py
@@ -151,7 +151,7 @@ def redis_connector() -> Generator[Connector[Any], None, None]:
 @pytest.fixture(scope='session')
 def margo_connector() -> Generator[Connector[Any], None, None]:
     """MargoConnector fixture."""
-    host = '127.0.0.1'
+    # host = '127.0.0.1'
     port = open_port()
     protocol = margo.Protocol.OFI_TCP
 
@@ -168,7 +168,7 @@ def margo_connector() -> Generator[Connector[Any], None, None]:
     with ctx():
         connector = margo.MargoConnector(
             protocol=protocol,
-            interface=host,
+            # interface=host,
             port=port,
             timeout=timeout,
         )

--- a/testing/connectors.py
+++ b/testing/connectors.py
@@ -151,7 +151,6 @@ def redis_connector() -> Generator[Connector[Any], None, None]:
 @pytest.fixture(scope='session')
 def margo_connector() -> Generator[Connector[Any], None, None]:
     """MargoConnector fixture."""
-    # host = '127.0.0.1'
     port = open_port()
     protocol = margo.Protocol.OFI_TCP
 
@@ -168,7 +167,6 @@ def margo_connector() -> Generator[Connector[Any], None, None]:
     with ctx():
         connector = margo.MargoConnector(
             protocol=protocol,
-            # interface=host,
             port=port,
             timeout=timeout,
         )
@@ -182,7 +180,6 @@ def margo_connector() -> Generator[Connector[Any], None, None]:
 @pytest.fixture(scope='session')
 def ucx_connector() -> Generator[Connector[Any], None, None]:
     """UCXConnector fixture."""
-    interface = '127.0.0.1'
     port = open_port()
 
     ucp_spec = importlib.util.find_spec('ucp')
@@ -192,7 +189,7 @@ def ucx_connector() -> Generator[Connector[Any], None, None]:
         ctx = mock_multiprocessing
 
     with ctx():
-        connector = ucx.UCXConnector(interface=interface, port=port)
+        connector = ucx.UCXConnector(port=port)
 
     yield connector
 

--- a/testing/connectors.py
+++ b/testing/connectors.py
@@ -205,7 +205,6 @@ def ucx_connector() -> Generator[Connector[Any], None, None]:
 @pytest.fixture(scope='session')
 def zmq_connector() -> Generator[Connector[Any], None, None]:
     """ZeroMQ store fixture."""
-    interface = '127.0.0.1'
     port = open_port()
 
     if platform.system() == 'Darwin':  # pragma: no cover
@@ -215,7 +214,6 @@ def zmq_connector() -> Generator[Connector[Any], None, None]:
         timeout = 0.5
 
     with zmq.ZeroMQConnector(
-        interface=interface,
         port=port,
         timeout=timeout,
     ) as connector:

--- a/testing/mocked/pymargo.py
+++ b/testing/mocked/pymargo.py
@@ -25,12 +25,15 @@ class MargoException(Exception):  # pragma: no cover  # noqa: N818
 class Address:  # pragma: no cover
     """Mock Address implementation."""
 
-    def __init__(self):
-        return
+    def __init__(self, url):
+        self.addr = url
 
     def shutdown(self) -> None:
         """Mock shutdown."""
         pass
+
+    def __str__(self) -> str:
+        return self.addr
 
 
 class Engine:
@@ -42,7 +45,14 @@ class Engine:
         mode: str = server,
         use_progress_thread: bool = False,
     ) -> None:
-        self.addr = Address()
+        if url is None or '://' not in url:
+            self.address = Address('tcp://127.0.0.1:1234')
+        else:
+            self.address = Address(url)
+
+    def addr(self) -> Address:
+        """Mock Engine addr implementation."""
+        return self.address
 
     def on_finalize(self, func: Any) -> None:
         """Mock engine on_finalize."""
@@ -62,7 +72,7 @@ class Engine:
 
     def lookup(self, addr: str) -> Address:
         """Mock lookup implementation."""
-        return self.addr
+        return self.address
 
     def finalize(self) -> None:
         """Mock finalize."""

--- a/testing/mocked/ucx.py
+++ b/testing/mocked/ucx.py
@@ -123,3 +123,8 @@ def create_listener(handler: Any, port: int) -> Any:  # pragma: no cover
 async def create_endpoint(host: str, port: int) -> MockEndpoint:
     """Create endpoint mock implementation."""
     return MockEndpoint()
+
+
+def get_address(ifname: str | None = None) -> str:
+    """Mock get_address implementation."""
+    return '127.0.0.1'

--- a/tests/connectors/dim/margo_test.py
+++ b/tests/connectors/dim/margo_test.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 from typing import Any
 from unittest import mock
 
@@ -9,6 +10,7 @@ import pytest
 
 from proxystore.connectors.dim.exceptions import ServerTimeoutError
 from proxystore.connectors.dim.margo import _when_finalize
+from proxystore.connectors.dim.margo import Engine as MargoEngine
 from proxystore.connectors.dim.margo import MargoConnector
 from proxystore.connectors.dim.margo import MargoServer
 from proxystore.connectors.dim.margo import spawn_server
@@ -40,12 +42,17 @@ def test_connector_spawns_server() -> None:
     with mock.patch(
         'proxystore.connectors.dim.margo.wait_for_server',
         side_effect=ServerTimeoutError,
-    ), mock.patch(
-        'proxystore.connectors.dim.margo.Engine',
+    ), mock.patch.object(
+        MargoEngine,
+        'lookup',
+    ), mock.patch.object(
+        MargoEngine,
+        'addr',
+        return_value='tcp://127.0.0.1:0',
     ), mock.patch(
         'proxystore.connectors.dim.margo.spawn_server',
     ) as mock_spawn_server:
-        with MargoConnector(protocol='tcp', interface='127.0.0.1', port=0):
+        with MargoConnector(protocol='tcp', port=0):
             pass
         mock_spawn_server.assert_called_once()
 
@@ -59,13 +66,13 @@ def test_multiple_connectors() -> None:  # pragma: no cover
     # C1 creates the server
     c1 = MargoConnector(
         protocol='tcp',
-        interface='127.0.0.1',
+        # interface='127.0.0.1',
         port=port,
         timeout=TIMEOUT,
     )
     c2 = MargoConnector(
         protocol='tcp',
-        interface='127.0.0.1',
+        # interface='127.0.0.1',
         port=port,
         timeout=TIMEOUT,
     )
@@ -102,10 +109,14 @@ def test_handle_server_error_responses() -> None:
     # to an existing server
     with mock.patch(
         'proxystore.connectors.dim.margo.wait_for_server',
-    ), mock.patch('proxystore.connectors.dim.margo.Engine'):
+    ), mock.patch.object(MargoEngine, 'lookup'), mock.patch.object(
+        MargoEngine,
+        'addr',
+        return_value='tcp://127.0.0.1:0',
+    ):
         connector = MargoConnector(
             protocol='tcp',
-            interface='127.0.0.1',
+            # interface='127.0.0.1',
             port=0,
         )
 
@@ -198,3 +209,19 @@ def test_mocked_spawn_server() -> None:
 def test_wait_for_server_raises_error() -> None:
     with pytest.raises(ServerTimeoutError):
         wait_for_server('tcp', '127.0.0.1', 0, timeout=0)
+
+
+def test_provide_interface() -> None:
+    with MargoConnector(
+        protocol='tcp',
+        address='127.0.0.1',
+        port=1234,
+    ) as connector:
+        assert connector.url == 'tcp://127.0.0.1:1234'
+
+    with MargoConnector(
+        protocol='tcp',
+        interface='lo',
+        port=1234,
+    ) as connector:
+        assert connector.url == 'tcp://127.0.0.1:1234'

--- a/tests/connectors/dim/margo_test.py
+++ b/tests/connectors/dim/margo_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import platform
 from typing import Any
 from unittest import mock
 
@@ -204,20 +205,31 @@ def test_wait_for_server_raises_error() -> None:
         wait_for_server('tcp', '127.0.0.1', 0, timeout=0)
 
 
-def test_provide_interface() -> None:
+def test_provide_ip() -> None:
     with mock.patch(
         'proxystore.connectors.dim.margo.wait_for_server',
     ):
         with MargoConnector(
+            port=0,
             protocol='tcp',
             address='127.0.0.1',
-            port=1234,
         ) as connector:
-            assert connector.url == 'tcp://127.0.0.1:1234'
+            assert connector.url == 'tcp://127.0.0.1:0'
 
+
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason=(
+        'Resolving an IP address from an interface is not supported on MacOS'
+    ),
+)
+def test_provide_interface() -> None:  # pragma: darwin no cover
+    with mock.patch(
+        'proxystore.connectors.dim.margo.wait_for_server',
+    ):
         with MargoConnector(
+            port=0,
             protocol='tcp',
             interface='lo',
-            port=1234,
         ) as connector:
-            assert connector.url == 'tcp://127.0.0.1:1234'
+            assert connector.url == 'tcp://127.0.0.1:0'

--- a/tests/connectors/dim/ucx_test.py
+++ b/tests/connectors/dim/ucx_test.py
@@ -227,23 +227,13 @@ def test_end_to_end() -> None:  # pragma: no cover
         assert connector.get(key) == b'data'
 
 
-def test_provide_ip() -> None:
-    port = open_port()
+def test_provide_ip_or_interface() -> None:
     host = '127.0.0.1'
     with mock.patch(
         'proxystore.connectors.dim.ucx.wait_for_server',
     ):
-        with UCXConnector(
-            address=host,
-            port=port,
-            timeout=1,
-        ) as connector:
+        with UCXConnector(port=0, address=host) as connector:
             assert connector.address == host
 
-        port = open_port()
-        with UCXConnector(
-            interface='lo',
-            port=port,
-            timeout=1,
-        ) as connector:
+        with UCXConnector(port=0, interface='lo') as connector:
             assert connector.address == host

--- a/tests/connectors/dim/ucx_test.py
+++ b/tests/connectors/dim/ucx_test.py
@@ -230,17 +230,20 @@ def test_end_to_end() -> None:  # pragma: no cover
 def test_provide_ip() -> None:
     port = open_port()
     host = '127.0.0.1'
-    with UCXConnector(
-        address=host,
-        port=port,
-        timeout=1,
-    ) as connector:
-        assert connector.address == host
+    with mock.patch(
+        'proxystore.connectors.dim.ucx.wait_for_server',
+    ):
+        with UCXConnector(
+            address=host,
+            port=port,
+            timeout=1,
+        ) as connector:
+            assert connector.address == host
 
-    port = open_port()
-    with UCXConnector(
-        interface='lo',
-        port=port,
-        timeout=1,
-    ) as connector:
-        assert connector.address == host
+        port = open_port()
+        with UCXConnector(
+            interface='lo',
+            port=port,
+            timeout=1,
+        ) as connector:
+            assert connector.address == host

--- a/tests/connectors/dim/ucx_test.py
+++ b/tests/connectors/dim/ucx_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import importlib.util
 import sys
 from unittest import mock
 
@@ -46,7 +47,7 @@ async def test_connector_spawns_server() -> None:
     ), mock.patch(
         'proxystore.connectors.dim.ucx.spawn_server',
     ) as mock_spawn_server:
-        with UCXConnector('eth0', 0):
+        with UCXConnector(port=0):
             pass
         mock_spawn_server.assert_called_once()
 
@@ -66,7 +67,7 @@ def test_connector_raises_rpc_error() -> None:
         'ucp.create_endpoint',
         AsyncMock(return_value=MockEndpoint()),
     ):
-        with UCXConnector('eth0', 0) as connector:
+        with UCXConnector(port=0) as connector:
             with pytest.raises(Exception, match='test'):
                 connector._send_rpcs([RPC('get', TEST_KEY)])
 
@@ -84,7 +85,7 @@ def test_connector_close_kills_server() -> None:
             self.join_called = True
 
     with mock.patch('proxystore.connectors.dim.ucx.wait_for_server'):
-        connector = UCXConnector('eth0', 0)
+        connector = UCXConnector(port=0)
 
     connector.server = MockProcess()  # type: ignore[assignment]
     connector.close(kill_server=True)
@@ -209,18 +210,37 @@ def test_mocked_spawn_server() -> None:
     reason='Not compatible with mocked UCP module.',
 )
 def test_end_to_end() -> None:  # pragma: no cover
-    host = '127.0.0.1'
     port = open_port()
 
+    host = '127.0.0.1'
     spawn_server(host, port, spawn_timeout=1)
 
-    with UCXConnector(host, port, timeout=1) as connector:
+    with UCXConnector(port=port, timeout=1) as connector:
         # assert connector.server is not None
 
         # Check multiple connectors okay
-        connector2 = UCXConnector(host, port, timeout=1)
+        connector2 = UCXConnector(port=port, timeout=1)
         connector2.close()
         assert connector2.server is None
 
         key = connector.put(b'data')
         assert connector.get(key) == b'data'
+
+
+def test_provide_ip() -> None:
+    port = open_port()
+    host = '127.0.0.1'
+    with UCXConnector(
+        address=host,
+        port=port,
+        timeout=1,
+    ) as connector:
+        assert connector.address == host
+
+    port = open_port()
+    with UCXConnector(
+        interface='lo',
+        port=port,
+        timeout=1,
+    ) as connector:
+        assert connector.address == host

--- a/tests/connectors/dim/zmq_test.py
+++ b/tests/connectors/dim/zmq_test.py
@@ -101,21 +101,23 @@ def test_handle_server_error_responses() -> None:
 
 
 def test_provide_ip() -> None:
-    port = open_port()
     host = '127.0.0.1'
     with mock.patch(
         'proxystore.connectors.dim.zmq.wait_for_server',
     ):
-        with ZeroMQConnector(
-            port=port,
-            address=host,
-            timeout=TIMEOUT,
-        ) as connector:
+        with ZeroMQConnector(port=0, address=host) as connector:
             assert connector.address == host
 
-        with ZeroMQConnector(
-            port=port,
-            interface='lo',
-            timeout=TIMEOUT,
-        ) as connector:
-            assert connector.address == host
+
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason=(
+        'Resolving an IP address from an interface is not supported on MacOS'
+    ),
+)
+def test_provide_interface() -> None:  # pragma: darwin no cover
+    with mock.patch(
+        'proxystore.connectors.dim.zmq.wait_for_server',
+    ):
+        with ZeroMQConnector(port=0, interface='lo') as connector:
+            assert connector.address == '127.0.0.1'

--- a/tests/connectors/dim/zmq_test.py
+++ b/tests/connectors/dim/zmq_test.py
@@ -40,7 +40,6 @@ def test_wait_for_server() -> None:
 def test_large_message_sizes() -> None:
     chunk_length = 1000
     with ZeroMQConnector(
-        '127.0.0.1',
         open_port(),
         chunk_length=1000,
         timeout=TIMEOUT,
@@ -54,8 +53,8 @@ def test_large_message_sizes() -> None:
 def test_multiple_connectors() -> None:
     port = open_port()
     # C1 creates the server
-    c1 = ZeroMQConnector('127.0.0.1', port, timeout=TIMEOUT)
-    c2 = ZeroMQConnector('127.0.0.1', port, timeout=TIMEOUT)
+    c1 = ZeroMQConnector(port, timeout=TIMEOUT)
+    c2 = ZeroMQConnector(port, timeout=TIMEOUT)
 
     key = c1.put(b'data')
     assert c2.get(key) == b'data'
@@ -88,7 +87,7 @@ def test_handle_server_error_responses() -> None:
 
     port = open_port()
     with mock.patch('proxystore.connectors.dim.zmq.wait_for_server'):
-        with ZeroMQConnector('127.0.0.1', port, timeout=TIMEOUT) as connector:
+        with ZeroMQConnector(port, timeout=TIMEOUT) as connector:
             with mock.patch.object(
                 connector.socket,
                 'send_multipart',
@@ -99,3 +98,21 @@ def test_handle_server_error_responses() -> None:
             ):
                 with pytest.raises(RuntimeError, match='xyz'):
                     connector._send_rpcs([rpc])
+
+
+def test_provide_ip() -> None:
+    port = open_port()
+    host = '127.0.0.1'
+    with ZeroMQConnector(
+        port=port,
+        address=host,
+        timeout=TIMEOUT,
+    ) as connector:
+        assert connector.address == host
+
+    with ZeroMQConnector(
+        port=port,
+        interface='lo',
+        timeout=TIMEOUT,
+    ) as connector:
+        assert connector.address == host

--- a/tests/connectors/dim/zmq_test.py
+++ b/tests/connectors/dim/zmq_test.py
@@ -103,16 +103,19 @@ def test_handle_server_error_responses() -> None:
 def test_provide_ip() -> None:
     port = open_port()
     host = '127.0.0.1'
-    with ZeroMQConnector(
-        port=port,
-        address=host,
-        timeout=TIMEOUT,
-    ) as connector:
-        assert connector.address == host
+    with mock.patch(
+        'proxystore.connectors.dim.zmq.wait_for_server',
+    ):
+        with ZeroMQConnector(
+            port=port,
+            address=host,
+            timeout=TIMEOUT,
+        ) as connector:
+            assert connector.address == host
 
-    with ZeroMQConnector(
-        port=port,
-        interface='lo',
-        timeout=TIMEOUT,
-    ) as connector:
-        assert connector.address == host
+        with ZeroMQConnector(
+            port=port,
+            interface='lo',
+            timeout=TIMEOUT,
+        ) as connector:
+            assert connector.address == host


### PR DESCRIPTION
# Description
Used respective UCX and Margo methods for obtaining the network IP directly without needing an interface or IP address
to be provided. ZMQ, by default, now obtains the IP from the hostname.


### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #148 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [X] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->


## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [X] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [X] Tests have been added to show the fix is effective or that the new feature works.
- [X] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
