### PR TITLE
Adding lock to register store factory

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
-import threading
 from types import TracebackType
 from typing import Any
 from typing import Callable


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
Added a lock in the store base class to prevent a race condition as multiple threads try to register a store.


### Fixes
- Fixes ##319 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
Unproxying many objects from multiple threads in [Proxy Imports](https://github.com/AK2000/lazy-imports) now works.


## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [ ] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
