### PR TITLE
Add `clear` flag to `Connector` implementations that support it

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -282,15 +282,21 @@ class Store(Generic[ConnectorT]):
             else proxystore.serialize.deserialize
         )
 
-    def close(self) -> None:
+    def close(self, *args: Any, **kwargs: Any) -> None:
         """Close the connector associated with the store.
 
         Warning:
             This method should only be called at the end of the program
             when the store will no longer be used, for example once all
             proxies have been resolved.
+
+        Args:
+            args: Positional arguments to pass to
+                [`Connector.close()`][proxystore.connectors.connector.Connector.close].
+            kwargs: Keyword arguments to pass to
+                [`Connector.close()`][proxystore.connectors.connector.Connector.close].
         """
-        self.connector.close()
+        self.connector.close(*args, **kwargs)
 
     def config(self) -> dict[str, Any]:
         """Get the store configuration.

--- a/testing/mocked/redis.py
+++ b/testing/mocked/redis.py
@@ -10,6 +10,10 @@ class MockStrictRedis:
     def __init__(self, data: dict[str, Any], *args, **kwargs):
         self.data = data
 
+    def close(self) -> None:
+        """Close the client."""
+        pass
+
     def delete(self, key: str) -> None:
         """Delete key."""
         if key in self.data:
@@ -18,6 +22,10 @@ class MockStrictRedis:
     def exists(self, key: str) -> bool:
         """Check if key exists."""
         return key in self.data
+
+    def flushdb(self) -> None:
+        """Remove all keys."""
+        self.data.clear()
 
     def get(self, key: str) -> bytes | None:
         """Get value with key."""

--- a/tests/connectors/file_test.py
+++ b/tests/connectors/file_test.py
@@ -1,4 +1,3 @@
-"""FileConnector Unit Tests."""
 from __future__ import annotations
 
 import os
@@ -8,19 +7,33 @@ import tempfile
 from proxystore.connectors.file import FileConnector
 
 
-def test_file_conenctor_close(tmp_path: pathlib.Path) -> None:
-    """Test FileConnector Cleanup."""
+def test_close_clears_by_default(tmp_path: pathlib.Path) -> None:
     connector = FileConnector(store_dir=str(tmp_path))
 
     assert os.path.exists(tmp_path)
-
     connector.close()
-
     assert not os.path.exists(tmp_path)
 
 
-def test_cwd_change(tmp_path: pathlib.Path) -> None:
-    """Checks FileConnector still resolve when the CWD changes."""
+def test_close_override_default(tmp_path: pathlib.Path) -> None:
+    connector = FileConnector(store_dir=str(tmp_path), clear=True)
+
+    assert os.path.exists(tmp_path)
+    connector.close(clear=False)
+    assert os.path.exists(tmp_path)
+
+
+def test_multiple_closed_connectors(tmp_path: pathlib.Path) -> None:
+    connector1 = FileConnector(store_dir=str(tmp_path))
+    connector2 = FileConnector(store_dir=str(tmp_path))
+
+    assert os.path.exists(tmp_path)
+    connector1.close(clear=True)
+    connector2.close(clear=True)
+    assert not os.path.exists(tmp_path)
+
+
+def test_paths_work_after_cwd_change(tmp_path: pathlib.Path) -> None:
     current = os.getcwd()
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/connectors/redis_test.py
+++ b/tests/connectors/redis_test.py
@@ -1,11 +1,36 @@
-"""RedisConnector Unit Tests."""
 from __future__ import annotations
 
+from proxystore.connectors.redis import RedisConnector
 
-def test_nothing() -> None:
-    """Test RedisConnector.
 
-    All RedisConnector functionality should be covered in
-    tests/connectors/connectors_test.py.
-    """
-    pass
+# Use redis_connector because it mocks StrictRedis client to act
+# like there is a single shared Redis server.
+def test_close_persists_keys_by_default(redis_connector) -> None:
+    connector = RedisConnector('localhost', 0)
+    key = connector.put(b'value')
+
+    assert connector.exists(key)
+    connector.close()
+    # This only works with the mocked connector because otherwise
+    # the connection pool used by Redis would have been closed
+    assert connector.exists(key)
+
+
+def test_close_override_default(redis_connector) -> None:
+    connector = RedisConnector('localhost', 0, clear=False)
+    key = connector.put(b'value')
+
+    assert connector.exists(key)
+    connector.close(clear=True)
+    assert not connector.exists(key)
+
+
+def test_multiple_closed_connectors(redis_connector) -> None:
+    connector1 = RedisConnector('localhost', 0)
+    connector2 = RedisConnector('localhost', 0)
+    key = connector1.put(b'value')
+
+    assert connector1.exists(key)
+    connector1.close(clear=True)
+    connector2.close(clear=True)
+    assert not connector2.exists(key)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds a `clear` flag to the `FileConnector`, `GlobusConnector`, and `RedisConnector`. The default semantics remain the same as they were previously (`FileConnector` and `GlobusConnector` clear their respective file system directories, and `RedisConnector` does not remove anything). The `clear` flag can be set when instantiating a connector, and override when `.close()` is called.

`Store.close()` now accepts `*args, **kwargs` which will be forwarded to the connector.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #313

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests to verify functionality.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
