### PR TITLE
Remove unused parameter `metrics` to `StoreFactory`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -528,7 +528,6 @@ class Store(Generic[ConnectorT]):
                 store_config=self.config(),
                 deserializer=deserializer,
                 evict=evict,
-                metrics=self.metrics is not None,
             )
             proxy = Proxy(factory)
 
@@ -677,7 +676,6 @@ class Store(Generic[ConnectorT]):
             store_config=self.config(),
             deserializer=deserializer,
             evict=evict,
-            metrics=self.metrics is not None,
         )
         logger.debug(f'Store(name="{self.name}"): PROXY_FROM_KEY {key}')
         return Proxy(factory)

--- a/proxystore/store/factory.py
+++ b/proxystore/store/factory.py
@@ -51,7 +51,6 @@ class StoreFactory(Generic[ConnectorT, T]):
         deserializer: Optional callable used to deserialize the byte string.
             If `None`, the default deserializer
             ([`deserialize()`][proxystore.serialize.deserialize]) will be used.
-        metrics: Enable recording operation metrics.
     """
 
     def __init__(
@@ -61,13 +60,11 @@ class StoreFactory(Generic[ConnectorT, T]):
         *,
         evict: bool = False,
         deserializer: DeserializerT | None = None,
-        metrics: bool = False,
     ) -> None:
         self.key = key
         self.store_config = store_config
         self.evict = evict
         self.deserializer = deserializer
-        self.metrics = metrics
 
         # The following are not included when a factory is serialized
         # because they are specific to that instance of the factory


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The `metrics` parameter of the `StoreFactory` is not used anywhere (the `StoreFactory` justs gets the `metrics` attribute of the `Store` directly) so this parameter can be removed.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #411

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [x] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
