### PR TITLE
Add optional `max_message_size` check to `RelayServer`

### DIFF
--- a/proxystore/p2p/relay/config.py
+++ b/proxystore/p2p/relay/config.py
@@ -73,6 +73,8 @@ class RelayServingConfig:
             taken from the certfile.
         auth: Authentication configuration.
         logging: Logging configuration.
+        max_message_bytes: Maximum size in bytes of messages received by
+            the relay server.
     """
 
     host: Optional[str] = None  # noqa: UP007
@@ -83,6 +85,7 @@ class RelayServingConfig:
     logging: RelayLoggingConfig = dataclasses.field(
         default_factory=RelayLoggingConfig,
     )
+    max_message_bytes: Optional[int] = None  # noqa: UP007
 
     @classmethod
     def from_toml(cls, filepath: str | pathlib.Path) -> Self:

--- a/proxystore/p2p/relay/run.py
+++ b/proxystore/p2p/relay/run.py
@@ -90,7 +90,10 @@ async def serve(config: RelayServingConfig) -> None:
         config: Serving configuration.
     """
     authenticator = get_authenticator(config.auth)
-    server = RelayServer(authenticator)
+    server = RelayServer(
+        authenticator,
+        max_message_bytes=config.max_message_bytes,
+    )
 
     # Set the stop condition when receiving SIGINT (ctrl-C) and SIGTERM.
     loop = asyncio.get_running_loop()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The `max_message_size` attribute of the `RelayServer` is optional and will disconnect clients which send messages that are too large to the relay. This value can be configured from the relay configuration file.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #398 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a new unit test and checked using a local relay server configured to limit the max message size to 100 bytes and 1000 bytes. This script will work when the limit is 1000 bytes, but will fail when the limit is only 100 bytes because the message size is ~150 bytes.

```python
import asyncio
import sys
import uuid
import websockets

from proxystore.p2p.relay.messages import decode_relay_message
from proxystore.p2p.relay.messages import encode_relay_message
from proxystore.p2p.relay.messages import RelayRegistrationRequest

async def main() -> None:
    async with websockets.connect('ws://localhost:8700') as websocket:
        request = RelayRegistrationRequest('test', uuid.uuid4())
        request_enc = encode_relay_message(request)
        print(f'Message size: {sys.getsizeof(request_enc)}')

        await websocket.send(request_enc)

        try:
            message = await websocket.recv()
            print(decode_relay_message(message))
        except websockets.ConnectionClosed:
            print(f'Websocket closed ({websocket.close_code}): {websocket.close_reason}')

asyncio.run(main())
```

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
