### PR TITLE
Add the `KafkaPublisher` and `KafkaSubscriber` for use with ProxyStore streams

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ plugins:
             - https://requests.readthedocs.io/en/latest/objects.inv
             - https://extensions.proxystore.dev/main/objects.inv
             - https://redis-py.readthedocs.io/en/stable/objects.inv
+            - https://kafka-python.readthedocs.io/en/master/objects.inv
           options:
             docstring_section_style: list
             docstring_style: google

--- a/proxystore/pubsub/kafka.py
+++ b/proxystore/pubsub/kafka.py
@@ -1,0 +1,108 @@
+"""Kafka pub/sub interface."""
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+import kafka
+
+_CLOSED_SENTINAL = b'<queue-publisher-closed-topic>'
+
+
+class KafkaPublisher:
+    """Publisher interface to Kafka message stream.
+
+    Args:
+        client: [`KafkaProducer`][kafka.KafkaProducer] client.
+        topics: Sequence or set of all topics that might be published to.
+        default_topic: Default topic to publish messages to. Must be contained
+            in `topics`.
+
+    Raises:
+        ValueError: if `default_topic` is not in `topics`.
+    """
+
+    def __init__(
+        self,
+        client: kafka.KafkaProducer,
+        *,
+        topics: Sequence[str] | set[str] = ('default',),
+        default_topic: str = 'default',
+    ) -> None:
+        if default_topic not in topics:
+            raise ValueError(
+                f'Default topic "{default_topic}" is not in the list of '
+                f'all topic: {topics}.',
+            )
+        self._topics = topics
+        self._default_topic = default_topic
+        self._client = client
+
+    def close(self, *, close_topics: bool = True) -> None:
+        """Close this publisher.
+
+        This will cause a [`StopIteration`][StopIteration] exception to be
+        raised in any
+        [`KafkaSubscriber`][proxystore.pubsub.kafka.KafkaSubscriber]
+        instances that are currently iterating on new messages from *any*
+        of the topics registered with this publisher. This behavior can be
+        altered by passing `close_topics=True`.
+
+        Args:
+            close_topics: Send an end-of-stream message to all topics
+                associated with this publisher.
+        """
+        if close_topics:
+            for topic in self._topics:
+                future = self._client.send(topic, _CLOSED_SENTINAL)
+                future.get()
+        self._client.close()
+
+    def send(self, message: bytes, *, topic: str | None = None) -> None:
+        """Publish a message to the stream.
+
+        Args:
+            message: Message as bytes to publish to the stream.
+            topic: Stream topic to publish to. `None` uses the default stream.
+
+        Raises:
+            ValueError: if `topic` is not in `topics` provided during
+                initialization.
+        """
+        topic = topic if topic is not None else self._default_topic
+        if topic not in self._topics:
+            raise ValueError(f'Topic "{topic}" is unknown.')
+        future = self._client.send(topic, message)
+        future.get()
+
+
+class KafkaSubscriber:
+    """Subscriber interface to message stream.
+
+    The subscriber protocol is an iterable object which yields objects
+    from the stream until the stream is closed.
+
+    Args:
+        client: [`KafkaConsumer`][kafka.KafkaConsumer] client.
+    """
+
+    def __init__(self, client: kafka.KafkaConsumer) -> None:
+        self._client = client
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> bytes:
+        message = next(self._client)
+        if message.value == _CLOSED_SENTINAL:
+            raise StopIteration
+        return message.value
+
+    def close(self) -> None:
+        """Close this subscriber."""
+        self._client.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ documentation = "https://docs.proxystore.dev"
 repository = "https://github.com/proxystore/proxystore"
 
 [project.optional-dependencies]
-all = ["proxystore[endpoints,extensions,redis]"]
+all = ["proxystore[endpoints,extensions,kafka,redis]"]
 endpoints = [
     "aiortc>=1.3.2",
     "aiosqlite",
@@ -57,6 +57,7 @@ endpoints = [
 extensions = [
     "proxystore-ex",
 ]
+kafka = ["kafka-python>=2.0.2"]
 redis = ["redis>=3.4"]
 dev = [
     "covdefaults>=2.2",
@@ -227,6 +228,7 @@ required-imports = ["from __future__ import annotations"]
 "proxystore/**.py" = ["PT"]
 "proxystore/store/*.py" = ["D102"]
 "tests/conftest.py" = ["F401"]
+"testing/**.py" = ["D10"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/testing/mocked/kafka.py
+++ b/testing/mocked/kafka.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import queue
+import sys
+from typing import NamedTuple
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+import kafka
+
+
+class Message(NamedTuple):
+    topic: str
+    value: bytes
+
+
+class Future:
+    def get(self) -> None:
+        pass
+
+
+class MockKafkaProducer(kafka.KafkaProducer):
+    def __init__(self, queues: dict[str, queue.Queue[Message]]) -> None:
+        self._queues = queues
+
+    def close(self) -> None:
+        pass
+
+    def send(self, topic: str, data: bytes) -> Future:
+        message = Message(topic, data)
+        self._queues[topic].put(message)
+        return Future()
+
+
+class MockKafkaConsumer(kafka.KafkaConsumer):
+    def __init__(self, queue_: queue.Queue[Message]) -> None:
+        self._queue = queue_
+
+    def __iter__(self) -> Self:  # pragma: no cover
+        return self
+
+    def __next__(self) -> Message:
+        return self._queue.get()
+
+    def close(self) -> None:
+        pass
+
+
+def make_producer_consumer_pair(
+    topic: str = 'default',
+) -> tuple[MockKafkaProducer, MockKafkaConsumer]:
+    queue_: queue.Queue[Message] = queue.Queue()
+    return MockKafkaProducer({topic: queue_}), MockKafkaConsumer(queue_)

--- a/testing/scripts/kafka_pubsub.py
+++ b/testing/scripts/kafka_pubsub.py
@@ -1,0 +1,95 @@
+"""Kafka pub/sub test.
+
+1. Start a Kafka broker. This varies, but I found this docker compose file
+   to be useful: https://sahansera.dev/setting-up-kafka-locally-for-testing/
+
+2. Start the subscriber.
+
+   $ python testing/scripts/kafka_pubsub.py subscriber --broker localhost:9092
+
+3. Start the publisher.
+C
+   $ python testing/scripts/kafka_pubsub.py publisher --broker localhost:9092
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Sequence
+
+import kafka
+
+from proxystore.pubsub.kafka import KafkaPublisher
+from proxystore.pubsub.kafka import KafkaSubscriber
+
+MESSAGES = [f'message_{i}'.encode() for i in range(10)]
+
+
+def publish(broker: str, delay: float) -> None:
+    """Publish messages to the stream."""
+    producer = kafka.KafkaProducer(bootstrap_servers=[broker])
+    publisher = KafkaPublisher(producer)
+
+    for message in MESSAGES:
+        publisher.send(message)
+        print(f'Sent: {message!r}')
+        time.sleep(delay)
+
+    publisher.close()
+    print('Publisher closed')
+
+
+def subscribe(broker: str) -> None:
+    """Subscribe to messages from the stream."""
+    consumer = kafka.KafkaConsumer('default', bootstrap_servers=[broker])
+    subscriber = KafkaSubscriber(consumer)
+
+    print('Listening for messages...')
+
+    for message in subscriber:
+        print(f'Received: {message!r}')
+
+    print('Publisher closed topic')
+
+    subscriber.close()
+    print('Subscriber closed')
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Redis pub/sub test."""
+    argv = argv if argv is not None else sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description='Test the Redis pub/sub interface with a Redis server',
+    )
+    parser.add_argument(
+        'role',
+        choices=['publisher', 'subscriber'],
+        help='Role to perform',
+    )
+    parser.add_argument(
+        '--broker',
+        default='localhost:9092',
+        help='Kafka broker address',
+    )
+    parser.add_argument(
+        '--delay',
+        default=1.0,
+        type=float,
+        help='Delay in seconds between sending messages',
+    )
+    args = parser.parse_args(argv)
+
+    if args.role == 'publisher':
+        publish(args.broker, args.delay)
+    elif args.role == 'subscriber':
+        subscribe(args.broker)
+    else:
+        raise AssertionError(f'Unknown role type "{args.role}"')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/pubsub/kafka_test.py
+++ b/tests/pubsub/kafka_test.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
-from proxystore.pubsub.kafka import KafkaPublisher
-from proxystore.pubsub.kafka import KafkaSubscriber
-from testing.mocked.kafka import make_producer_consumer_pair
+try:
+    import kafka
+
+    from proxystore.pubsub.kafka import KafkaPublisher
+    from proxystore.pubsub.kafka import KafkaSubscriber
+    from testing.mocked.kafka import make_producer_consumer_pair
+
+    kafka_available = True
+except ImportError:  # pragma: no cover
+    kafka_available = False
+
+if kafka_available:  # pragma: no branch
+    kafka_version = tuple(kafka.__version__.split('.'))
+
+skip_py312 = not kafka_available or (
+    sys.version_info >= (3, 12) and kafka_version <= (2, 0, 2)
+)
+skip_py312_reason = 'kafka-python<=2.0.2 is not compatible with Python 3.12'
 
 
+@pytest.mark.skipif(skip_py312, reason=skip_py312_reason)
 def test_bad_publisher_default_topic() -> None:
     producer, _ = make_producer_consumer_pair()
 
@@ -14,6 +32,7 @@ def test_bad_publisher_default_topic() -> None:
         KafkaPublisher(producer, topics=['default'], default_topic='other')
 
 
+@pytest.mark.skipif(skip_py312, reason=skip_py312_reason)
 def test_publish_unknown_topic() -> None:
     topic = 'default'
     producer, _ = make_producer_consumer_pair(topic)
@@ -26,12 +45,14 @@ def test_publish_unknown_topic() -> None:
     publisher.close()
 
 
+@pytest.mark.skipif(skip_py312, reason=skip_py312_reason)
 def test_publisher_close_client_only() -> None:
     producer, _ = make_producer_consumer_pair()
     publisher = KafkaPublisher(producer)
     publisher.close(close_topics=False)
 
 
+@pytest.mark.skipif(skip_py312, reason=skip_py312_reason)
 def test_basic_publish_subscribe() -> None:
     producer, consumer = make_producer_consumer_pair('default')
     publisher = KafkaPublisher(producer)

--- a/tests/pubsub/kafka_test.py
+++ b/tests/pubsub/kafka_test.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from proxystore.pubsub.kafka import KafkaPublisher
+from proxystore.pubsub.kafka import KafkaSubscriber
+from testing.mocked.kafka import make_producer_consumer_pair
+
+
+def test_bad_publisher_default_topic() -> None:
+    producer, _ = make_producer_consumer_pair()
+
+    with pytest.raises(ValueError, match='other'):
+        KafkaPublisher(producer, topics=['default'], default_topic='other')
+
+
+def test_publish_unknown_topic() -> None:
+    topic = 'default'
+    producer, _ = make_producer_consumer_pair(topic)
+
+    publisher = KafkaPublisher(producer, topics=[topic], default_topic=topic)
+
+    with pytest.raises(ValueError, match='other'):
+        publisher.send(b'message', topic='other')
+
+    publisher.close()
+
+
+def test_publisher_close_client_only() -> None:
+    producer, _ = make_producer_consumer_pair()
+    publisher = KafkaPublisher(producer)
+    publisher.close(close_topics=False)
+
+
+def test_basic_publish_subscribe() -> None:
+    producer, consumer = make_producer_consumer_pair('default')
+    publisher = KafkaPublisher(producer)
+    subscriber = KafkaSubscriber(consumer)
+
+    messages = [f'message_{i}'.encode() for i in range(3)]
+
+    for message in messages:
+        publisher.send(message)
+
+    publisher.close()
+
+    received = []
+    for message in subscriber:
+        received.append(message)
+
+    subscriber.close()
+
+    assert messages == received

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{38,39,310,311,312}, pre-commit, docs
 
 [testenv]
-extras = dev,endpoints,extensions,redis
+extras = dev,endpoints,extensions,kafka,redis
 commands =
     coverage erase
     coverage run -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,10 @@ commands =
     coverage erase
     coverage run -m pytest {posargs}
     coverage combine --quiet
-    coverage report
+    py{38,39,310,311}: coverage report
+    # kafka-python 2.0.2 does not work on Python 3.12 so those tests get
+    # skipped and we need to omit the files from coverage
+    py312: coverage report --omit proxystore/pubsub/kafka.py,tests/pubsub/kafka_test.py,testing/mocked/kafka.py
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds the `KafkaPublisher` and `KafkaSubscriber` interfaces for using Kafka with the ProxyStore stream interface.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #449

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added unit tests using mock Kafka interfaces.

Also added the `testing/scripts/kafka_pubsub.py` script for running against an actual Kaka service. I used the following `docker-compose.yml` from https://sahansera.dev/setting-up-kafka-locally-for-testing/ to test it.

```yaml
version: '3'
services:
  zookeeper:
    image: confluentinc/cp-zookeeper:7.0.1
    container_name: zookeeper
    environment:
      ZOOKEEPER_CLIENT_PORT: 2181
      ZOOKEEPER_TICK_TIME: 2000

  broker:
    image: confluentinc/cp-kafka:7.0.1
    container_name: broker
    ports:
    # To learn about configuring Kafka for access across networks see
    # https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc/
      - "9092:9092"
    depends_on:
      - zookeeper
    environment:
      KAFKA_BROKER_ID: 1
      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1

```

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
