### PR TITLE
Add the `ProxyFuture` interface and `Store.future()` method

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,4 +4,5 @@
 * [Endpoints Overview](endpoints.md)
 * [Endpoints Debugging](endpoints-debugging.md)
 * [Performance Tracking](performance.md)
+* [Proxy Futures](proxy-futures.md)
 * [Relay Serving](relay-serving.md)

--- a/docs/guides/proxy-futures.md
+++ b/docs/guides/proxy-futures.md
@@ -1,0 +1,117 @@
+# Proxy Futures
+
+*Last updated 1 November 2023*
+
+This guide walks through the use of the
+[`Store.future()`][proxystore.store.base.Store.future] interface and associated
+[`ProxyFuture`][proxystore.store.future.ProxyFuture].
+
+!!! note
+
+    Some familiarity with ProxyStore is assumed. Check out the
+    [Get Started](../get-started.md){target=_blank} guide and
+    [Concepts](../concepts/index.md){target=_blank} page to learn more about
+    ProxyStore's core concepts.
+
+!!! warning
+
+    The [`Store.future()`][proxystore.store.base.Store.future] and
+    [`ProxyFuture`][proxystore.store.future.ProxyFuture] interfaces are
+    experimental features and may change in future releases.
+
+The [`ProxyFuture`][proxystore.store.future.ProxyFuture] interface enables
+a data producer to preemptively send a proxy to a data consumer before the
+target data has been created. The consumer of the target data proxy will
+block when the proxy is first used and resolved until the producer
+has created the target data.
+
+Here is a trivial example using a [`Store`][proxystore.store.base.Store] and
+[`LocalConnector`][proxystore.connectors.local.LocalConnector]. The
+[`future.proxy()`][proxystore.store.future.ProxyFuture.proxy] method is used
+to create a [`Proxy`][proxystore.proxy.Proxy] which will resolve to the
+result of the future.
+
+```python linenums="1" title="example.py"
+from proxystore.connectors.local import LocalConnector
+from proxystore.store import Store
+from proxystore.store.future import ProxyFuture
+
+with Store('proxy-future-example', LocalConnector()) as store:
+    future: ProxyFuture[str] = store.future()
+    proxy = future.proxy()
+
+    future.set_result('value')
+    assert future.result() == 'value'
+    assert proxy == 'value'
+```
+
+!!! info
+
+    Not all [`Connector`][proxystore.connectors.protocols.Connector]
+    implementations are compatible with the
+    [`Store.future()`][proxystore.store.base.Store.future] interface.
+    The [`Connector`][proxystore.connectors.protocols.Connector] instance used
+    to initialize the [`Store`][proxystore.store.base.Store] must also
+    implement the
+    [`DeferrableConnector`][proxystore.connectors.protocols.DeferrableConnector]
+    protocol. A [`NotImplementedError`][NotImplementedError] will be
+    raised when calling [`Store.future()`][proxystore.store.base.Store.future]
+    if the connector is not an instance of
+    [`DeferrableConnector`][proxystore.connectors.protocols.DeferrableConnector].
+    Many of the out-of-the-box implementations implement the
+    [`DeferrableConnector`][proxystore.connectors.protocols.DeferrableConnector]
+    protocol such as the
+    [`EndpointConnector`][proxystore.connectors.endpoint.EndpointConnector],
+    [`FileConnector`][proxystore.connectors.file.FileConnector], and
+    [`RedisConnector`][proxystore.connectors.redis.RedisConnector].
+
+The power of [`ProxyFuture`][proxystore.store.future.ProxyFuture] comes when
+the data producer and consumer are executing independently in time and space
+(i.e., execution occurs in different processes, potentially on different
+systems, and in an undefined order). The
+[`ProxyFuture`][proxystore.store.future.ProxyFuture] enables the producer
+and consumer to share a data dependency, while allowing the consumer to
+eagerly start execution before the data dependencies are fully satisfied.
+
+Consider the following example where we have a client which invokes two
+functions, `foo()` and `bar()` on remote processes. `foo()` will produce an
+object needed by `bar()`, but we want to start executing `foo()` and `bar()`
+at the same time. (We could even start `bar()` before `foo()`!)
+
+```python linenums="1" title="client.py"
+from proxystore.connectors.redis import RedisConnector
+from proxystore.store import Store
+from proxystore.store.future import ProxyFuture
+
+class MyData:
+    ...
+
+def foo(future: ProxyFuture[MyData]) -> None:
+    data: MyData = compute(...)
+    future.set_result(data)
+
+def bar(data: MyData) -> None:
+    # Computation not involving data can execute freely.
+    compute(...)
+    # Computation using data will block until foo
+    # sets the result of the future.
+    compute(data)
+
+
+with Store('proxy-future-example', RedisConnector(...)) as store:
+    future: ProxyFuture[MyData] = store.future()
+
+    # The invoke_remote function will execute the function with
+    # the provided on arguments on an arbitrary remote process.
+    foo_result_future = invoke_remote(foo, future)
+    bar_result_future = invoke_remote(bar, future.proxy())
+
+    # Wait on the functions to finish executing.
+    foo_result_future.result()
+    bar_result_future.result()
+```
+
+In this example, `foo()` and `bar()` started executing at the same time.
+This allows `bar()` to eagerly execute code which does not depend on the
+data produced by `foo()`. `bar()` will only block once the data is needed by
+the computation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - Endpoints Overview: guides/endpoints.md
       - Endpoints Debugging: guides/endpoints-debugging.md
       - Performance Tracking: guides/performance.md
+      - Proxy Futures: guides/proxy-futures.md
       - Relay Serving: guides/relay-serving.md
   - API Reference:
       - ProxyStore: api/

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import warnings
 from types import TracebackType
 from typing import Any
 from typing import cast
@@ -26,7 +27,9 @@ from proxystore.proxy import Proxy
 from proxystore.proxy import ProxyLocker
 from proxystore.store.cache import LRUCache
 from proxystore.store.exceptions import NonProxiableTypeError
+from proxystore.store.factory import PollingStoreFactory
 from proxystore.store.factory import StoreFactory
+from proxystore.store.future import ProxyFuture
 from proxystore.store.metrics import StoreMetrics
 from proxystore.store.types import ConnectorKeyT
 from proxystore.store.types import ConnectorT
@@ -35,6 +38,7 @@ from proxystore.store.types import SerializerT
 from proxystore.utils.imports import get_class_path
 from proxystore.utils.imports import import_class
 from proxystore.utils.timer import Timer
+from proxystore.warnings import ExperimentalWarning
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +210,102 @@ class Store(Generic[ConnectorT]):
         connector = import_class(connector_type)
         config['connector'] = connector.from_config(connector_config)
         return cls(**config)
+
+    def future(
+        self,
+        *,
+        evict: bool = False,
+        serializer: SerializerT | None = None,
+        deserializer: DeserializerT | None = None,
+        polling_interval: float = 1,
+        polling_timeout: float | None = None,
+    ) -> ProxyFuture[T]:
+        """Create a future to an object.
+
+        Example:
+            ```python
+            from proxystore.connectors.file import FileConnector
+            from proxystore.store import Store
+            from proxystore.store.future import ProxyFuture
+
+            def remote_foo(future: ProxyFuture) -> None:
+                # Computation that generates a result value needed by
+                # the remote_bar function.
+                future.set_result(...)
+
+            def remote_bar(data: Any) -> None:
+                # Function uses data, which is a proxy, as normal, blocking
+                # until the remote_foo function has called set_result.
+                ...
+
+            with Store('future-example', FileConnector(...)) as store:
+                future = store.future()
+
+                # The invoke_remove function invokes a provided function
+                # on a remote process. For example, this could be a serverless
+                # function execution.
+                foo_result_future = invoke_remote(remote_foo, future)
+                bar_result_future = invoke_remote(remote_bar, future.proxy())
+
+                foo_result_future.result()
+                bar_result_future.result()
+            ```
+
+        Warning:
+            This method only works if the `connector` is of type
+            [`DeferrableConnector`][proxystore.connectors.protocols.DeferrableConnector].
+
+        Warning:
+            This method and the
+            [`ProxyFuture.proxy()`][proxystore.store.future.ProxyFuture.proxy]
+            are experimental features and may change in future releases.
+
+        Args:
+            evict: If a proxy returned by
+                [`ProxyFuture.proxy()`][proxystore.store.future.ProxyFuture.proxy]
+                should evict the object once resolved.
+            serializer: Optionally override the default serializer for the
+                store instance.
+            deserializer: Optionally override the default deserializer for the
+                store instance.
+            polling_interval: Seconds to sleep between polling the store for
+                the object when getting the result of the future.
+            polling_timeout: Optional maximum number of seconds to poll for
+                when getting the result of the future.
+
+        Returns:
+            Future which can be used to get the result object at a later time \
+            or create a proxy which will resolve to the result of the future.
+
+        Raises:
+            NotImplementedError: If the `connector` is not of type
+                [`DeferrableConnector`][proxystore.connectors.protocols.DeferrableConnector].
+        """
+        if not isinstance(self.connector, DeferrableConnector):
+            raise NotImplementedError(
+                'The provided connector is type '
+                f'{type(self.connector).__name__} which does not implement '
+                f'the {DeferrableConnector.__name__} necessary to use the '
+                f'{ProxyFuture.__name__} interface.',
+            )
+
+        warnings.warn(
+            'The Store.future() and ProxyFuture interfaces are experimental '
+            'and may change in future releases.',
+            category=ExperimentalWarning,
+            stacklevel=2,
+        )
+
+        key = self.connector.new_key()
+        factory: PollingStoreFactory[ConnectorT, T] = PollingStoreFactory(
+            key,
+            store_config=self.config(),
+            deserializer=deserializer,
+            evict=evict,
+            polling_interval=polling_interval,
+            polling_timeout=polling_timeout,
+        )
+        return ProxyFuture(factory, serializer=serializer)
 
     def evict(self, key: ConnectorKeyT) -> None:
         """Evict the object associated with the key.

--- a/proxystore/store/factory.py
+++ b/proxystore/store/factory.py
@@ -159,12 +159,12 @@ class PollingStoreFactory(StoreFactory[ConnectorT, T]):
         key: Key corresponding to object in store.
         store_config: Store configuration used to reinitialize the store if
             needed.
-        evict: If True, evict the object from the store once
-            [`resolve()`][proxystore.store.base.StoreFactory.resolve]
-            is called.
         deserializer: Optional callable used to deserialize the byte string.
             If `None`, the default deserializer
             ([`deserialize()`][proxystore.serialize.deserialize]) will be used.
+        evict: If True, evict the object from the store once
+            [`resolve()`][proxystore.store.base.StoreFactory.resolve]
+            is called.
         polling_interval: Seconds to sleep between polling the store for the
             object.
         polling_timeout: Optional maximum number of seconds to poll for.
@@ -175,8 +175,8 @@ class PollingStoreFactory(StoreFactory[ConnectorT, T]):
         key: ConnectorKeyT,
         store_config: dict[str, Any],
         *,
-        evict: bool = False,
         deserializer: DeserializerT | None = None,
+        evict: bool = False,
         polling_interval: float = 1,
         polling_timeout: float | None = None,
     ) -> None:

--- a/proxystore/store/future.py
+++ b/proxystore/store/future.py
@@ -1,0 +1,53 @@
+"""Proxy-future interface implementation."""
+from __future__ import annotations
+
+from typing import Generic
+from typing import TypeVar
+
+from proxystore.proxy import Proxy
+from proxystore.store.factory import PollingStoreFactory
+from proxystore.store.types import ConnectorT
+from proxystore.store.types import SerializerT
+
+T = TypeVar('T')
+
+
+class ProxyFuture(Generic[T]):
+    """Proxy-Future interface to a [`Store`][proxystore.store.base.Store].
+
+    Args:
+        factory: Factory that can resolve the object once it is resolved.
+            This factory should block when resolving until the object is
+            available.
+        serializer: Use a custom serializer when setting the result object
+            of this future.
+    """
+
+    def __init__(
+        self,
+        factory: PollingStoreFactory[ConnectorT, T],
+        *,
+        serializer: SerializerT | None = None,
+    ) -> None:
+        self._factory = factory
+        self._serializer = serializer
+
+    def proxy(self) -> Proxy[T]:
+        """Create a proxy which will resolve to the result of this future."""
+        return Proxy(self._factory)
+
+    def result(self) -> T:
+        """Get the result object of this future."""
+        return self._factory.resolve()
+
+    def set_result(self, obj: T) -> None:
+        """Set the result object of this future.
+
+        Args:
+            obj: Result object.
+        """
+        self._factory.get_store()._set(
+            self._factory.key,
+            obj,
+            serializer=self._serializer,
+        )

--- a/tests/store/factory_test.py
+++ b/tests/store/factory_test.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from proxystore.connectors.local import LocalConnector
+from proxystore.serialize import deserialize
+from proxystore.serialize import serialize
+from proxystore.store import Store
+from proxystore.store import store_registration
+from proxystore.store.exceptions import ProxyResolveMissingKeyError
+from proxystore.store.factory import PollingStoreFactory
+
+FactoryT = PollingStoreFactory[LocalConnector, str]
+
+
+def test_polling_store_factory_resolve() -> None:
+    with Store('polling-store-factory-resolve', LocalConnector()) as store:
+        with store_registration(store):
+            value = 'test-value'
+            key = store.put(value)
+            factory: FactoryT = PollingStoreFactory(
+                key=key,
+                store_config=store.config(),
+            )
+            assert factory.resolve() == value
+            assert factory() == value
+
+
+def test_polling_store_factory_evict() -> None:
+    with Store('polling-store-factory-evict', LocalConnector()) as store:
+        with store_registration(store):
+            value = 'test-value'
+            key = store.put(value)
+            factory: FactoryT = PollingStoreFactory(
+                key=key,
+                store_config=store.config(),
+                evict=True,
+            )
+            assert factory.resolve() == value
+            assert not store.exists(key)
+
+
+def test_polling_store_factory_metrics() -> None:
+    with Store(
+        'polling-store-factory-metrics',
+        LocalConnector(),
+        metrics=True,
+    ) as store:
+        with store_registration(store):
+            value = 'test-value'
+            key = store.put(value)
+            factory: FactoryT = PollingStoreFactory(
+                key=key,
+                store_config=store.config(),
+            )
+            assert factory.resolve() == value
+
+            assert store.metrics is not None
+            metrics = store.metrics.get_metrics(key)
+            assert metrics is not None
+            assert 'factory.polling_resolve' in metrics.times
+
+
+def test_polling_store_factory_timeout() -> None:
+    with Store('polling-store-factory-timeout', LocalConnector()) as store:
+        with store_registration(store):
+            key = store.connector.new_key()
+            factory: FactoryT = PollingStoreFactory(
+                key=key,
+                store_config=store.config(),
+                evict=True,
+                polling_interval=0.001,
+                polling_timeout=0.002,
+            )
+            with pytest.raises(ProxyResolveMissingKeyError):
+                factory.resolve()
+
+
+def test_polling_store_factory_serialize() -> None:
+    with Store('polling-store-factory-serialize', LocalConnector()) as store:
+        with store_registration(store):
+            value = 'test-value'
+            key = store.put(value)
+            factory: FactoryT = PollingStoreFactory(
+                key=key,
+                store_config=store.config(),
+            )
+            factory = deserialize(serialize(factory))
+            assert factory.resolve() == value
+            assert factory() == value

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import threading
 from typing import Any
 from unittest import mock
 
 import pytest
 
 from proxystore.connectors.local import LocalConnector
+from proxystore.proxy import Proxy
 from proxystore.store import Store
+from proxystore.store.future import ProxyFuture
 
 
 def test_negative_cache_size() -> None:
@@ -135,3 +138,42 @@ def test_set_custom_serializer(store: Store[LocalConnector]) -> None:
 
     with pytest.raises(TypeError, match='bytes'):
         store._set(key, 'test_value', serializer=lambda s: s)
+
+
+def test_future(store: Store[LocalConnector]) -> None:
+    future: ProxyFuture[str] = store.future()
+    proxy = future.proxy()
+    future.set_result('test_value')
+    assert future.result() == 'test_value'
+    assert proxy == 'test_value'
+
+
+def test_future_in_threads(store: Store[LocalConnector]) -> None:
+    future: ProxyFuture[str] = store.future()
+
+    def _foo(
+        future: ProxyFuture[str],
+        barrier: threading.Barrier,
+    ) -> None:
+        future.set_result('test_value')
+        barrier.wait()
+
+    def _bar(value: Proxy[str], barrier: threading.Barrier) -> None:
+        barrier.wait()
+        assert value == 'test_value'
+
+    barrier = threading.Barrier(2, timeout=5)
+    t_foo = threading.Thread(target=_foo, args=(future, barrier))
+    t_bar = threading.Thread(target=_bar, args=(future.proxy(), barrier))
+
+    t_bar.start()
+    t_foo.start()
+
+    t_foo.join()
+    t_bar.join()
+
+
+def test_future_bad_connector_type(store: Store[LocalConnector]) -> None:
+    with mock.patch.object(store, 'connector', object()):
+        with pytest.raises(NotImplementedError, match='DeferrableConnector'):
+            store.future()

--- a/tests/store/store_metrics_test.py
+++ b/tests/store/store_metrics_test.py
@@ -30,6 +30,7 @@ def test_store_single_key_operations(store: Store[FileConnector]) -> None:
     assert store.get(key) == value
     assert store.get(key) == value
     assert store.exists(key)
+    store._set(key, value)
     store.evict(key)
 
     assert store.metrics is not None
@@ -39,6 +40,7 @@ def test_store_single_key_operations(store: Store[FileConnector]) -> None:
     size = len(serialize(value))
     assert key_metrics.attributes['store.get.object_size'] == size
     assert key_metrics.attributes['store.put.object_size'] == size
+    assert key_metrics.attributes['store.set.object_size'] == size
 
     assert key_metrics.counters['store.get.cache_hits'] == 1
     assert key_metrics.counters['store.get.cache_misses'] == 1
@@ -55,6 +57,10 @@ def test_store_single_key_operations(store: Store[FileConnector]) -> None:
 
     assert key_metrics.times['store.put'].count == 1
     assert key_metrics.times['store.put.connector'].count == 1
+    assert key_metrics.times['store.put.serialize'].count == 1
+
+    assert key_metrics.times['store.set'].count == 1
+    assert key_metrics.times['store.set.connector'].count == 1
     assert key_metrics.times['store.put.serialize'].count == 1
 
     proxy = store.proxy(value)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

This PR adds the `ProxyFuture` interface and `Store.future()` method for creating a `ProxyFuture` instance. The `ProxyFuture` interface exposes two primary methods: `set_result()` and `proxy()`. A data producer uses `set_result()` to set the result of a future, and `proxy()` will produce a `Proxy` which will block on the resolve of the target object until the data producer has called `set_result()`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #303

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
