### PR TITLE
Make endpoints support Globus Auth relays (#62)

### DIFF
--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -108,6 +108,12 @@ def version() -> None:
     help='Optional relay server address.',
 )
 @click.option(
+    '--relay-auth/--no-relay-auth',
+    default=True,
+    metavar='BOOL',
+    help='Disable relay server authentication.',
+)
+@click.option(
     '--peer-channels',
     default=1,
     type=int,
@@ -124,6 +130,7 @@ def configure(
     name: str,
     port: int,
     relay_server: str,
+    relay_auth: bool,
     peer_channels: int,
     persist: bool,
 ) -> None:
@@ -133,6 +140,7 @@ def configure(
             name,
             port=port,
             relay_server=relay_server,
+            relay_auth=relay_auth,
             peer_channels=peer_channels,
             persist_data=persist,
         ),

--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -101,6 +101,7 @@ def configure_endpoint(
     *,
     port: int,
     relay_server: str | None,
+    relay_auth: bool = True,
     proxystore_dir: str | None = None,
     peer_channels: int = 1,
     persist_data: bool = False,
@@ -111,6 +112,7 @@ def configure_endpoint(
         name: Name of endpoint.
         port: Port for endpoint to listen on.
         relay_server: Optional relay server address for P2P endpoint connections.
+        relay_auth: Relay server used Globus Auth.
         proxystore_dir: Optionally specify the proxystore home directory.
             Defaults to [`home_dir()`][proxystore.utils.environment.home_dir].
         peer_channels: Number of datachannels per peer connection
@@ -138,6 +140,7 @@ def configure_endpoint(
             host=None,
             port=port,
             relay_server=relay_server,
+            relay_auth='globus' if relay_auth else None,
             database_path=database_path,
             peer_channels=peer_channels,
         )

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import uuid
+from typing import Literal
 
 from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
 
@@ -25,6 +26,7 @@ class EndpointConfig:
         host: Host endpoint is running on.
         port: Port endpoint is running on.
         relay_server: Optional relay server the endpoint should register with.
+        relay_auth: Relay server authentication method.
         database_path: Optional path to SQLite database file that will be used
             for storing endpoint data. If `None`, data will only be stored
             in-memory.
@@ -45,6 +47,7 @@ class EndpointConfig:
     host: str | None
     port: int
     relay_server: str | None = None
+    relay_auth: Literal['globus'] | None = None
     database_path: str | None = None
     max_object_size: int | None = MAX_OBJECT_SIZE_DEFAULT
     peer_channels: int = 1

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -17,6 +17,7 @@ import requests
 
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.endpoint import Endpoint
+from proxystore.endpoint.serve import _get_auth_headers
 from proxystore.endpoint.serve import create_app
 from proxystore.endpoint.serve import MAX_CHUNK_LENGTH
 from proxystore.endpoint.serve import serve
@@ -386,3 +387,21 @@ def test_serve_logging(use_uvloop: bool, tmp_path: pathlib.Path) -> None:
     _serve(log_file2)
     assert os.path.isdir(tmp_dir)
     assert os.path.exists(log_file2)
+
+
+def test_get_auth_headers() -> None:
+    assert _get_auth_headers(None) == {}
+
+    mock_authorizer = mock.MagicMock()
+    header = 'Bearer <TOKEN>'
+    with mock.patch(
+        'proxystore.globus.manager.NativeAppAuthManager.get_authorizer',
+        return_value=mock_authorizer,
+    ), mock.patch(
+        'proxystore.globus.manager.get_token_storage_adapter',
+    ), mock.patch.object(
+        mock_authorizer,
+        'get_authorization_header',
+        return_value=header,
+    ):
+        assert _get_auth_headers('globus')['Authorization'] == header


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The EndpointConfig now contains a relay_auth attribute indicating the type of authentication that the relay_server uses. Currently supported methods are 'globus' or None.

The `proxystore-endpoint configure` defaults to configuring the endpoint with 'globus' as the authentication method, but this can be overrode via the --no-relay-auth flag.

Issue #62 also proposed updating the `EndpointConnector` to authenticate with the endpoint it is connected to. I've decided against this for the time being because it is assumed that an endpoint is operating within a private network (hence why we need hole-punching to connect two endpoints together). We may want to revisit this in the future.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #62 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested connecting a local endpoint to a relay without auth and a relay with Globus Auth.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
