### PR TITLE
Use TOML for endpoint and relay configuration files

### DIFF
--- a/docs/guides/endpoints-debugging.md
+++ b/docs/guides/endpoints-debugging.md
@@ -66,10 +66,10 @@ with UUID `bbbbab4d-c73a-44ee-a316-58ec8857e83a`.
 
 ### Check Relay Server Connections
 Both endpoints must be connected to the same relay server to form a peer
-connection. First, check the `relay_server` value in the endpoint config is
-correct and not `null`.
-The endpoint config is found in the `config.json` file in the endpoint
-directory (e.g., `~/.local/share/proxystore/myendpoint/config.json`).
+connection. First, check the `address` value in the `[relay]` section
+is present and set to the correct URI string.
+The endpoint config is found in the `config.toml` file in the endpoint
+directory (e.g., `~/.local/share/proxystore/myendpoint/config.toml`).
 Restart your endpoints if you had to change the configuration.
 
 Second, confirm the endpoint connects to the relay server when started by

--- a/docs/guides/relay-serving.md
+++ b/docs/guides/relay-serving.md
@@ -42,19 +42,18 @@ encryption if a valid SSL certificate is provided.
 
 Advanced serving, such as TLS encryption, requires a relay configuration file.
 
-```cfg title="relay.cfg"
-[serving]
+```toml title="relay.toml"
 port = 8700
-certfile = cert.pem
-keyfile = privkey.pem
+certfile = "cert.pem"
+keyfile = "privkey.pem"
 ```
 
-The relay can be started using the `relay.cfg` file and will be accessible
+The relay can be started using the `relay.toml` file and will be accessible
 at `wss://localhost:8700` (note the change in protocol from `ws://` to
 `wss://`).
 
 ```bash
-$ proxystore-relay --config relay.cfg
+$ proxystore-relay --config relay.toml
 ```
 
 ### Logging Behavior
@@ -67,15 +66,15 @@ options or via the configuration file.
     CLI options can be combined with a configuration file, and CLI options
     will override the values in the configuration file if both are provided.
 
-The logging configuration is set in the `[serving.logging]` section. All
+The logging configuration is set in the `[logging]` section. All
 configurations are optional with defaults defined in
 [`RelayLoggingConfig`][proxystore.p2p.relay.config.RelayLoggingConfig].
 
-```cfg title="relay.cfg"
-[serving.logging]
-log_dir = /path/to/log/dir
-default_log_level = INFO
-websockets_log_level = WARNING
+```toml title="relay.toml"
+[logging]
+log_dir = "/path/to/log/dir"
+default_log_level = "INFO"
+websockets_log_level = "WARNING"
 current_client_interval = 60
 current_client_limit = 32
 ```
@@ -175,18 +174,20 @@ to authenticate the clients.
 
 ### Update the Relay Config
 
-The `[serving.auth]` section of the relay configuration is used to enable
+The `[auth]` section of the relay configuration is used to enable
 the authentication method of the relay server. Add the following and update
 the `client_id` and `client_secret` with the client UUID and secret from the
 application registration. The `audience` parameter should also be set to the
 client UUID.
 
-```cfg title="relay.cfg"
-[serving.auth]
-method = globus
-client_id = ...
-client_secret = ...
-audience = ...
+```toml title="relay.toml"
+[auth]
+method = "globus"
+
+[auth.kwargs]
+client_id = "..."
+client_secret = "..."
+audience = "..."
 ```
 
 The relay server will use the
@@ -206,7 +207,7 @@ After updating the configuration file, the relay can be run normally.
     using Globus Auth for user authentication.
 
 ```bash
-$ proxystore-relay --config relay.cfg
+$ proxystore-relay --config relay.toml
 ```
 
 ### Connecting as a Client

--- a/proxystore/connectors/endpoint.py
+++ b/proxystore/connectors/endpoint.py
@@ -90,27 +90,28 @@ class EndpointConnector:
         )
         found_endpoint: EndpointConfig | None = None
         for endpoint in available_endpoints:
-            if endpoint.uuid in self.endpoints:
-                logger.debug(f'Attempting connection to {endpoint.uuid}')
+            endpoint_uuid = UUID(endpoint.uuid)
+            if endpoint_uuid in self.endpoints:
+                logger.debug(f'Attempting connection to {endpoint_uuid}')
                 response = self._session.get(
                     f'http://{endpoint.host}:{endpoint.port}/endpoint',
                 )
                 if response.status_code == 200:
-                    uuid = response.json()['uuid']
-                    if str(endpoint.uuid) == uuid:
+                    uuid_ = response.json()['uuid']
+                    if endpoint_uuid == UUID(uuid_):
                         logger.debug(
-                            f'Connection to {endpoint.uuid} successful, using '
+                            f'Connection to {endpoint_uuid} successful, using '
                             'as local endpoint',
                         )
                         found_endpoint = endpoint
                         break
                     else:
                         logger.debug(
-                            f'Connection to {endpoint.uuid} returned '
+                            f'Connection to {endpoint_uuid} returned '
                             'different UUID',
                         )
                 else:
-                    logger.debug(f'Connection to {endpoint.uuid} failed')
+                    logger.debug(f'Connection to {endpoint_uuid} failed')
 
         if found_endpoint is None:
             self._session.close()
@@ -118,9 +119,9 @@ class EndpointConnector:
                 'Failed to find endpoint configuration matching one of the '
                 'provided endpoint UUIDs.',
             )
-        self.endpoint_uuid = found_endpoint.uuid
-        self.endpoint_host = found_endpoint.host
-        self.endpoint_port = found_endpoint.port
+        self.endpoint_uuid: uuid.UUID = uuid.UUID(found_endpoint.uuid)
+        self.endpoint_host: str | None = found_endpoint.host
+        self.endpoint_port: int = found_endpoint.port
 
         self.address = f'http://{self.endpoint_host}:{self.endpoint_port}'
 

--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -109,7 +109,7 @@ def version() -> None:
 )
 @click.option(
     '--relay-auth/--no-relay-auth',
-    default=True,
+    default=False,
     metavar='BOOL',
     help='Disable relay server authentication.',
 )

--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -23,6 +23,9 @@ import psutil
 from proxystore import utils
 from proxystore.endpoint.config import ENDPOINT_DATABASE_FILE
 from proxystore.endpoint.config import EndpointConfig
+from proxystore.endpoint.config import EndpointRelayAuthConfig
+from proxystore.endpoint.config import EndpointRelayConfig
+from proxystore.endpoint.config import EndpointStorageConfig
 from proxystore.endpoint.config import get_configs
 from proxystore.endpoint.config import get_log_filepath
 from proxystore.endpoint.config import get_pid_filepath
@@ -136,13 +139,17 @@ def configure_endpoint(
     try:
         cfg = EndpointConfig(
             name=name,
-            uuid=uuid.uuid4(),
+            uuid=str(uuid.uuid4()),
             host=None,
             port=port,
-            relay_server=relay_server,
-            relay_auth='globus' if relay_auth else None,
-            database_path=database_path,
-            peer_channels=peer_channels,
+            relay=EndpointRelayConfig(
+                address=relay_server,
+                auth=EndpointRelayAuthConfig(
+                    method='globus' if relay_auth else None,
+                ),
+                peer_channels=peer_channels,
+            ),
+            storage=EndpointStorageConfig(database_path=database_path),
         )
     except ValueError as e:
         logger.error(str(e))

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -2,18 +2,90 @@
 from __future__ import annotations
 
 import dataclasses
-import json
 import os
 import re
 import uuid
+from typing import Any
+from typing import Dict
 from typing import Literal
+from typing import Optional
+
+import tosholi
 
 from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
 
-ENDPOINT_CONFIG_FILE = 'config.json'
+ENDPOINT_CONFIG_FILE = 'config.toml'
 ENDPOINT_DATABASE_FILE = 'blobs.db'
 ENDPOINT_LOG_FILE = 'log.txt'
 ENDPOINT_PID_FILE = 'daemon.pid'
+
+
+@dataclasses.dataclass
+class EndpointRelayAuthConfig:
+    """Endpoint relay server authentication configuration.
+
+    Attributes:
+        method: Relay server authentication method.
+        kwargs: Arbitrary options used by the authentication method.
+    """
+
+    method: Optional[Literal['globus']] = None  # noqa: UP007
+    kwargs: Dict[str, Any] = dataclasses.field(  # noqa: UP006
+        default_factory=dict,
+    )
+
+
+@dataclasses.dataclass
+class EndpointRelayConfig:
+    """Endpoint relay server configuration.
+
+    Attributes:
+        address: Address of the relay server to register with.
+        auth: Relay server authentication configuration.
+        peer_channels: Number of peer channels to multiplex communication over.
+        verify_certificates: Validate the relay server's SSL certificate. This
+            should only be disabled when testing endpoint with local relay
+            servers using self-signed certificates.
+    """
+
+    address: Optional[str] = None  # noqa: UP007
+    auth: EndpointRelayAuthConfig = dataclasses.field(
+        default_factory=EndpointRelayAuthConfig,
+    )
+    peer_channels: int = 1
+    verify_certificate: bool = True
+
+    def __post_init__(self) -> None:
+        if self.address is not None and not (
+            self.address.startswith('ws://')
+            or self.address.startswith('wss://')
+        ):
+            raise ValueError(
+                'Server must start with ws:// or wss://.',
+            )
+        if self.peer_channels < 1:
+            raise ValueError('Peer channels must be >= 1.')
+
+
+@dataclasses.dataclass
+class EndpointStorageConfig:
+    """Endpoint data storage configuration.
+
+    Args:
+        database_path: Optional path to SQLite database file that will be used
+            for storing endpoint data. If `None`, data will only be stored
+            in-memory.
+        max_object_size: Optional maximum object size.
+    """
+
+    database_path: Optional[str] = None  # noqa: UP007
+    max_object_size: Optional[int] = MAX_OBJECT_SIZE_DEFAULT  # noqa: UP007
+
+    def __post_init__(self) -> None:
+        if self.max_object_size is not None and self.max_object_size < 1:
+            raise ValueError(
+                'Max object size must be None or greater than zero.',
+            )
 
 
 @dataclasses.dataclass
@@ -25,16 +97,8 @@ class EndpointConfig:
         uuid: Endpoint UUID.
         host: Host endpoint is running on.
         port: Port endpoint is running on.
-        relay_server: Optional relay server the endpoint should register with.
-        relay_auth: Relay server authentication method.
-        database_path: Optional path to SQLite database file that will be used
-            for storing endpoint data. If `None`, data will only be stored
-            in-memory.
-        max_object_size: Optional maximum object size.
-        peer_channels: Number of peer channels to multiplex communications
-            over.
-        verify_certificates: Validate the SSL certificates of the `relay`
-            server.
+        peering: Peering configuration.
+        storage: Storage configuration.
 
     Raises:
         ValueError: If the name does not contain only alphanumeric, dash, or
@@ -43,15 +107,15 @@ class EndpointConfig:
     """
 
     name: str
-    uuid: uuid.UUID
-    host: str | None
+    uuid: str
+    host: Optional[str]  # noqa: UP007
     port: int
-    relay_server: str | None = None
-    relay_auth: Literal['globus'] | None = None
-    database_path: str | None = None
-    max_object_size: int | None = MAX_OBJECT_SIZE_DEFAULT
-    peer_channels: int = 1
-    verify_certificate: bool = True
+    relay: EndpointRelayConfig = dataclasses.field(
+        default_factory=EndpointRelayConfig,
+    )
+    storage: EndpointStorageConfig = dataclasses.field(
+        default_factory=EndpointStorageConfig,
+    )
 
     def __post_init__(self) -> None:
         if not validate_name(self.name):
@@ -59,28 +123,14 @@ class EndpointConfig:
                 'Name must only contain alphanumeric characters, dashes, and '
                 f' underscores. Got {self.name}.',
             )
-        if isinstance(self.uuid, str):
-            try:
-                self.uuid = uuid.UUID(self.uuid, version=4)
-            except ValueError:
-                raise ValueError(
-                    f'{self.uuid} is not a valid UUID4 string.',
-                ) from None
+        try:
+            uuid.UUID(self.uuid, version=4)
+        except ValueError:
+            raise ValueError(
+                f'{self.uuid} is not a valid UUID4 string.',
+            ) from None
         if self.port < 1 or self.port > 65535:
             raise ValueError('Port must be in range [1, 65535].')
-        if self.relay_server is not None and not (
-            self.relay_server.startswith('ws://')
-            or self.relay_server.startswith('wss://')
-        ):
-            raise ValueError(
-                'Server must start with ws:// or wss://.',
-            )
-        if self.max_object_size is not None and self.max_object_size < 1:
-            raise ValueError(
-                'Max object size must be None or greater than zero.',
-            )
-        if self.peer_channels < 1:
-            raise ValueError('Peer channels must be >= 1.')
 
 
 def get_configs(proxystore_dir: str) -> list[EndpointConfig]:
@@ -153,20 +203,13 @@ def read_config(endpoint_dir: str) -> EndpointConfig:
     path = os.path.join(endpoint_dir, ENDPOINT_CONFIG_FILE)
 
     if os.path.exists(path):
-        with open(path) as f:
+        with open(path, 'rb') as f:
             try:
-                cfg_json = json.load(f)
-            except json.decoder.JSONDecodeError as e:
+                return tosholi.load(EndpointConfig, f)
+            except Exception as e:
                 raise ValueError(
                     f'Unable to parse ({path}): {e!s}.',
                 ) from None
-        try:
-            cfg = EndpointConfig(**cfg_json)
-        except TypeError as e:
-            raise ValueError(
-                f'Keys in config ({path}) do not match expected: {e!s}.',
-            ) from None
-        return cfg
     else:
         raise FileNotFoundError(
             f'Endpoint directory {endpoint_dir} does not contain a valid '
@@ -188,9 +231,5 @@ def write_config(cfg: EndpointConfig, endpoint_dir: str) -> None:
     """
     os.makedirs(endpoint_dir, exist_ok=True)
     path = os.path.join(endpoint_dir, ENDPOINT_CONFIG_FILE)
-    with open(path, 'w') as f:
-        data = dataclasses.asdict(cfg)
-        data['uuid'] = str(data['uuid'])
-        json.dump(data, f, indent=4)
-        # Add newline so cat on the file looks better
-        f.write('\n')
+    with open(path, 'wb') as f:
+        tosholi.dump(cfg, f)

--- a/proxystore/p2p/relay/run.py
+++ b/proxystore/p2p/relay/run.py
@@ -105,11 +105,16 @@ async def serve(config: RelayServingConfig) -> None:
 
     client_logger_task: asyncio.Task[None] | None = None
     if config.logging.current_client_interval is not None:  # pragma: no branch
+        level = (
+            config.logging.default_level
+            if isinstance(config.logging.default_level, int)
+            else logging.getLevelName(config.logging.default_level)
+        )
         client_logger_task = periodic_client_logger(
             server,
             config.logging.current_client_interval,
             config.logging.current_client_limit,
-            config.logging.default_level,
+            level=level,
         )
 
     config_repr = pprint.pformat(config, indent=2)
@@ -171,7 +176,7 @@ def cli(
     config = (
         RelayServingConfig()
         if config_path is None
-        else RelayServingConfig.from_config(config_path)
+        else RelayServingConfig.from_toml(config_path)
     )
 
     # Override config with CLI options if given

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ endpoints = [
     "python-daemon",
     "quart>=0.18.0",
     "requests>=2.27.1",
+    "tosholi",
     "websockets>=10.0",
 ]
 redis = ["redis>=3.4"]

--- a/testing/endpoint.py
+++ b/testing/endpoint.py
@@ -57,10 +57,9 @@ def endpoint(use_uvloop: bool) -> Generator[EndpointConfig, None, None]:
     """Launch endpoint in subprocess."""
     config = EndpointConfig(
         name='endpoint-fixture',
-        uuid=uuid.uuid4(),
+        uuid=str(uuid.uuid4()),
         host='localhost',
         port=open_port(),
-        relay_server=None,
     )
     server_handle = Process(
         target=serve_endpoint_silent,

--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -66,7 +66,7 @@ def test_configure_command(home_dir) -> None:
     cfg = read_config(endpoint_dir)
     assert cfg.name == name
     assert cfg.port == port
-    assert cfg.relay_server == relay_server
+    assert cfg.relay.address == relay_server
 
 
 def test_list_command(home_dir, caplog) -> None:

--- a/tests/endpoint/commands_test.py
+++ b/tests/endpoint/commands_test.py
@@ -86,7 +86,7 @@ def test_configure_endpoint_basic(tmp_path: pathlib.Path, caplog) -> None:
     assert cfg.name == _NAME
     assert cfg.host is None
     assert cfg.port == _PORT
-    assert cfg.relay_server == _SERVER
+    assert cfg.relay.address == _SERVER
 
     assert any(
         [
@@ -337,7 +337,7 @@ def test_start_endpoint_bad_config(tmp_path: pathlib.Path, caplog) -> None:
     endpoint_dir = os.path.join(tmp_path, _NAME)
     os.makedirs(endpoint_dir)
     with open(os.path.join(endpoint_dir, ENDPOINT_CONFIG_FILE), 'w') as f:
-        f.write('not valid json')
+        f.write('not valid toml')
 
     rv = start_endpoint(_NAME, proxystore_dir=str(tmp_path))
     assert rv == 1
@@ -355,7 +355,12 @@ def test_start_endpoint_hanging_different_host(
 
     endpoint_dir = os.path.join(tmp_path, _NAME)
 
-    config = EndpointConfig(name=_NAME, uuid=_UUID, host='abcd', port=1234)
+    config = EndpointConfig(
+        name=_NAME,
+        uuid=str(_UUID),
+        host='abcd',
+        port=1234,
+    )
     write_config(config, endpoint_dir)
 
     pid_file = get_pid_filepath(endpoint_dir)
@@ -379,7 +384,7 @@ def test_start_endpoint_old_pid_file(tmp_path: pathlib.Path, caplog) -> None:
 
     endpoint_dir = os.path.join(tmp_path, _NAME)
 
-    config = EndpointConfig(name=_NAME, uuid=_UUID, host=None, port=1234)
+    config = EndpointConfig(name=_NAME, uuid=str(_UUID), host=None, port=1234)
     write_config(config, endpoint_dir)
 
     pid_file = get_pid_filepath(endpoint_dir)
@@ -465,7 +470,12 @@ def test_stop_endpoint_hanging_different_host(
     caplog.set_level(logging.ERROR)
     endpoint_dir = os.path.join(tmp_path, _NAME)
 
-    config = EndpointConfig(name=_NAME, uuid=_UUID, host='abcd', port=1234)
+    config = EndpointConfig(
+        name=_NAME,
+        uuid=str(_UUID),
+        host='abcd',
+        port=1234,
+    )
     write_config(config, endpoint_dir)
 
     pid_file = get_pid_filepath(endpoint_dir)
@@ -491,7 +501,7 @@ def test_stop_endpoint_dangling_pid_file(
     caplog.set_level(logging.DEBUG)
     endpoint_dir = os.path.join(tmp_path, _NAME)
 
-    config = EndpointConfig(name=_NAME, uuid=_UUID, host=None, port=1234)
+    config = EndpointConfig(name=_NAME, uuid=str(_UUID), host=None, port=1234)
     write_config(config, endpoint_dir)
 
     pid_file = get_pid_filepath(endpoint_dir)

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -16,6 +16,7 @@ import quart
 import requests
 
 from proxystore.endpoint.config import EndpointConfig
+from proxystore.endpoint.config import EndpointStorageConfig
 from proxystore.endpoint.endpoint import Endpoint
 from proxystore.endpoint.serve import _get_auth_headers
 from proxystore.endpoint.serve import create_app
@@ -319,10 +320,10 @@ async def test_missing_key(quart_app) -> None:
 def test_serve(use_uvloop: bool) -> None:
     config = EndpointConfig(
         name='my-endpoint',
-        uuid=uuid.uuid4(),
+        uuid=str(uuid.uuid4()),
         host='localhost',
         port=open_port(),
-        database_path=':memory:',
+        storage=EndpointStorageConfig(database_path=':memory:'),
     )
 
     process = multiprocessing.Process(
@@ -348,7 +349,7 @@ def test_serve(use_uvloop: bool) -> None:
 def test_serve_config_validation(use_uvloop: bool) -> None:
     config = EndpointConfig(
         name='my-endpoint',
-        uuid=uuid.uuid4(),
+        uuid=str(uuid.uuid4()),
         host=None,
         port=open_port(),
     )
@@ -363,10 +364,9 @@ def test_serve_logging(use_uvloop: bool, tmp_path: pathlib.Path) -> None:
     def _serve(log_file: str) -> None:
         config = EndpointConfig(
             name='name',
-            uuid=uuid.uuid4(),
+            uuid=str(uuid.uuid4()),
             host='0.0.0.0',
             port=open_port(),
-            relay_server=None,
         )
         with mock.patch('uvicorn.Server.serve', AsyncMock()):
             serve(

--- a/tests/integration/endpoints_test.py
+++ b/tests/integration/endpoints_test.py
@@ -69,11 +69,11 @@ def endpoints() -> Generator[tuple[list[uuid.UUID], list[str]], None, None]:
     for port in (open_port(), open_port()):
         cfg = EndpointConfig(
             name=f'test-endpoint-{port}',
-            uuid=uuid.uuid4(),
+            uuid=str(uuid.uuid4()),
             host='localhost',
             port=port,
-            relay_server=f'ws://{ss_host}:{ss_port}',
         )
+        cfg.relay.address = f'ws://{ss_host}:{ss_port}'
         assert cfg.host is not None
 
         # We want a unique proxystore_dir for each endpoint to simulate
@@ -81,7 +81,7 @@ def endpoints() -> Generator[tuple[list[uuid.UUID], list[str]], None, None]:
         proxystore_dir = os.path.join(tmp_path, str(port))
         endpoint_dir = os.path.join(proxystore_dir, cfg.name)
         write_config(cfg, endpoint_dir)
-        uuids.append(cfg.uuid)
+        uuids.append(uuid.UUID(cfg.uuid))
         dirs.append(proxystore_dir)
 
         handle = Process(target=serve_endpoint_silent, args=[cfg])

--- a/tests/p2p/relay/config_test.py
+++ b/tests/p2p/relay/config_test.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 import pathlib
 
-import pytest
-
 from proxystore.p2p.relay.config import RelayAuthConfig
 from proxystore.p2p.relay.config import RelayLoggingConfig
 from proxystore.p2p.relay.config import RelayServingConfig
@@ -15,83 +13,48 @@ def test_auth_config_default() -> None:
     assert config.method is None
 
 
-def test_auth_config_from_config_dict() -> None:
-    config = RelayAuthConfig.from_config_dict({})
-    assert config == RelayAuthConfig()
-
-    # Check method case parsing
-    config = RelayAuthConfig.from_config_dict({'method': 'GLOBUS'})
-    assert config.method == 'globus'
-
-    # Check extra kwargs
-    config = RelayAuthConfig.from_config_dict(
-        {'method': 'GLOBUS', 'kwarg1': 'value'},
-    )
-    assert config.method == 'globus'
-    assert config.kwargs['kwarg1'] == 'value'
-
-    # Check method unknown error
-    with pytest.raises(ValueError, match='Unknown authentication method'):
-        RelayAuthConfig.from_config_dict({'method': 'fake'})
-
-
 def test_logging_config_default() -> None:
     config = RelayLoggingConfig()
     assert config.default_level == logging.INFO
 
 
-def test_logging_config_from_config_dict() -> None:
-    config = RelayLoggingConfig.from_config_dict({})
-    assert config == RelayLoggingConfig()
-
-    # Check type conversion using string versions of default options
-    options = {
-        'default_level': 'INFO',
-        'websockets_level': 'WARNING',
-        'current_client_interval': str(config.current_client_interval),
-        'current_client_limit': str(config.current_client_limit),
-    }
-    config = RelayLoggingConfig.from_config_dict(options)
-    assert config == RelayLoggingConfig()
-
-
 def test_read_from_config_file_empty(tmp_path: pathlib.Path) -> None:
     data = '[serving]'
 
-    filepath = tmp_path / 'relay.cfg'
+    filepath = tmp_path / 'relay.toml'
     with open(filepath, 'w') as f:
         f.write(data)
 
-    config = RelayServingConfig.from_config(filepath)
+    config = RelayServingConfig.from_toml(filepath)
     assert config == RelayServingConfig()
 
 
 def test_read_from_config_file(tmp_path: pathlib.Path) -> None:
     data = """\
-[serving]
-host = localhost
+host = "localhost"
 port = 1234
-certfile = /path/to/cert.pem
-keyfile = /path/to/privkey.pem
+certfile = "/path/to/cert.pem"
+keyfile = "/path/to/privkey.pem"
 
-[serving.auth]
-method = globus
-client_id = ABC
-client_secret
+[auth]
+method = "globus"
 
-[serving.logging]
-log_dir = /path/to/log/dir
-default_level = DEBUG
-websockets_level = INFO
+[auth.kwargs]
+client_id = "ABC"
+
+[logging]
+log_dir = "/path/to/log/dir"
+default_level = "DEBUG"
+websockets_level = "INFO"
 current_client_interval = 3
 current_client_limit = 5
 """
 
-    filepath = tmp_path / 'relay.cfg'
+    filepath = tmp_path / 'relay.toml'
     with open(filepath, 'w') as f:
         f.write(data)
 
-    config = RelayServingConfig.from_config(filepath)
+    config = RelayServingConfig.from_toml(filepath)
 
     assert config.host == 'localhost'
     assert config.port == 1234
@@ -100,10 +63,10 @@ current_client_limit = 5
 
     assert config.auth.method == 'globus'
     assert config.auth.kwargs['client_id'] == 'ABC'
-    assert config.auth.kwargs['client_secret'] is None
+    assert 'client_secret' not in config.auth.kwargs
 
     assert config.logging.log_dir == '/path/to/log/dir'
-    assert config.logging.default_level == logging.DEBUG
-    assert config.logging.websockets_level == logging.INFO
+    assert config.logging.default_level == 'DEBUG'
+    assert config.logging.websockets_level == 'INFO'
     assert config.logging.current_client_interval == 3
     assert config.logging.current_client_limit == 5


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Unifies all configuration files to TOML with the `tosholi` package for loading/dumping to/from TOML files using dataclass representations of the configuration.

This is a breaking change for endpoint users, and will require them to recreate their endpoint configuration files.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [x] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update unit tests, and tested running a relay and endpoint from the new configuration files using the CLIs.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
