### PR TITLE
Add a spawn Margo server shortcut

### DIFF
--- a/testing/connectors.py
+++ b/testing/connectors.py
@@ -169,6 +169,7 @@ def margo_connector() -> Generator[Connector[Any], None, None]:
             protocol=protocol,
             port=port,
             timeout=timeout,
+            force_spawn_server=True,
         )
 
     yield connector

--- a/tests/connectors/dim/margo_test.py
+++ b/tests/connectors/dim/margo_test.py
@@ -66,6 +66,7 @@ def test_multiple_connectors() -> None:  # pragma: no cover
         protocol='tcp',
         port=port,
         timeout=TIMEOUT,
+        force_spawn_server=True,
     )
     c2 = MargoConnector(
         protocol='tcp',


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

By default, the `MargoConnector` will attempt an RPC to the address it expects a server to be listening on. This "ping" is used by the `MargoConnector` to determine if a new server needs to be spawned.

However, Margo is very slow to raise an error when you attempt to make an RPC to an address without a server. This can take as much as 90 seconds and causes the test suite to be very slow.

This commit adds a `force_spawn_server` parameter to the `MargoConnector` which is False by default (preserving the old behavior). If True, the `MargoConnector` will not attempt the "ping" of a server and will instead immediately spawn a server. This flag is useful when the caller knows they intend to spawn a server such as in the test suite where we intentionally spawn a couple servers in the integrations tests.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #295

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

The integration tests previously took 5-7 minutes but now take 2-3 minutes.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
