### PR TITLE
Support Globus Client Identities for endpoint authentication

### DIFF
--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -64,6 +64,14 @@ access management. To use the provided relay server, authenticate using the
 [`proxystore-globus-auth login`](../../api/cli/#proxystore-globus-auth-login)
 CLI. Authentication only needs to be performed once per system.
 
+!!! tip
+
+    Endpoints can be started using a client identity, rather than as a user,
+    by exporting the `PROXYSTORE_GLOBUS_CLIENT_ID` and
+    `PROXYSTORE_GLOBUS_CLIENT_SECRET` environment variables. This is similar
+    to how
+    [Globus Compute supports client login](https://funcx.readthedocs.io/en/latest/sdk.html#client-credentials-with-clients){target=_blank}.
+
 ```bash
 $ proxystore-globus-auth login
 $ proxystore-endpoint configure my-endpoint

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -30,6 +30,9 @@ from proxystore.endpoint.exceptions import PeerRequestError
 from proxystore.endpoint.storage import DictStorage
 from proxystore.endpoint.storage import SQLiteStorage
 from proxystore.endpoint.storage import Storage
+from proxystore.globus.client import is_client_login
+from proxystore.globus.manager import ConfidentialAppAuthManager
+from proxystore.globus.manager import GlobusAuthManager
 from proxystore.globus.manager import NativeAppAuthManager
 from proxystore.globus.scopes import ProxyStoreRelayScopes
 from proxystore.p2p.manager import PeerManager
@@ -76,7 +79,13 @@ def _get_auth_headers(
     if method is None:
         return {}
     elif method == 'globus':
-        manager = NativeAppAuthManager()
+        manager: GlobusAuthManager
+        if is_client_login():
+            logger.info('Using confidential app Globus Auth client')
+            manager = ConfidentialAppAuthManager()
+        else:
+            logger.info('Using native app Globus Auth client')
+            manager = NativeAppAuthManager()
         resource_server = kwargs.get(
             'resource_server',
             ProxyStoreRelayScopes.resource_server,

--- a/proxystore/globus/client.py
+++ b/proxystore/globus/client.py
@@ -96,3 +96,21 @@ def get_native_app_auth_client(
         client_id=client_id,
         app_name=app_name,
     )
+
+
+def is_client_login() -> bool:
+    """Check if Globus client identity environment variables are set.
+
+    Based on the Globus Compute SDK's
+    [`is_client_login()`](https://github.com/funcx-faas/funcX/blob/8f5b59075ae6f8e8b8b13fe1b91430271f4e0c3c/compute_sdk/globus_compute_sdk/sdk/login_manager/client_login.py#L24-L38){target=_blank}.
+
+    Returns:
+        `True` if `PROXYSTORE_GLOBUS_CLIENT_ID` and \
+        `PROXYSTORE_GLOBUS_CLIENT_SECRET` are set.
+    """
+    try:
+        _get_client_credentials_from_env()
+    except ValueError:
+        return False
+    else:
+        return True

--- a/tests/globus/client_test.py
+++ b/tests/globus/client_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from proxystore.globus.client import get_confidential_app_auth_client
 from proxystore.globus.client import get_native_app_auth_client
+from proxystore.globus.client import is_client_login
 from proxystore.globus.client import PROXYSTORE_GLOBUS_CLIENT_ID_ENV_NAME
 from proxystore.globus.client import PROXYSTORE_GLOBUS_CLIENT_SECRET_ENV_NAME
 
@@ -53,3 +54,16 @@ def test_get_confidential_app_auth_client_bad_uuid() -> None:
 def test_get_native_app_auth_client() -> None:
     client = get_native_app_auth_client()
     assert isinstance(client, globus_sdk.NativeAppAuthClient)
+
+
+def test_is_client_login() -> None:
+    with mock.patch.dict(os.environ, {}):
+        assert not is_client_login()
+
+    env = {PROXYSTORE_GLOBUS_CLIENT_ID_ENV_NAME: str(uuid.uuid4())}
+    with mock.patch.dict(os.environ, env):
+        assert not is_client_login()
+
+    env[PROXYSTORE_GLOBUS_CLIENT_SECRET_ENV_NAME] = 'secret'
+    with mock.patch.dict(os.environ, env):
+        assert is_client_login()

--- a/tests/globus/manager_test.py
+++ b/tests/globus/manager_test.py
@@ -1,17 +1,102 @@
 from __future__ import annotations
 
+import os
+import pathlib
+import uuid
 from unittest import mock
 
 import globus_sdk
 import pytest
 from globus_sdk.scopes import AuthScopes
 from globus_sdk.scopes import TransferScopes
+from globus_sdk.tokenstorage import SQLiteAdapter
 
+from proxystore.globus.client import PROXYSTORE_GLOBUS_CLIENT_ID_ENV_NAME
+from proxystore.globus.client import PROXYSTORE_GLOBUS_CLIENT_SECRET_ENV_NAME
+from proxystore.globus.manager import ConfidentialAppAuthManager
 from proxystore.globus.manager import NativeAppAuthManager
 
+CLIENT_IDENTITY_ENV = {
+    PROXYSTORE_GLOBUS_CLIENT_ID_ENV_NAME: str(uuid.uuid4()),
+    PROXYSTORE_GLOBUS_CLIENT_SECRET_ENV_NAME: '<SECRET>',
+}
 
-def test_native_app_auth_manager_not_authenticated() -> None:
-    manager = NativeAppAuthManager()
+
+@pytest.fixture()
+def storage(tmp_path: pathlib.Path) -> SQLiteAdapter:
+    return SQLiteAdapter(':memory:')
+
+
+@mock.patch.dict(os.environ, CLIENT_IDENTITY_ENV)
+def test_confidential_app_auth_manager_login(
+    storage: SQLiteAdapter,
+) -> None:
+    manager = ConfidentialAppAuthManager(storage=storage)
+    assert isinstance(manager.client, globus_sdk.ConfidentialAppAuthClient)
+    assert manager.logged_in
+
+    # Login is a no-op so will not change the state of the manager
+    manager.login()
+    assert manager.logged_in
+
+
+@mock.patch.dict(os.environ, CLIENT_IDENTITY_ENV)
+@mock.patch('globus_sdk.ClientCredentialsAuthorizer')
+def test_confidential_app_auth_manager_get_authorizer(
+    mock_authorizer,
+    storage: SQLiteAdapter,
+) -> None:
+    manager = ConfidentialAppAuthManager(storage=storage)
+
+    manager.get_authorizer(AuthScopes.resource_server)
+
+    tokens = {'access_token': '<TOKEN>', 'expires_at_seconds': 0}
+    with mock.patch.object(
+        manager._storage,
+        'get_token_data',
+        return_value=tokens,
+    ):
+        manager.get_authorizer(AuthScopes.resource_server)
+
+
+@mock.patch.dict(os.environ, CLIENT_IDENTITY_ENV)
+@mock.patch('globus_sdk.ConfidentialAppAuthClient.oauth2_revoke_token')
+def test_confidential_app_auth_manager_logout(
+    mock_revoke,
+    storage: SQLiteAdapter,
+) -> None:
+    data = {
+        'auth.api.globus.org': {
+            'access_token': 'xxx',
+            'refresh_token': 'xxx',
+        },
+        'transfer.api.globus.org': {
+            'access_token': 'xxx',
+            'refresh_token': 'xxx',
+        },
+    }
+
+    manager = ConfidentialAppAuthManager(storage=storage)
+
+    with mock.patch.object(
+        manager._storage,
+        'get_by_resource_server',
+        return_value=data,
+    ), mock.patch.object(
+        manager._storage,
+        'remove_tokens_for_resource_server',
+    ) as mock_remove_tokens:
+        manager.logout()
+
+        assert mock_remove_tokens.call_count == len(data)
+
+    assert mock_revoke.call_count == 2 * len(data)
+
+
+def test_native_app_auth_manager_not_authenticated(
+    storage: SQLiteAdapter,
+) -> None:
+    manager = NativeAppAuthManager(storage=storage)
     assert isinstance(manager.client, globus_sdk.NativeAppAuthClient)
     assert not manager.logged_in
     with pytest.raises(
@@ -24,8 +109,11 @@ def test_native_app_auth_manager_not_authenticated() -> None:
     manager.logout()
 
 
-def test_native_app_auth_manager_logged_in_property() -> None:
+def test_native_app_auth_manager_logged_in_property(
+    storage: SQLiteAdapter,
+) -> None:
     manager = NativeAppAuthManager(
+        storage=storage,
         resource_server_scopes={AuthScopes.resource_server: []},
     )
 
@@ -58,10 +146,11 @@ def test_native_app_auth_manager_login_flow(
     mock_prompt,
     mock_logged_in,
     mock_store,
+    storage: SQLiteAdapter,
 ) -> None:
     mock_logged_in.return_value = False
 
-    manager = NativeAppAuthManager()
+    manager = NativeAppAuthManager(storage=storage)
 
     # Mock these click methods so they don't print to stdout
     with mock.patch('click.echo'), mock.patch('click.secho'):
@@ -86,15 +175,21 @@ def test_native_app_auth_manager_login_flow(
 
 
 @mock.patch('globus_sdk.RefreshTokenAuthorizer')
-def test_native_app_auth_manager_get_authorizer(mock_authorizer) -> None:
-    manager = NativeAppAuthManager()
+def test_native_app_auth_manager_get_authorizer(
+    mock_authorizer,
+    storage: SQLiteAdapter,
+) -> None:
+    manager = NativeAppAuthManager(storage=storage)
 
     with mock.patch.object(manager._storage, 'get_token_data'):
         manager.get_authorizer(AuthScopes.resource_server)
 
 
 @mock.patch('globus_sdk.NativeAppAuthClient.oauth2_revoke_token')
-def test_native_app_auth_manager_logout(mock_revoke) -> None:
+def test_native_app_auth_manager_logout(
+    mock_revoke,
+    storage: SQLiteAdapter,
+) -> None:
     data = {
         'auth.api.globus.org': {
             'access_token': 'xxx',
@@ -106,7 +201,7 @@ def test_native_app_auth_manager_logout(mock_revoke) -> None:
         },
     }
 
-    manager = NativeAppAuthManager()
+    manager = NativeAppAuthManager(storage=storage)
 
     with mock.patch.object(
         manager._storage,


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Users can now export the `PROXYSTORE_GLOBUS_CLIENT_ID` and `PROXYSTORE_GLOBUS_CLIENT_SECRET` environment variables to using a Globus client identity for endpoint authentication (as opposed to authenticating as a user). 

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #402 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests and tested with a local endpoint and personal client identity. This works with the currently deployed relay server.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
