### PR TITLE
Make `StreamProducer`/`StreamConsumer` not generic

### DIFF
--- a/proxystore/stream.py
+++ b/proxystore/stream.py
@@ -29,7 +29,6 @@ from proxystore.proxy import Proxy
 from proxystore.pubsub.protocols import Publisher
 from proxystore.pubsub.protocols import Subscriber
 from proxystore.store.base import Store
-from proxystore.store.types import ConnectorT
 from proxystore.utils.imports import get_class_path
 from proxystore.utils.imports import import_class
 from proxystore.warnings import ExperimentalWarning
@@ -44,8 +43,6 @@ logger = logging.getLogger(__name__)
 
 
 KeyT = TypeVar('KeyT', bound=NamedTuple)
-PublisherT = TypeVar('PublisherT', bound=Publisher)
-SubscriberT = TypeVar('SubscriberT', bound=Subscriber)
 
 
 @dataclasses.dataclass
@@ -74,7 +71,7 @@ class _Event(Generic[KeyT]):
         return key_type(*self.raw_key)
 
 
-class StreamProducer(Generic[ConnectorT, PublisherT]):
+class StreamProducer:
     """Proxy stream producer interface.
 
     Note:
@@ -101,8 +98,8 @@ class StreamProducer(Generic[ConnectorT, PublisherT]):
 
     def __init__(
         self,
-        store: Store[ConnectorT],
-        publisher: PublisherT,
+        store: Store[Any],
+        publisher: Publisher,
     ) -> None:
         self._store = store
         self._publisher = publisher
@@ -180,7 +177,7 @@ class StreamProducer(Generic[ConnectorT, PublisherT]):
         self._publisher.send(message, topic=topic)
 
 
-class StreamConsumer(Generic[ConnectorT, SubscriberT]):
+class StreamConsumer:
     """Proxy stream consumer interface.
 
     This interface acts as an iterator that will yield items from the stream
@@ -221,8 +218,8 @@ class StreamConsumer(Generic[ConnectorT, SubscriberT]):
 
     def __init__(
         self,
-        store: Store[ConnectorT],
-        subscriber: SubscriberT,
+        store: Store[Any],
+        subscriber: Subscriber,
     ) -> None:
         self._store = store
         self._subscriber = subscriber


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Make `StreamProducer`/`StreamConsumer` not generic.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #462

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Mypy passes.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
