### PR TITLE
Improve auto-reconnection in relay server client

### DIFF
--- a/proxystore/p2p/relay_client.py
+++ b/proxystore/p2p/relay_client.py
@@ -210,7 +210,8 @@ class RelayServerClient:
         Note:
             If an existing and open connection exists, that will be returned.
             Otherwise, a new connection will be attempted with
-            exponential backoff for connection failures.
+            exponential backoff (starting at 1 second and increasing to a max
+            of 60 seconds) for connection failures.
 
         Returns:
             WebSocket connection to the relay server.
@@ -242,7 +243,7 @@ class RelayServerClient:
                         f'{backoff_seconds} seconds',
                     )
                     await asyncio.sleep(backoff_seconds)
-                    backoff_seconds *= 2
+                    backoff_seconds = min(backoff_seconds * 2, 60)
                 else:
                     # Coverage doesn't detect the singular break but it does
                     # get executed to break from the loop

--- a/tests/p2p/relay_cli_test.py
+++ b/tests/p2p/relay_cli_test.py
@@ -75,7 +75,7 @@ def _serve(host: str, port: int) -> None:
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio()
 async def test_server_without_ssl() -> None:
-    host = 'localhost'
+    host = '127.0.0.1'
     port = open_port()
     address = f'ws://{host}:{port}'
 
@@ -104,11 +104,13 @@ async def test_server_without_ssl() -> None:
 
     process.join()
 
+    await client.close()
+
 
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio()
 async def test_start_server_cli() -> None:
-    host = 'localhost'
+    host = '127.0.0.1'
     port = str(open_port())
     address = f'ws://{host}:{port}'
 
@@ -135,3 +137,5 @@ async def test_start_server_cli() -> None:
 
     with pytest.raises(websockets.exceptions.ConnectionClosedOK):
         await websocket.recv()
+
+    await client.close()

--- a/tests/p2p/relay_test.py
+++ b/tests/p2p/relay_test.py
@@ -20,24 +20,24 @@ _WAIT_FOR = 0.2
 
 @pytest.mark.asyncio()
 async def test_connect_twice(relay_server) -> None:
-    client = RelayServerClient(relay_server.address)
-    websocket = await client.connect()
-    pong_waiter = await websocket.ping()
-    await asyncio.wait_for(pong_waiter, _WAIT_FOR)
-    await websocket.send(
-        messages.encode(
-            messages.ServerRegistration(
-                name='different-host',
-                uuid=client.uuid,
+    async with RelayServerClient(relay_server.address) as client:
+        websocket = await client.connect()
+        pong_waiter = await websocket.ping()
+        await asyncio.wait_for(pong_waiter, _WAIT_FOR)
+        await websocket.send(
+            messages.encode(
+                messages.ServerRegistration(
+                    name='different-host',
+                    uuid=client.uuid,
+                ),
             ),
-        ),
-    )
-    message_ = await asyncio.wait_for(websocket.recv(), _WAIT_FOR)
-    assert isinstance(message_, str)
-    message = messages.decode(message_)
-    assert isinstance(message, messages.ServerResponse)
-    assert message.success
-    assert not message.error
+        )
+        message_ = await asyncio.wait_for(websocket.recv(), _WAIT_FOR)
+        assert isinstance(message_, str)
+        message = messages.decode(message_)
+        assert isinstance(message, messages.ServerResponse)
+        assert message.success
+        assert not message.error
 
 
 @pytest.mark.asyncio()
@@ -59,10 +59,13 @@ async def test_connect_reconnect_new_socket(relay_server) -> None:
     pong_waiter = await websocket2.ping()
     await asyncio.wait_for(pong_waiter, _WAIT_FOR)
 
+    await client1.close()
+    await client2.close()
+
 
 @pytest.mark.asyncio()
 async def test_expected_client_disconnect(relay_server) -> None:
-    client = RelayServerClient(relay_server.address)
+    client = RelayServerClient(relay_server.address, reconnect_task=False)
     websocket = await client.connect()
     server_client = relay_server.relay_server._uuid_to_client[client.uuid]
     assert (
@@ -81,10 +84,12 @@ async def test_expected_client_disconnect(relay_server) -> None:
         not in relay_server.relay_server._websocket_to_client.values()
     )
 
+    await client.close()
+
 
 @pytest.mark.asyncio()
 async def test_unexpected_client_disconnect(relay_server) -> None:
-    client = RelayServerClient(relay_server.address)
+    client = RelayServerClient(relay_server.address, reconnect_task=False)
     websocket = await client.connect()
     server_client = relay_server.relay_server._uuid_to_client[client.uuid]
     assert (
@@ -103,16 +108,18 @@ async def test_unexpected_client_disconnect(relay_server) -> None:
         not in relay_server.relay_server._websocket_to_client.values()
     )
 
+    await client.close()
+
 
 @pytest.mark.asyncio()
 async def test_server_deserialization_fails_silently(relay_server) -> None:
-    client = RelayServerClient(relay_server.address)
-    websocket = await client.connect()
-    # This message should cause deserialization error on server but
-    # server should catch and wait for next message
-    await websocket.send('invalid message')
-    pong_waiter = await websocket.ping()
-    await asyncio.wait_for(pong_waiter, _WAIT_FOR)
+    async with RelayServerClient(relay_server.address) as client:
+        websocket = await client.connect()
+        # This message should cause deserialization error on server but
+        # server should catch and wait for next message
+        await websocket.send('invalid message')
+        pong_waiter = await websocket.ping()
+        await asyncio.wait_for(pong_waiter, _WAIT_FOR)
 
 
 @pytest.mark.asyncio()
@@ -186,6 +193,9 @@ async def test_p2p_message_passing(relay_server) -> None:
     message = await asyncio.wait_for(client1.recv(), 1)
     assert isinstance(message, messages.PeerConnection)
 
+    await client1.close()
+    await client2.close()
+
 
 @pytest.mark.asyncio()
 async def test_p2p_message_passing_unknown_peer(relay_server) -> None:
@@ -209,6 +219,8 @@ async def test_p2p_message_passing_unknown_peer(relay_server) -> None:
     assert str(peer2_uuid) in message.error
     assert 'unknown' in message.error
 
+    await client1.close()
+
 
 @pytest.mark.asyncio()
 async def test_relay_server_send_encode_error(
@@ -217,10 +229,10 @@ async def test_relay_server_send_encode_error(
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    client = RelayServerClient(relay_server.address)
-    websocket = await client.connect()
-    # Error should be logged but not raised
-    await relay_server.relay_server.send(websocket, 'abc')
+    async with RelayServerClient(relay_server.address) as client:
+        websocket = await client.connect()
+        # Error should be logged but not raised
+        await relay_server.relay_server.send(websocket, 'abc')
 
     assert any(
         [
@@ -251,6 +263,8 @@ async def test_relay_server_send_connection_closed(
             for record in caplog.records
         ],
     )
+
+    await client.close()
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

- Locked connect method which could potentially have multiple coroutines attempt a websocket connection.
- Clients now automatically reconnect in the background.
- Limit max backoff on reconnects to 60 seconds.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added/updated unit tests and tested with a local relay and endpoint.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
