### PR TITLE
Add the `RedisPublisher` and `RedisSubscriber` for use with ProxyStore streams

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ plugins:
             - https://websockets.readthedocs.io/en/stable/objects.inv
             - https://requests.readthedocs.io/en/latest/objects.inv
             - https://extensions.proxystore.dev/main/objects.inv
+            - https://redis-py.readthedocs.io/en/stable/objects.inv
           options:
             docstring_section_style: list
             docstring_style: google

--- a/proxystore/pubsub/redis.py
+++ b/proxystore/pubsub/redis.py
@@ -1,0 +1,160 @@
+"""Redis pub/sub interface."""
+from __future__ import annotations
+
+import sys
+from typing import Any
+from typing import Sequence
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+import redis
+
+_CLOSED_SENTINAL = b'<queue-publisher-closed-topic>'
+
+
+class RedisPublisher:
+    """Publisher interface to Redis pub/sub.
+
+    Args:
+        hostname: Redis server hostname.
+        port: Redis server port.
+        topics: Sequence or set of all topics that might be published to.
+        default_topic: Default topic to publish messages to. Must be contained
+            in `topics`.
+        kwargs: Extra keyword arguments to pass to
+            [`redis.Redis()`][redis.Redis].
+
+    Raises:
+        ValueError: if `default_topic` is not in `topics`.
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        *,
+        topics: Sequence[str] | set[str] = ('default',),
+        default_topic: str = 'default',
+        **kwargs: Any,
+    ) -> None:
+        if default_topic not in topics:
+            raise ValueError(
+                f'Default topic "{default_topic}" is not in the list of '
+                f'all topic: {topics}.',
+            )
+        self._topics = topics
+        self._default_topic = default_topic
+        self._redis_client = redis.StrictRedis(
+            host=hostname,
+            port=port,
+            **kwargs,
+        )
+
+    def close(self, *, close_topics: bool = True) -> None:
+        """Close this publisher.
+
+        This will cause a [`StopIteration`][StopIteration] exception to be
+        raised in any
+        [`RedisSubscriber`][proxystore.pubsub.redis.RedisSubscriber]
+        instances that are currently iterating on new messages from *any*
+        of the topics registered with this publisher. This behavior
+        can be altered by passing `close_topics=True`.
+
+        Args:
+            close_topics: Send an end-of-stream message to all topics
+                associated with this publisher.
+        """
+        if close_topics:
+            for topic in self._topics:
+                self._redis_client.publish(topic, _CLOSED_SENTINAL)
+        self._redis_client.close()
+
+    def send(self, message: bytes, *, topic: str | None = None) -> None:
+        """Publish a message to the stream.
+
+        Args:
+            message: Message as bytes to publish to the stream.
+            topic: Stream topic to publish to. `None` uses the default stream.
+
+        Raises:
+            ValueError: if `topic` is not in `topics` provided during
+                initialization.
+        """
+        topic = topic if topic is not None else self._default_topic
+        if topic not in self._topics:
+            raise ValueError(f'Topic "{topic}" is unknown.')
+        self._redis_client.publish(topic, message)
+
+
+class RedisSubscriber:
+    """Subscriber interface to Redis pub/sub topic.
+
+    The subscriber protocol is an iterable object which yields objects
+    from the stream until the stream is closed.
+
+    Args:
+        hostname: Redis server hostname.
+        port: Redis server port.
+        topic: Topic or sequence of topics to subscribe to.
+        kwargs: Extra keyword arguments to pass to
+            [`redis.Redis()`][redis.Redis].
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        *,
+        topic: str | Sequence[str] = 'default',
+        **kwargs: Any,
+    ) -> None:
+        self._topic = [topic] if isinstance(topic, str) else topic
+        self._redis_client = redis.StrictRedis(
+            host=hostname,
+            port=port,
+            **kwargs,
+        )
+        self._pubsub_client = self._redis_client.pubsub()
+        self._pubsub_client.subscribe(*self._topic)
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> bytes:
+        while True:
+            message = self._pubsub_client.get_message(
+                ignore_subscribe_messages=True,
+                # The type hint from redis is "timeout: float" but the
+                # docstring and code also support None type.
+                # https://github.com/redis/redis-py/blob/0a824962e9c0f8ec1b6b9b0fc823db8ec296e580/redis/client.py#L1046
+                timeout=None,  # type: ignore[arg-type]
+            )
+            if message is None:
+                # None is returned in a few cases, such as the message
+                # beign given to a handler or when subscribe messages
+                # are ignored.
+                continue
+
+            kind = message['type']
+            data = message['data']
+
+            if (
+                kind in redis.client.PubSub.UNSUBSCRIBE_MESSAGE_TYPES
+            ):  # pragma: no cover
+                raise StopIteration
+            elif kind in redis.client.PubSub.PUBLISH_MESSAGE_TYPES:
+                if data == _CLOSED_SENTINAL:
+                    self._pubsub_client.unsubscribe()
+                    raise StopIteration
+                return data
+            else:  # pragma: no cover
+                # This case is pings and health check messages.
+                continue
+
+    def close(self) -> None:
+        """Close this subscriber."""
+        self._pubsub_client.close()
+        self._redis_client.close()

--- a/proxystore/stream.py
+++ b/proxystore/stream.py
@@ -55,7 +55,7 @@ Example:
     ```
 
     **Consumer Side**
-    ```
+    ```python
     from proxystore.connector.redis import RedisConnector
     from proxystore.pubsub.redis import RedisSubscriber
     from proxystore.store import Store

--- a/testing/mocked/redis.py
+++ b/testing/mocked/redis.py
@@ -1,14 +1,34 @@
 """Mocked classes for Redis."""
 from __future__ import annotations
 
+import queue
 from typing import Any
+from typing import TypedDict
+
+
+class Message(TypedDict):
+    """Pub/sub message type."""
+
+    pattern: bytes | None
+    type: str
+    channel: bytes
+    data: Any
 
 
 class MockStrictRedis:
     """Mock StrictRedis."""
 
-    def __init__(self, data: dict[str, Any], *args, **kwargs):
+    def __init__(
+        self,
+        data: dict[str, Any],
+        pubsub_queue: queue.Queue[Message] | None = None,
+        *args,
+        **kwargs,
+    ):
         self.data = data
+        self.pubsub_queue = (
+            queue.Queue() if pubsub_queue is None else pubsub_queue
+        )
 
     def close(self) -> None:
         """Close the client."""
@@ -42,6 +62,76 @@ class MockStrictRedis:
         for key, value in values.items():
             self.set(key, value)
 
+    def publish(self, topic: str, data: bytes) -> None:
+        """Publish a message to a topic."""
+        message = Message(
+            pattern=None,
+            type='message',
+            channel=topic.encode(),
+            data=data,
+        )
+        self.pubsub_queue.put(message)
+
+    def pubsub(self) -> MockPubSub:
+        """Create a pubsub client."""
+        return MockPubSub(self)
+
     def set(self, key: str, value: bytes) -> None:
         """Set value in MockStrictRedis."""
         self.data[key] = value
+
+
+class MockPubSub:
+    """Mock PubSub client."""
+
+    def __init__(self, redis: MockStrictRedis):
+        self.redis = redis
+        self.subscribed: set[str] = set()
+
+    def close(self) -> None:
+        """Close the pub/sub client."""
+        pass
+
+    def get_message(
+        self,
+        ignore_subscribe_messages: bool = False,
+        timeout: float | None = None,
+    ) -> Message | None:
+        """Get the next message from subscribed topics."""
+        if len(self.subscribed) == 0:  # pragma: no cover
+            raise RuntimeError('Not subscribed to any topics.')
+
+        while True:
+            message = self.redis.pubsub_queue.get(timeout=timeout)
+            if (
+                message['channel'].decode() not in self.subscribed
+            ):  # pragma: no cover
+                continue
+            if message['type'] == 'subscribe' and ignore_subscribe_messages:
+                return None
+            else:
+                return message
+
+    def subscribe(self, *topics: str) -> None:
+        """Subscribe to a topic."""
+        for topic in topics:
+            self.subscribed.add(topic)
+            message = Message(
+                pattern=None,
+                type='subscribe',
+                channel=topic.encode(),
+                data=len(self.subscribed),
+            )
+            self.redis.pubsub_queue.put(message)
+
+    def unsubscribe(self) -> None:
+        """Unsubscribe from all topics."""
+        for i, topic in enumerate(self.subscribed):
+            message = Message(
+                pattern=None,
+                type='unsubscribe',
+                channel=topic.encode(),
+                data=len(self.subscribed) - i,
+            )
+            self.redis.pubsub_queue.put(message)
+        self.subscribed = set()

--- a/testing/scripts/redis_pubsub.py
+++ b/testing/scripts/redis_pubsub.py
@@ -1,0 +1,98 @@
+"""Redis pub/sub test.
+
+1. Start a Redis server.
+
+   $ redis-server --protected-mode no --save "" --appendonly no
+
+2. Start the subscriber.
+
+   $ python testing/scripts/redis_pubsub.py subscriber
+
+3. Start the publisher.
+C
+   $ python testing/scripts/redis_pubsub.py publisher
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Sequence
+
+from proxystore.pubsub.redis import RedisPublisher
+from proxystore.pubsub.redis import RedisSubscriber
+
+MESSAGES = [f'message_{i}'.encode() for i in range(10)]
+
+
+def publish(host: str, port: int, delay: float) -> None:
+    """Publish messages to the stream."""
+    publisher = RedisPublisher(host, port)
+
+    for message in MESSAGES:
+        publisher.send(message)
+        print(f'Sent: {message!r}')
+        time.sleep(delay)
+
+    publisher.close()
+    print('Publisher closed')
+
+
+def subscribe(host: str, port: int) -> None:
+    """Subscribe to messages from the stream."""
+    subscriber = RedisSubscriber(host, port)
+
+    print('Listening for messages...')
+
+    for message in subscriber:
+        print(f'Received: {message!r}')
+
+    print('Publisher closed topic')
+
+    subscriber.close()
+    print('Subscriber closed')
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Redis pub/sub test."""
+    argv = argv if argv is not None else sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description='Test the Redis pub/sub interface with a Redis server',
+    )
+    parser.add_argument(
+        'role',
+        choices=['publisher', 'subscriber'],
+        help='Role to perform',
+    )
+    parser.add_argument(
+        '--host',
+        default='localhost',
+        help='Redis server host',
+    )
+    parser.add_argument(
+        '--port',
+        default=6379,
+        type=int,
+        help='Redis server port',
+    )
+    parser.add_argument(
+        '--delay',
+        default=1.0,
+        type=float,
+        help='Delay in seconds between sending messages',
+    )
+    args = parser.parse_args(argv)
+
+    if args.role == 'publisher':
+        publish(args.host, args.port, args.delay)
+    elif args.role == 'subscriber':
+        subscribe(args.host, args.port)
+    else:
+        raise AssertionError(f'Unknown role type "{args.role}"')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/pubsub/redis_test.py
+++ b/tests/pubsub/redis_test.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import queue
+from typing import Any
+from typing import Generator
+from unittest import mock
+
+import pytest
+
+from proxystore.pubsub.redis import RedisPublisher
+from proxystore.pubsub.redis import RedisSubscriber
+from testing.mocked.redis import Message
+from testing.mocked.redis import MockStrictRedis
+
+
+@pytest.fixture(autouse=True)
+def _mock_redis() -> Generator[None, None, None]:
+    redis_store: dict[str, bytes] = {}
+    redis_queue: queue.Queue[Message] = queue.Queue()
+
+    def create_mocked_redis(*args: Any, **kwargs: Any) -> MockStrictRedis:
+        return MockStrictRedis(redis_store, redis_queue, *args, **kwargs)
+
+    with mock.patch('redis.StrictRedis', side_effect=create_mocked_redis):
+        yield
+
+
+def test_bad_publisher_default_topic() -> None:
+    with pytest.raises(ValueError, match='other'):
+        RedisPublisher(
+            'localhost',
+            0,
+            topics=['default'],
+            default_topic='other',
+        )
+
+
+def test_publish_unknown_topic() -> None:
+    publisher = RedisPublisher('localhost', 0)
+
+    with pytest.raises(ValueError, match='other'):
+        publisher.send(b'message', topic='other')
+
+    publisher.close()
+
+
+def test_publisher_close_client_only() -> None:
+    publisher = RedisPublisher('localhost', 0)
+    publisher.close(close_topics=False)
+
+
+def test_basic_publish_subscribe() -> None:
+    publisher = RedisPublisher('localhost', 0)
+    subscriber = RedisSubscriber('localhost', 0)
+
+    messages = [f'message_{i}'.encode() for i in range(3)]
+
+    for message in messages:
+        publisher.send(message)
+
+    publisher.close()
+
+    received = []
+    for message in subscriber:
+        received.append(message)
+
+    subscriber.close()
+
+    assert messages == received


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds the `RedisPublisher` and `RedisSubscriber` interfaces for using Redis pub/sub with the ProxyStore stream interface.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #448

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added unit tests using mock Redis client.

Also added the `testing/scripts/redis_pubsub.py` script for running against an actual Redis server.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
