### PR TITLE
Improve propagation of errors in endpoint route handlers and the `EndpointConnector`

### DIFF
--- a/proxystore/connectors/endpoint.py
+++ b/proxystore/connectors/endpoint.py
@@ -116,8 +116,10 @@ class EndpointConnector:
         if found_endpoint is None:
             self._session.close()
             raise EndpointConnectorError(
-                'Failed to find endpoint configuration matching one of the '
-                'provided endpoint UUIDs.',
+                'Failed to find an endpoint configuration matching one of the '
+                'provided endpoint UUIDs, or an endpoint configuration was '
+                'found but the endpoint could not be connected to. '
+                'Enable debug level logging for more more details.',
             )
         self.endpoint_uuid: uuid.UUID = uuid.UUID(found_endpoint.uuid)
         self.endpoint_host: str | None = found_endpoint.host

--- a/proxystore/endpoint/client.py
+++ b/proxystore/endpoint/client.py
@@ -119,7 +119,9 @@ def get(
         stream=True,
     )
 
-    if response.status_code == 400:
+    # Status code 404 is only returned if there's no data associated with the
+    # provided key.
+    if response.status_code == 404:
         return None
 
     if not response.ok:

--- a/tests/connectors/endpoint_test.py
+++ b/tests/connectors/endpoint_test.py
@@ -50,7 +50,7 @@ def test_bad_responses(endpoint_connector) -> None:
     connector = EndpointConnector.from_config(endpoint_connector.config())
 
     response = requests.Response()
-    response.status_code = 400
+    response.status_code = 404
 
     with mock.patch('requests.Session.get', return_value=response):
         key = connector.put(b'value')

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -95,7 +95,7 @@ async def test_get_request(quart_app) -> None:
         '/get',
         query_string={'key': 'missing-key'},
     )
-    assert get_response.status_code == 400
+    assert get_response.status_code == 404
 
 
 @pytest.mark.asyncio()
@@ -272,19 +272,19 @@ async def test_unknown_endpoint_uuid(quart_app) -> None:
             'evict',
             query_string={'key': 'my-key', 'endpoint': unknown_uuid},
         )
-        assert evict_response.status_code == 400
+        assert evict_response.status_code == 500
 
         exists_response = await client.get(
             'exists',
             query_string={'key': 'my-key', 'endpoint': unknown_uuid},
         )
-        assert exists_response.status_code == 400
+        assert exists_response.status_code == 500
 
         get_response = await client.get(
             'get',
             query_string={'key': 'my-key', 'endpoint': unknown_uuid},
         )
-        assert get_response.status_code == 400
+        assert get_response.status_code == 500
 
         data = randbytes(100)
         set_response = await client.post(
@@ -293,7 +293,7 @@ async def test_unknown_endpoint_uuid(quart_app) -> None:
             query_string={'key': 'my-key', 'endpoint': unknown_uuid},
             data=data,
         )
-        assert set_response.status_code == 400
+        assert set_response.status_code == 500
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Previously, all errors in the endpoint serving routes returned HTTP status code 400. This is misleading so the error codes have been updated to correctly reflect the type of error. Additionally, the endpoint routes are now included in the API reference with their response types.

The `proxystore.endpoint.client.get()` function caught 400 errors and assumed that meant the data requested was not available. This is not always the case, so that function was updated to only catch 404 errors and raise all other error code.

An error when the `EndpointConnector` fails to find its local endpoint was also improved.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #413

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
