### PR TITLE
Fix flakey unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,12 +36,6 @@ def pytest_addoption(parser):
         default=False,
         help='Use uvloop as the default event loop for asyncio tests',
     )
-    parser.addoption(
-        '--extras',
-        action='store_true',
-        default=False,
-        help='Run extra tests that are disable by default',
-    )
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Fixes for flakey unit tests.
- Relay serving logging reading log file before flushing.
- MacOS address lookup error in `start_endpoint`.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [x] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Ran tests 10+ times on MacOS to make sure they no longer failed.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
