### PR TITLE
Add the `ZeroMQPublisher` and `ZeroMQSubscriber` for use with ProxyStore streams

### DIFF
--- a/proxystore/pubsub/zmq.py
+++ b/proxystore/pubsub/zmq.py
@@ -1,0 +1,121 @@
+"""ZeroMQ pub/sub interface."""
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+import zmq
+
+_CLOSED_SENTINAL = b'<queue-publisher-closed-topic>'
+
+
+class ZeroMQPublisher:
+    """ZeroMQ publisher interface.
+
+    Args:
+        address: Address to bind to. The full address bound to will be
+            `'tcp://{address}:{port}'`.
+        port: Port to bind to.
+        topics: Sequence or set of all topics that might be published to.
+        default_topic: Default topic to publish messages to. Must be contained
+            in `topics`.
+
+    Raises:
+        ValueError: if `default_topic` is not in `topics`.
+    """
+
+    def __init__(
+        self,
+        address: str,
+        port: int,
+        *,
+        topics: Sequence[str] | set[str] = ('default',),
+        default_topic: str = 'default',
+    ) -> None:
+        if default_topic not in topics:
+            raise ValueError(
+                f'Default topic "{default_topic}" is not in the list of '
+                f'all topic: {topics}.',
+            )
+        self._topics = topics
+        self._default_topic = default_topic
+
+        self._context = zmq.Context()
+        self._socket = self._context.socket(zmq.PUB)
+        self._socket.bind(f'tcp://{address}:{port}')
+
+    def close(self, *, close_topics: bool = True) -> None:
+        """Close this publisher.
+
+        This will cause a [`StopIteration`][StopIteration] exception to be
+        raised in any
+        [`ZeroMQSubscriber`][proxystore.pubsub.zmq.ZeroMQSubscriber]
+        instances that are currently iterating on new messages from *any*
+        of the topics registered with this publisher. This behavior can be
+        altered by passing `close_topics=True`.
+
+        Args:
+            close_topics: Send an end-of-stream message to all topics
+                associated with this publisher.
+        """
+        if close_topics:
+            for topic in self._topics:
+                self._socket.send_multipart(
+                    (topic.encode(), _CLOSED_SENTINAL),
+                )
+        self._context.destroy()
+
+    def send(self, message: bytes, *, topic: str | None = None) -> None:
+        """Publish a message to the stream.
+
+        Args:
+            message: Message as bytes to publish to the stream.
+            topic: Stream topic to publish to. `None` uses the default stream.
+
+        Raises:
+            ValueError: if `topic` is not in `topics` provided during
+                initialization.
+        """
+        topic = topic if topic is not None else self._default_topic
+        if topic not in self._topics:
+            raise ValueError(f'Topic "{topic}" is unknown.')
+        self._socket.send_multipart((topic.encode(), message))
+
+
+class ZeroMQSubscriber:
+    """ZeroMQ subscriber interface.
+
+    The subscriber protocol is an iterable object which yields objects
+    from the stream until the stream is closed.
+
+    Args:
+        address: Publisher address to connect to. The full address will be
+            constructed as `'tcp://{address}:{port}'`.
+        port: Publisher port to connect to.
+        topic: Topic to subscribe to. The default `''` subscribes to all
+            topics.
+    """
+
+    def __init__(self, address: str, port: int, *, topic: str = '') -> None:
+        self._context = zmq.Context()
+        self._socket = self._context.socket(zmq.SUB)
+        self._socket.connect(f'tcp://{address}:{port}')
+        self._socket.setsockopt(zmq.SUBSCRIBE, topic.encode())
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> bytes:
+        _, message = self._socket.recv_multipart()
+        if message == _CLOSED_SENTINAL:
+            raise StopIteration
+        return message
+
+    def close(self) -> None:
+        """Close this subscriber."""
+        self._context.destroy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ documentation = "https://docs.proxystore.dev"
 repository = "https://github.com/proxystore/proxystore"
 
 [project.optional-dependencies]
-all = ["proxystore[endpoints,extensions,kafka,redis]"]
+all = ["proxystore[endpoints,extensions,kafka,redis,zmq]"]
 endpoints = [
     "aiortc>=1.3.2",
     "aiosqlite",
@@ -59,6 +59,7 @@ extensions = [
 ]
 kafka = ["kafka-python>=2.0.2"]
 redis = ["redis>=3.4"]
+zmq = ["pyzmq"]
 dev = [
     "covdefaults>=2.2",
     "coverage",

--- a/tests/pubsub/zmq_test.py
+++ b/tests/pubsub/zmq_test.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from proxystore.pubsub.zmq import ZeroMQPublisher
+from proxystore.pubsub.zmq import ZeroMQSubscriber
+from testing.utils import open_port
+
+
+def test_bad_publisher_default_topic() -> None:
+    with pytest.raises(ValueError, match='other'):
+        ZeroMQPublisher(
+            '127.0.0.1',
+            0,
+            topics=['default'],
+            default_topic='other',
+        )
+
+
+def test_publish_unknown_topic() -> None:
+    publisher = ZeroMQPublisher(
+        '127.0.0.1',
+        open_port(),
+        topics=['default'],
+        default_topic='default',
+    )
+
+    with pytest.raises(ValueError, match='other'):
+        publisher.send(b'message', topic='other')
+
+    publisher.close()
+
+
+def test_publisher_close_client_only() -> None:
+    publisher = ZeroMQPublisher('127.0.0.1', open_port())
+    publisher.close(close_topics=False)
+
+
+def publish(publisher: ZeroMQPublisher, messages: list[bytes]) -> None:
+    for message in messages:
+        publisher.send(message)
+
+
+def subscribe(
+    subscriber: ZeroMQSubscriber,
+    publisher: ZeroMQPublisher,
+    messages: list[bytes],
+) -> None:
+    received = []
+
+    for message in subscriber:
+        received.append(message)
+
+        if len(received) == len(messages):
+            publisher.close()
+
+    assert received == messages
+
+    subscriber.close()
+
+
+def test_basic_publish_subscribe() -> None:
+    address, port = '127.0.0.1', open_port()
+
+    publisher = ZeroMQPublisher(address, port)
+    subscriber = ZeroMQSubscriber(address, port)
+
+    messages = [f'message_{i}'.encode() for i in range(3)]
+
+    pproc = threading.Thread(target=publish, args=[publisher, messages])
+    sproc = threading.Thread(
+        target=subscribe,
+        args=[subscriber, publisher, messages],
+    )
+
+    sproc.start()
+    pproc.start()
+
+    pproc.join(timeout=5)
+    sproc.join(timeout=5)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{38,39,310,311,312}, pre-commit, docs
 
 [testenv]
-extras = dev,endpoints,extensions,kafka,redis
+extras = dev,endpoints,extensions,kafka,redis,zmq
 commands =
     coverage erase
     coverage run -m pytest {posargs}


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds the `ZeroMQPublisher` and `ZeroMQSubscriber` interfaces for using ZeroMQ PUB/SUB with the ProxyStore stream interface.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #450

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
