### PR TITLE
Add NAT type checks and tools for endpoint peering

### DIFF
--- a/docs/guides/endpoints-debugging.md
+++ b/docs/guides/endpoints-debugging.md
@@ -90,6 +90,38 @@ INFO: Object exists: False
 
 You will get an error if the peer connection fails. For example:
 ```bash
-ERROR: Endpoint returned HTTP error code 400. Request to peer bbbbab4d-c73a-44ee-a316-58ec8857e83a failed: ...
+ERROR: Endpoint returned HTTP error code 500. Request to peer bbbbab4d-c73a-44ee-a316-58ec8857e83a failed: ...
 ```
 If this happens, check the logs for both endpoints for further error messages.
+Peer requests typically fail for two reasons:
+
+1. One of the endpoints is not running (e.g., an endpoint crashed) or is not
+   connected to the relay server.
+2. One of the endpoints is behind a symmetric NAT. The NAT traversal
+   techniques used to establish peer-to-peer connections between endpoints
+   are not reliable across symmetric NATs or poorly behaved legacy NATs.
+
+### Check Peer-to-Peer Compatibility
+After ensuring both endpoints are running and connected to the relay server,
+you can check the NAT compatibility in two ways.
+
+1. Endpoints will attempt to discover and log the NAT type on startup, so check
+   the logs to see if this could be the reason.
+   ```
+   INFO  (proxystore.p2p.nat) :: Checking NAT type. This may take a moment...
+   INFO  (proxystore.p2p.nat) :: NAT Type:       Full-cone NAT
+   INFO  (proxystore.p2p.nat) :: External IP:    <IP ADDRESS>
+   INFO  (proxystore.p2p.nat) :: External Port:  <PORT>
+   INFO  (proxystore.p2p.nat) :: NAT traversal for peer-to-peer methods (e.g., hole-punching) is likely to work. (NAT traversal does not work reliably across symmetric NATs or poorly behaved legacy NATs.)
+   ```
+2. Use the
+   [`proxystore-endpoint check-nat`](../api/cli.md#proxystore-endpoint-check-nat)
+   command to discover your NAT type.
+   ```
+   $ proxystore-endpoint check-nat
+   INFO: Checking NAT type. This may take a moment...
+   INFO: NAT Type:       Full-cone NAT
+   INFO: External IP:    <IP ADDRESS>
+   INFO: External Port:  <PORT>
+   INFO: NAT traversal for peer-to-peer methods (e.g., hole-punching) is likely to work. (NAT traversal does not work reliably across symmetric NATs or poorly behaved legacy NATs.)
+   ```

--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -55,6 +55,15 @@ the request along and facilitate returning the response back to the client.
 
 ## Endpoint CLI
 
+!!! warning
+
+    Peer-to-peer connections between two Endpoints are not supported on
+    all network types. The NAT traversal techniques used to establish
+    peer-to-peer connections are unreliable across symmetric NATs or poorly
+    behaved legacy NATs. To check the compatibility of your network, use the
+    [`proxystore-endpoint check-nat`](../api/cli.md#proxystore-endpoint-check-nat)
+    CLI tool.
+
 Endpoints can be configure and started with the
 [`proxystore-endpoint`](../../api/cli/#proxystore-endpoint)
 command. By default, an Endpoint is configured to connect to ProxyStore's

--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -22,6 +22,7 @@ from proxystore.endpoint.commands import remove_endpoint
 from proxystore.endpoint.commands import start_endpoint
 from proxystore.endpoint.commands import stop_endpoint
 from proxystore.endpoint.config import read_config
+from proxystore.p2p.nat import check_nat_and_log
 from proxystore.serialize import deserialize
 from proxystore.serialize import serialize
 from proxystore.utils.environment import home_dir
@@ -90,6 +91,25 @@ def show_help() -> None:
 def version() -> None:
     """Show the ProxyStore version."""
     click.echo(f'ProxyStore v{proxystore.__version__}')
+
+
+@cli.command(name='check-nat')
+@click.option(
+    '--host',
+    default='0.0.0.0',
+    metavar='ADDR',
+    help='Network interface address to listen on.',
+)
+@click.option(
+    '--port',
+    default=54320,
+    type=int,
+    metavar='PORT',
+    help='Port to listen on.',
+)
+def check_nat_command(host: str, port: int) -> None:
+    """Check the type of NAT you are behind."""
+    check_nat_and_log(host, port)
 
 
 @cli.command()

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -36,6 +36,7 @@ from proxystore.globus.manager import GlobusAuthManager
 from proxystore.globus.manager import NativeAppAuthManager
 from proxystore.globus.scopes import ProxyStoreRelayScopes
 from proxystore.p2p.manager import PeerManager
+from proxystore.p2p.nat import check_nat_and_log
 from proxystore.p2p.relay.client import RelayClient
 from proxystore.utils.data import chunk_bytes
 
@@ -143,6 +144,7 @@ async def _serve_async(config: EndpointConfig) -> None:
             relay_client,
             peer_channels=config.relay.peer_channels,
         )
+        check_nat_and_log()
 
     endpoint = await Endpoint(
         name=config.name,

--- a/proxystore/p2p/nat.py
+++ b/proxystore/p2p/nat.py
@@ -1,0 +1,126 @@
+"""Tools for getting the NAT type using STUN.
+
+This module is a wrapper around the tools provided by
+[pystun3](https://github.com/talkiq/pystun3){target=_blank}.
+"""
+from __future__ import annotations
+
+import enum
+import socket
+from typing import NamedTuple
+
+import stun
+
+# Selected from the following sources:
+#   https://github.com/pradt2/always-online-stun
+#   https://gist.github.com/mondain/b0ec1cf5f60ae726202e
+_STUN_SERVERS = (
+    'stun.l.google.com:19302',
+    'stun1.l.google.com:19302',
+    'stun2.l.google.com:19302',
+    'stun3.l.google.com:19302',
+    'stun4.l.google.com:19302',
+    'stun.ideasip.com:3478',
+    'stun.voiparound.com:3478',
+    'stun.voipstunt.com:3478',
+)
+
+
+class NatType(enum.Enum):
+    """NAT type.
+
+    Learn more about NAT types at
+    https://en.wikipedia.org/wiki/Network_address_translation.
+    """
+
+    OpenInternet = 'Open Internet (No NAT)'
+    """Host is not behind a NAT."""
+    FullCone = 'Full-cone NAT'
+    """Host is behind a full-cone NAT."""
+    SymmetricUDPFirewall = 'Symmetric UDP Firewall NAT'
+    """Host is behind a symmetric UDP firewall."""
+    RestrictedCone = 'Restricted-cone NAT'
+    """Host is behind a restricted-cone NAT."""
+    PortRestrictedCone = 'Port Restricted-cone NAT'
+    """Host is behind a port-restricted-cone NAT."""
+    Symmetric = 'Symmetric NAT'
+    """Host is behind a symmetric NAT."""
+
+    @classmethod
+    def _from_str(cls, nat_type: str) -> NatType:
+        if nat_type == stun.Blocked:
+            raise RuntimeError(
+                'No response from a STUN server. Unable to determine NAT type.',
+            )
+        elif nat_type == stun.ChangedAddressError:
+            raise RuntimeError('Address changed during NAT type check.')
+
+        return {
+            stun.OpenInternet: cls.OpenInternet,
+            stun.FullCone: cls.FullCone,
+            stun.SymmetricUDPFirewall: cls.SymmetricUDPFirewall,
+            stun.RestricNAT: cls.RestrictedCone,
+            stun.RestricPortNAT: cls.PortRestrictedCone,
+            stun.SymmetricNAT: cls.Symmetric,
+        }[nat_type]
+
+
+class Result(NamedTuple):
+    """Result of NAT type check.
+
+    Attributes:
+        nat_type: Enum type of the found NAT this host is behind.
+        external_ip: External IP of this host.
+        external_port: External port of this host.
+    """
+
+    nat_type: NatType
+    external_ip: str
+    external_port: int
+
+
+def check_nat(
+    source_ip: str = '0.0.0.0',
+    source_port: int = 54320,
+) -> Result:
+    """Check the NAT type this host is behind.
+
+    This function uses the STUN protocol (RFC 3489) to discover the
+    presence and type of the NAT between this host and the open Internet.
+
+    Returns:
+        Result containing the NAT type and external IP/port of the host.
+
+    Raises:
+        RuntimeError: if no STUN servers return a response or if the hosts
+            IP or port changed during the STUN process.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.settimeout(2)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind((source_ip, source_port))
+
+        for stun_server in _STUN_SERVERS:
+            stun_server_address, stun_server_port = stun_server.split(':')
+
+            _nat_type, external = stun.get_nat_type(
+                s,
+                source_ip,
+                source_port,
+                stun_host=stun_server_address,
+                stun_port=int(stun_server_port),
+            )
+
+            try:
+                nat_type = NatType._from_str(_nat_type)
+            except RuntimeError:
+                pass
+            else:
+                break
+        else:
+            raise RuntimeError(
+                'No STUN servers returned a valid response. '
+                'Enable debug level logging for more details.',
+            )
+
+    return Result(nat_type, external['ExternalIP'], external['ExternalPort'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ endpoints = [
     "aiosqlite",
     "uvicorn[standard]",
     "psutil",
+    "pystun3",
     "python-daemon",
     "quart>=0.18.0",
     "requests>=2.27.1",

--- a/tests/p2p/nat_test.py
+++ b/tests/p2p/nat_test.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import stun
+
+from proxystore.p2p.nat import check_nat
+from proxystore.p2p.nat import NatType
+from testing.utils import open_port
+
+
+def test_nat_type() -> None:
+    assert NatType._from_str(stun.FullCone) == NatType.FullCone
+
+    with pytest.raises(RuntimeError, match='No response from a STUN server.'):
+        NatType._from_str(stun.Blocked)
+
+    with pytest.raises(
+        RuntimeError,
+        match='Address changed during NAT type check.',
+    ):
+        NatType._from_str(stun.ChangedAddressError)
+
+
+def test_check_nat() -> None:
+    external = {'ExternalIP': '192.168.1.1', 'ExternalPort': 1234}
+
+    with mock.patch(
+        'stun.get_nat_type',
+        return_value=(stun.RestricNAT, external),
+    ):
+        result = check_nat(source_port=open_port())
+
+    assert result.nat_type == NatType.RestrictedCone
+    assert result.external_ip == external['ExternalIP']
+    assert result.external_port == external['ExternalPort']
+
+
+def test_check_nat_failure() -> None:
+    external = {'ExternalIP': '192.168.1.1', 'ExternalPort': 1234}
+
+    with mock.patch(
+        'stun.get_nat_type',
+        return_value=(stun.Blocked, external),
+    ):
+        with pytest.raises(RuntimeError, match='No STUN servers returned'):
+            check_nat(source_port=open_port())


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

This PR adds the `check_nat` utility function which will detect the presence of a NAT and its type using STUN. A CLI tool, `proxystore-endpoint check-nat`, has been added to help users debug endpoint peering problems. Endpoints will also check the NAT type and log it on start up.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #417

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests, and tested the CLI/endpoint serving locally.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
