### PR TITLE
Make `StreamProducer`/`StreamConsumer` generic type containers

### DIFF
--- a/proxystore/stream/event.py
+++ b/proxystore/stream/event.py
@@ -28,7 +28,7 @@ class Event(Generic[KeyT]):
     """
 
     key_type: str
-    raw_key: tuple[Any]
+    raw_key: tuple[Any, ...]
     evict: bool
 
     @classmethod

--- a/tests/stream/interface_test.py
+++ b/tests/stream/interface_test.py
@@ -37,8 +37,8 @@ def store() -> Generator[Store[LocalConnector], None, None]:
 def test_basic_interface(store: Store[LocalConnector]) -> None:
     publisher, subscriber = create_pubsub_pair()
 
-    producer = StreamProducer(store, publisher)
-    consumer = StreamConsumer(store, subscriber)
+    producer = StreamProducer[uuid.UUID](store, publisher)
+    consumer = StreamConsumer[uuid.UUID](store, subscriber)
 
     objects = [uuid.uuid4() for _ in range(10)]
 
@@ -72,8 +72,8 @@ def test_basic_interface(store: Store[LocalConnector]) -> None:
 def test_context_manager(store: Store[LocalConnector]) -> None:
     publisher, subscriber = create_pubsub_pair()
 
-    with StreamProducer(store, publisher) as producer:
-        with StreamConsumer(store, subscriber) as consumer:
+    with StreamProducer[str](store, publisher) as producer:
+        with StreamConsumer[str](store, subscriber) as consumer:
             producer.send('default', 'value')
             assert next(consumer) == 'value'
 
@@ -83,14 +83,14 @@ def test_close_without_closing_connectors(
 ) -> None:
     publisher, subscriber = create_pubsub_pair()
 
-    producer = StreamProducer(store, publisher)
-    consumer = StreamConsumer(store, subscriber)
+    producer = StreamProducer[str](store, publisher)
+    consumer = StreamConsumer[str](store, subscriber)
 
     producer.close(store=False, publisher=False)
     consumer.close(store=False, subscriber=False)
 
     # Reuse store, publisher, subscriber
-    with StreamProducer(store, publisher) as producer:
-        with StreamConsumer(store, subscriber) as consumer:
+    with StreamProducer[str](store, publisher) as producer:
+        with StreamConsumer[str](store, subscriber) as consumer:
             producer.send('default', 'value')
             assert next(consumer) == 'value'


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Make `StreamProducer`/`StreamConsumer` generic on the type of the data in the stream. This will help code bases that type annotated their code to prevent sending the wrong object types to a stream, or to ensure objects consumed from the stream are types appropriately.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #467 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
