### PR TITLE
Avoid proxying singleton types (`True`, `False`, `None`)

### DIFF
--- a/proxystore/proxy.py
+++ b/proxystore/proxy.py
@@ -82,6 +82,20 @@ class Proxy(slots.Proxy, Generic[T]):
         will be called again to resolve the object.
 
     Warning:
+        A proxy of a singleton type (e.g., `True`, `False`, and `None`) will
+        not behave exactly as a singleton type would. This is because the
+        proxy itself is not a singleton.
+
+        ```python
+        >>> from proxystore.proxy import Proxy
+        >>> p = Proxy(lambda: True)
+        >>> p == True
+        True
+        >>> p is True
+        False
+        ```
+
+    Warning:
         Python bindings to other languages (e.g., C, C++) may throw type
         errors when receiving a [`Proxy`][proxystore.proxy.Proxy] instance.
         Casting the proxy or extracting the target object may be needed.

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -44,6 +44,8 @@ SerializerT = Callable[[Any], bytes]
 DeserializerT = Callable[[bytes], Any]
 """Deserializer type alias."""
 
+_MISSING_OBJECT = object()
+
 
 class StoreFactory(Generic[ConnectorT, T]):
     """Factory that resolves an object from a store.
@@ -132,9 +134,13 @@ class StoreFactory(Generic[ConnectorT, T]):
         """
         with Timer() as timer:
             store = self.get_store()
-            obj = store.get(self.key, deserializer=self.deserializer)
+            obj = store.get(
+                self.key,
+                deserializer=self.deserializer,
+                default=_MISSING_OBJECT,
+            )
 
-            if obj is None:
+            if obj is _MISSING_OBJECT:
                 raise ProxyResolveMissingKeyError(
                     self.key,
                     type(store),

--- a/proxystore/store/exceptions.py
+++ b/proxystore/store/exceptions.py
@@ -49,3 +49,7 @@ class ProxyResolveMissingKeyError(Exception):
             f"from {self.store_type.__name__}(name='{self.store_name}'): "
             'store returned NoneType with key.',
         )
+
+
+class NonProxiableTypeError(Exception):
+    """Exception raised when proxying an unproxiable type."""

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -134,6 +134,18 @@ def test_store_proxy(store_implementation: StoreFixtureType) -> None:
     unregister_store(store_info.name)
 
 
+def test_store_proxy_none_type(store_implementation: StoreFixtureType) -> None:
+    store, store_info = store_implementation
+
+    register_store(store)
+
+    p: Proxy[None] = store.proxy(None)
+    assert isinstance(p, Proxy)
+    assert isinstance(p, type(None))
+
+    unregister_store(store_info)
+
+
 def test_proxy_recreates_store(store_implementation: StoreFixtureType) -> None:
     """Test Proxy Recreates Store."""
     store, store_info = store_implementation


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Proxies of built-in constants/singletons do not behave exactly as the singletons themselves. E.g., `(Proxy(None) is None) is False`. To avoid users unknowingly seeing strange behavior with these singleton proxies, this PR changes the default behavior of `Store.proxy()`, `Store.proxy_batch()`, and `Store.locked_proxy()` to raise a `NonProxiableTypeError`. Currently, this error is only raised for `True`, `False`, and `None` because these are the only relevant built-in constants in Python (https://docs.python.org/3/library/constants.html).

If users want to proxy objects that may potentially be a built-in constant without having to catch the exception, the `skip_nonproxiable=True` flag will silently return the object without proxying it. I considered having this be the default in #311, but decided against this to maintain the default semantics that `Store.proxy()` and related methods return an instance of a `Proxy`.

In the case a user really wants to create a proxy of a built-constant, the following method still works.
```python
with Store(...) as store:
    key = store.put(None)
    proxy = store.proxy_from_key(key)
    assert proxy == None  # Works
    assert proxy is None  # Does not work
```

See the example below to see the change to type annotations inferred by MyPy.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #311

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

New unit tests have been added to verify the semantics of the changes. Additionally, this small code snippet was used with MyPy to check type resolution.

```python
from proxystore.connectors.local import LocalConnector
from proxystore.store import Store

with Store('test', LocalConnector()) as store:
    # Store.proxy()
    p1 = store.proxy('string', skip_nonproxiable=True)
    reveal_type(p1)  # Proxy[str]

    p2 = store.proxy(None, skip_nonproxiable=True)
    reveal_type(p2)  # None

    p3 = store.proxy(True, skip_nonproxiable=True)
    reveal_type(p3)  # bool

    p4 = store.proxy('string', skip_nonproxiable=False)
    reveal_type(p4)  # Proxy[str]

    p5 = store.proxy(None, skip_nonproxiable=False)
    reveal_type(p5)  # Proxy[None] (but raises error at runtime)

    p6 = store.proxy(True, skip_nonproxiable=False)
    reveal_type(p6)  # Proxy[bool] (but raises error at runtime)

    # Store.proxy_batch()
    p7 = store.proxy_batch(['a', 'b', 'c'], skip_nonproxiable=True)
    reveal_type(p7)  # List[Proxy[str]]

    p8 = store.proxy_batch([True, False], skip_nonproxiable=True)
    reveal_type(p8)  # List[bool]

    p9 = store.proxy_batch([True, None], skip_nonproxiable=True)
    reveal_type(p9)  # List[Proxy[bool, None]] (mixed type lists get caught by general case)

    p10 = store.proxy_batch([True, False], skip_nonproxiable=False)
    reveal_type(p10)  # List[Proxy[bool]] (but raises error at runtime)

    # Store.locked_proxy()
    p11 = store.locked_proxy('string', skip_nonproxiable=True)
    reveal_type(p11)  # ProxyLocker[str]

    p12 = store.locked_proxy(None, skip_nonproxiable=True)
    reveal_type(p12)  # None

    p13 = store.locked_proxy(True, skip_nonproxiable=True)
    reveal_type(p13)  # bool

    p14 = store.locked_proxy('string', skip_nonproxiable=False)
    reveal_type(p14)  # ProxyLocker[str]

    p15 = store.locked_proxy(None, skip_nonproxiable=False)
    reveal_type(p15)  # ProxyLocker[None] (but raises error at runtime)

    p16 = store.locked_proxy(True, skip_nonproxiable=False)
    reveal_type(p16)  # ProxyLocker[bool] (but raises error at runtime)
```

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
