### PR TITLE
`StreamProducer` controls which `Store` instances are used for each stream topic

### DIFF
--- a/proxystore/stream/events.py
+++ b/proxystore/stream/events.py
@@ -34,14 +34,25 @@ class NewObjectEvent:
     key_type: str
     raw_key: list[Any]
     evict: bool
+    topic: str
+    store_config: dict[str, Any]
 
     @classmethod
-    def from_key(cls, key: Any, *, evict: bool = True) -> NewObjectEvent:
+    def from_key(
+        cls,
+        key: Any,
+        topic: str,
+        store_config: dict[str, Any],
+        *,
+        evict: bool = True,
+    ) -> NewObjectEvent:
         """Create a new event from a key to a stored object."""
         return NewObjectEvent(
             key_type=get_class_path(type(key)),
             raw_key=list(key),
             evict=evict,
+            topic=topic,
+            store_config=store_config,
         )
 
     def get_key(self) -> Any:

--- a/tests/stream/events_test.py
+++ b/tests/stream/events_test.py
@@ -20,7 +20,11 @@ class _TestKey(NamedTuple):
     'event',
     (
         EndOfStreamEvent(),
-        NewObjectEvent.from_key(_TestKey('a', 123)),
+        NewObjectEvent.from_key(
+            _TestKey('a', 123),
+            topic='default',
+            store_config={},
+        ),
     ),
 )
 def test_encode_decode(event: Event) -> None:
@@ -31,7 +35,7 @@ def test_encode_decode(event: Event) -> None:
 
 def test_new_object_to_from_key() -> None:
     key = _TestKey('a', 123)
-    event = NewObjectEvent.from_key(key)
+    event = NewObjectEvent.from_key(key, 'default', {})
     new_key = event.get_key()
     assert key == new_key
     assert type(key) == type(new_key)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The StreamProducer now has full control over the stores used for objects in each stream topic. The StreamConsumer no longer needs to know ahead of time which stores will be used; that metadata is included in stream events.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #464

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
