### PR TITLE
Switch from dataclasses to Pydantic BaseModels for configuration classes

### DIFF
--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -5,6 +5,7 @@ import os
 import re
 import uuid
 from typing import Any
+from typing import Dict
 from typing import Literal
 from typing import Optional
 
@@ -31,7 +32,7 @@ class EndpointRelayAuthConfig(BaseModel):
     """
 
     method: Optional[Literal['globus']] = None  # noqa: UP007
-    kwargs: dict[str, Any] = Field(default_factory=dict)
+    kwargs: Dict[str, Any] = Field(default_factory=dict)  # noqa: UP006
 
 
 class EndpointRelayConfig(BaseModel):

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -76,7 +76,7 @@ class EndpointRelayConfig(BaseModel):
 class EndpointStorageConfig(BaseModel):
     """Endpoint data storage configuration.
 
-    Args:
+    Attributes:
         database_path: Optional path to SQLite database file that will be used
             for storing endpoint data. If `None`, data will only be stored
             in-memory.

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -1,18 +1,20 @@
 """Endpoint configuration."""
 from __future__ import annotations
 
-import dataclasses
 import os
 import re
 import uuid
 from typing import Any
-from typing import Dict
 from typing import Literal
 from typing import Optional
 
-import tosholi
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import field_validator
 
 from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
+from proxystore.utils.config import dump
+from proxystore.utils.config import load
 
 ENDPOINT_CONFIG_FILE = 'config.toml'
 ENDPOINT_DATABASE_FILE = 'blobs.db'
@@ -20,8 +22,7 @@ ENDPOINT_LOG_FILE = 'log.txt'
 ENDPOINT_PID_FILE = 'daemon.pid'
 
 
-@dataclasses.dataclass
-class EndpointRelayAuthConfig:
+class EndpointRelayAuthConfig(BaseModel):
     """Endpoint relay server authentication configuration.
 
     Attributes:
@@ -30,13 +31,10 @@ class EndpointRelayAuthConfig:
     """
 
     method: Optional[Literal['globus']] = None  # noqa: UP007
-    kwargs: Dict[str, Any] = dataclasses.field(  # noqa: UP006
-        default_factory=dict,
-    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclasses.dataclass
-class EndpointRelayConfig:
+class EndpointRelayConfig(BaseModel):
     """Endpoint relay server configuration.
 
     Attributes:
@@ -49,26 +47,32 @@ class EndpointRelayConfig:
     """
 
     address: Optional[str] = None  # noqa: UP007
-    auth: EndpointRelayAuthConfig = dataclasses.field(
+    auth: EndpointRelayAuthConfig = Field(
         default_factory=EndpointRelayAuthConfig,
     )
     peer_channels: int = 1
     verify_certificate: bool = True
 
-    def __post_init__(self) -> None:
-        if self.address is not None and not (
-            self.address.startswith('ws://')
-            or self.address.startswith('wss://')
+    @field_validator('address')
+    @classmethod
+    def _address_validator(cls, v: str | None) -> str | None:
+        if v is not None and not (
+            v.startswith('ws://') or v.startswith('wss://')
         ):
             raise ValueError(
                 'Server must start with ws:// or wss://.',
             )
-        if self.peer_channels < 1:
+        return v
+
+    @field_validator('peer_channels')
+    @classmethod
+    def _peer_channels_validator(cls, v: int) -> int:
+        if v < 1:
             raise ValueError('Peer channels must be >= 1.')
+        return v
 
 
-@dataclasses.dataclass
-class EndpointStorageConfig:
+class EndpointStorageConfig(BaseModel):
     """Endpoint data storage configuration.
 
     Args:
@@ -81,15 +85,17 @@ class EndpointStorageConfig:
     database_path: Optional[str] = None  # noqa: UP007
     max_object_size: Optional[int] = MAX_OBJECT_SIZE_DEFAULT  # noqa: UP007
 
-    def __post_init__(self) -> None:
-        if self.max_object_size is not None and self.max_object_size < 1:
+    @field_validator('max_object_size')
+    @classmethod
+    def _max_object_size_validator(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
             raise ValueError(
                 'Max object size must be None or greater than zero.',
             )
+        return v
 
 
-@dataclasses.dataclass
-class EndpointConfig:
+class EndpointConfig(BaseModel):
     """Endpoint configuration.
 
     Attributes:
@@ -108,29 +114,42 @@ class EndpointConfig:
 
     name: str
     uuid: str
-    host: Optional[str]  # noqa: UP007
     port: int
-    relay: EndpointRelayConfig = dataclasses.field(
+    host: Optional[str] = None  # noqa: UP007
+    relay: EndpointRelayConfig = Field(
         default_factory=EndpointRelayConfig,
     )
-    storage: EndpointStorageConfig = dataclasses.field(
+    storage: EndpointStorageConfig = Field(
         default_factory=EndpointStorageConfig,
     )
 
-    def __post_init__(self) -> None:
-        if not validate_name(self.name):
+    @field_validator('name')
+    @classmethod
+    def _name_validator(cls, v: str) -> str:
+        if not validate_name(v):
             raise ValueError(
                 'Name must only contain alphanumeric characters, dashes, and '
-                f' underscores. Got {self.name}.',
+                f' underscores. Got {v}.',
             )
+        return v
+
+    @field_validator('uuid')
+    @classmethod
+    def _uuid_validator(cls, v: str) -> str:
         try:
-            uuid.UUID(self.uuid, version=4)
+            uuid.UUID(v, version=4)
         except ValueError:
             raise ValueError(
-                f'{self.uuid} is not a valid UUID4 string.',
+                f'"{v}" is not a valid UUID4 string.',
             ) from None
-        if self.port < 1 or self.port > 65535:
+        return v
+
+    @field_validator('port')
+    @classmethod
+    def _port_validator(cls, v: int) -> int:
+        if v < 1 or v > 65535:
             raise ValueError('Port must be in range [1, 65535].')
+        return v
 
 
 def get_configs(proxystore_dir: str) -> list[EndpointConfig]:
@@ -205,7 +224,7 @@ def read_config(endpoint_dir: str) -> EndpointConfig:
     if os.path.exists(path):
         with open(path, 'rb') as f:
             try:
-                return tosholi.load(EndpointConfig, f)
+                return load(EndpointConfig, f)
             except Exception as e:
                 raise ValueError(
                     f'Unable to parse ({path}): {e!s}.',
@@ -232,4 +251,4 @@ def write_config(cfg: EndpointConfig, endpoint_dir: str) -> None:
     os.makedirs(endpoint_dir, exist_ok=True)
     path = os.path.join(endpoint_dir, ENDPOINT_CONFIG_FILE)
     with open(path, 'wb') as f:
-        tosholi.dump(cfg, f)
+        dump(cfg, f)

--- a/proxystore/p2p/relay/config.py
+++ b/proxystore/p2p/relay/config.py
@@ -1,12 +1,10 @@
 """Relay server configuration file parsing."""
 from __future__ import annotations
 
-import dataclasses
 import logging
 import pathlib
 import sys
 from typing import Any
-from typing import Dict
 from typing import Literal
 from typing import Optional
 from typing import Union
@@ -16,11 +14,13 @@ if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
-import tosholi
+from pydantic import BaseModel
+from pydantic import Field
+
+from proxystore.utils.config import load
 
 
-@dataclasses.dataclass
-class RelayAuthConfig:
+class RelayAuthConfig(BaseModel):
     """Relay authentication configuration.
 
     Attributes:
@@ -31,14 +31,10 @@ class RelayAuthConfig:
     """
 
     method: Optional[Literal['globus']] = None  # noqa: UP007
-    kwargs: Dict[str, Any] = dataclasses.field(  # noqa: UP006
-        default_factory=dict,
-        repr=False,
-    )
+    kwargs: dict[str, Any] = Field(default_factory=dict, repr=False)
 
 
-@dataclasses.dataclass
-class RelayLoggingConfig:
+class RelayLoggingConfig(BaseModel):
     """Relay logging configuration.
 
     Attributes:
@@ -61,8 +57,7 @@ class RelayLoggingConfig:
     current_client_limit: Optional[int] = 32  # noqa: UP007
 
 
-@dataclasses.dataclass
-class RelayServingConfig:
+class RelayServingConfig(BaseModel):
     """Relay serving configuration.
 
     Attributes:
@@ -81,10 +76,8 @@ class RelayServingConfig:
     port: int = 8700
     certfile: Optional[str] = None  # noqa: UP007
     keyfile: Optional[str] = None  # noqa: UP007
-    auth: RelayAuthConfig = dataclasses.field(default_factory=RelayAuthConfig)
-    logging: RelayLoggingConfig = dataclasses.field(
-        default_factory=RelayLoggingConfig,
-    )
+    auth: RelayAuthConfig = Field(default_factory=RelayAuthConfig)
+    logging: RelayLoggingConfig = Field(default_factory=RelayLoggingConfig)
     max_message_bytes: Optional[int] = None  # noqa: UP007
 
     @classmethod
@@ -150,4 +143,4 @@ class RelayServingConfig:
             ```
         """
         with open(filepath, 'rb') as f:
-            return tosholi.load(cls, f)
+            return load(cls, f)

--- a/proxystore/p2p/relay/config.py
+++ b/proxystore/p2p/relay/config.py
@@ -5,6 +5,7 @@ import logging
 import pathlib
 import sys
 from typing import Any
+from typing import Dict
 from typing import Literal
 from typing import Optional
 from typing import Union
@@ -31,7 +32,10 @@ class RelayAuthConfig(BaseModel):
     """
 
     method: Optional[Literal['globus']] = None  # noqa: UP007
-    kwargs: dict[str, Any] = Field(default_factory=dict, repr=False)
+    kwargs: Dict[str, Any] = Field(  # noqa: UP006
+        default_factory=dict,
+        repr=False,
+    )
 
 
 class RelayLoggingConfig(BaseModel):

--- a/proxystore/utils/config.py
+++ b/proxystore/utils/config.py
@@ -1,0 +1,75 @@
+"""Read and write TOML config files using Pydantic BaseClasses."""
+from __future__ import annotations
+
+import sys
+from typing import BinaryIO
+from typing import TypeVar
+
+import tomli_w
+from pydantic import BaseModel
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    import tomllib
+else:  # pragma: <3.11 cover
+    import tomli as tomllib
+
+
+BaseModelT = TypeVar('BaseModelT', bound=BaseModel)
+
+
+def dump(
+    model: BaseModel,
+    fp: BinaryIO,
+    *,
+    exclude_none: bool = True,
+) -> None:
+    """Serialize data class as a TOML formatted stream to file-like object.
+
+    Args:
+        model: Config model instance to write.
+        fp: File-like bytes stream to write to.
+        exclude_none: Skip writing none attributes.
+    """
+    data_dict = model.model_dump(exclude_none=exclude_none)
+    tomli_w.dump(data_dict, fp)
+
+
+def dumps(model: BaseModel, *, exclude_none: bool = True) -> str:
+    """Serialize data class to a TOML formatted string.
+
+    Args:
+        model: Config model instance to write.
+        exclude_none: Skip writing none attributes.
+
+    Returns:
+        TOML string of data class.
+    """
+    data_dict = model.model_dump(exclude_none=exclude_none)
+    return tomli_w.dumps(data_dict)
+
+
+def load(model: type[BaseModelT], fp: BinaryIO) -> BaseModelT:
+    """Parse TOML from a binary file to a data class.
+
+    Args:
+        model: Config model type to parse TOML using.
+        fp: File-like bytes stream to read in.
+
+    Returns:
+        Model initialized from TOML file.
+    """
+    return loads(model, fp.read().decode())
+
+
+def loads(model: type[BaseModelT], data: str) -> BaseModelT:
+    """Parse TOML string to data class.
+
+    Args:
+        model: Config model type to parse TOML using.
+        data: TOML string to parse.
+
+    Returns:
+        Model initialized from TOML file.
+    """
+    data = tomllib.loads(data)
+    return model.model_validate(data, strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,13 @@ endpoints = [
     "aiosqlite",
     "uvicorn[standard]",
     "psutil",
+    "pydantic>=2.0.0",
     "pystun3",
     "python-daemon",
     "quart>=0.18.0",
     "requests>=2.27.1",
-    "tosholi",
+    "tomli ; python_version<'3.11'",
+    "tomli-w",
     "websockets>=10.0",
 ]
 extensions = [

--- a/tests/endpoint/config_test.py
+++ b/tests/endpoint/config_test.py
@@ -127,10 +127,10 @@ def test_validate_config(bad_cfg: Any, valid: bool) -> None:
     options.update(bad_cfg)
 
     if valid:
-        EndpointConfig(**options)  # type: ignore
+        EndpointConfig(**options)
     else:
         with pytest.raises(ValueError):
-            EndpointConfig(**options)  # type: ignore
+            EndpointConfig(**options)
 
 
 @pytest.mark.parametrize(

--- a/tests/p2p/relay/authenticate_test.py
+++ b/tests/p2p/relay/authenticate_test.py
@@ -116,7 +116,10 @@ def test_get_authenticator() -> None:
 
 
 def test_get_authenticator_unknown() -> None:
-    config = RelayAuthConfig(method='test')  # type: ignore[arg-type]
+    config = RelayAuthConfig(method='globus')
+    # Modify attribute after construction to avoid Pydantic checking string
+    # literal type.
+    config.method = 'test'  # type: ignore[assignment]
     with pytest.raises(ValueError, match='Unknown authentication method'):
         get_authenticator(config)
 

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pathlib
+from typing import List
+
+from pydantic import BaseModel
+
+from proxystore.utils.config import dump
+from proxystore.utils.config import dumps
+from proxystore.utils.config import load
+from proxystore.utils.config import loads
+
+
+class _Subsection(BaseModel):
+    field1: float
+    field2: str
+
+
+class _Section(BaseModel):
+    subsection: _Subsection
+    values: List[int]  # noqa: UP006
+
+
+class _Config(BaseModel):
+    option1: bool
+    option2: bool
+    section: _Section
+
+
+TEST_CONFIG = _Config(
+    option1=True,
+    option2=False,
+    section=_Section(
+        subsection=_Subsection(field1=42.0, field2='test'),
+        values=[1, 2, 3],
+    ),
+)
+TEST_CONFIG_REPR = """\
+option1 = true
+option2 = false
+
+[section]
+values = [
+    1,
+    2,
+    3,
+]
+
+[section.subsection]
+field1 = 42.0
+field2 = "test"
+"""
+
+
+def test_dump(tmp_path: pathlib.Path) -> None:
+    filepath = tmp_path / 'test.toml'
+
+    with open(filepath, 'wb') as f:
+        dump(TEST_CONFIG, f)
+
+    with open(filepath) as f:
+        assert f.read() == TEST_CONFIG_REPR
+
+
+def test_dump_drops_none_values(tmp_path: pathlib.Path) -> None:
+    filepath = tmp_path / 'test.toml'
+
+    class _Config(BaseModel):
+        field1: str | None = None
+        field2: str = 'abc'
+
+    with open(filepath, 'wb') as fw:
+        dump(_Config(), fw)
+
+    with open(filepath) as fr:
+        data = fr.read()
+
+    assert 'field1' not in data
+    assert 'field2' in data
+
+
+def test_dumps() -> None:
+    assert dumps(TEST_CONFIG) == TEST_CONFIG_REPR
+
+
+def test_load(tmp_path: pathlib.Path) -> None:
+    filepath = tmp_path / 'test.toml'
+
+    with open(filepath, 'w') as f:
+        f.write(TEST_CONFIG_REPR)
+
+    with open(filepath, 'rb') as f:
+        assert load(_Config, f) == TEST_CONFIG
+
+
+def test_loads() -> None:
+    assert loads(_Config, TEST_CONFIG_REPR) == TEST_CONFIG

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 from typing import List
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -66,7 +67,7 @@ def test_dump_drops_none_values(tmp_path: pathlib.Path) -> None:
     filepath = tmp_path / 'test.toml'
 
     class _Config(BaseModel):
-        field1: str | None = None
+        field1: Optional[str] = None  # noqa: UP007
         field2: str = 'abc'
 
     with open(filepath, 'wb') as fw:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Switches configuration models from Python dataclasses to Pydantic BaseModels. Since dataclasses don't provide type validation, we previously used `tosholi` to do type validation, but Pydantic provides better type validation support and better maintenance. Because `tosholi` is no longer needed, I've added the `proxystore.utils.config` module with TOML configuration file loading/dumping.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #443

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [x] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests where relevant and updated old unit tests. Also verified that endpoint config loading worked from the CLI with new and old configs.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
