### PR TITLE
Improve logging when tokens are missing on endpoint start

### DIFF
--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -60,14 +60,12 @@ Endpoints can be configure and started with the
 command. By default, an Endpoint is configured to connect to ProxyStore's
 cloud-hosted relay server. This relay server uses
 [Globus Auth](https://www.globus.org/globus-auth-service) for identity and
-access management. You will be prompted to authenticate and get access
-tokens on [globus.org](https::/globus.org) the first time you start the
-endpoint. Alternatively, you can use the
+access management. To use the provided relay server, authenticate using the
 [`proxystore-globus-auth login`](../../api/cli/#proxystore-globus-auth-login)
-CLI to authenticate. Authentication only needs to be performed once per
-system.
+CLI. Authentication only needs to be performed once per system.
 
 ```bash
+$ proxystore-globus-auth login
 $ proxystore-endpoint configure my-endpoint
 INFO: Configured endpoint: my-endpoint <a6c7f036-3e29-4a7a-bf90-5a5f21056e39>
 INFO: Config and log file directory: ~/.local/share/proxystore/my-endpoint

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -81,7 +81,15 @@ def _get_auth_headers(
             'resource_server',
             ProxyStoreRelayScopes.resource_server,
         )
-        authorizer = manager.get_authorizer(resource_server)
+        try:
+            authorizer = manager.get_authorizer(resource_server)
+        except LookupError as e:
+            logger.error(
+                'Failed to find Globus Auth tokens for the specified relay '
+                'resource server. Have you logged in yet? If not, login then '
+                'try again.\n  $ proxystore-globus-auth login',
+            )
+            raise SystemExit(1) from e
         bearer = authorizer.get_authorization_header()
         assert bearer is not None
         return {'Authorization': bearer}

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -405,3 +405,18 @@ def test_get_auth_headers() -> None:
         return_value=header,
     ):
         assert _get_auth_headers('globus')['Authorization'] == header
+
+
+def test_get_auth_headers_missing() -> None:
+    assert _get_auth_headers(None) == {}
+
+    mock.MagicMock()
+    with mock.patch(
+        'proxystore.globus.manager.NativeAppAuthManager.get_authorizer',
+        side_effect=LookupError,
+    ), mock.patch(
+        'proxystore.globus.manager.get_token_storage_adapter',
+    ), pytest.raises(
+        SystemExit,
+    ):
+        assert _get_auth_headers('globus')


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Previously, if the tokens for the ProxyStore Relay Server resource server were missing, the user would get an ugly stack trace and `LookupError` when starting an endpoint. This improves the logging to catch the error, print a helpful message, and exit. The endpoint guide has also been updated to instruct users to log in first before starting their endpoint.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested the new functionality in the CLI.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
