### PR TITLE
Support aggregation, batching, and filtering in stream interfaces

### DIFF
--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -97,7 +97,9 @@ producer.close() # (5)!
    implementations depending on your deployment or data characteristics.
 2. The [`Publisher`][proxystore.stream.protocols.Publisher] is the interface
    to a pub/sub channel which will be used for sending event metadata to
-   consumers.
+   consumers. The
+   [`StreamProducer`][proxystore.stream.interface.StreamProducer] also supports
+   aggregation, batching, and filtering.
 3. In the mapping of topics to stores, the `None` key is considered the
    default for when a topic is not found in the mapping. For example,
    `{None: store}` will use the same store for all topics.

--- a/proxystore/stream/events.py
+++ b/proxystore/stream/events.py
@@ -34,6 +34,7 @@ class NewObjectEvent:
     key_type: str
     raw_key: list[Any]
     evict: bool
+    metadata: dict[str, Any]
     topic: str
     store_config: dict[str, Any]
 
@@ -45,12 +46,14 @@ class NewObjectEvent:
         store_config: dict[str, Any],
         *,
         evict: bool = True,
+        metadata: dict[str, Any] | None = None,
     ) -> NewObjectEvent:
         """Create a new event from a key to a stored object."""
         return NewObjectEvent(
             key_type=get_class_path(type(key)),
             raw_key=list(key),
             evict=evict,
+            metadata=metadata if metadata is not None else {},
             topic=topic,
             store_config=store_config,
         )

--- a/proxystore/stream/events.py
+++ b/proxystore/stream/events.py
@@ -24,7 +24,10 @@ from proxystore.utils.imports import import_class
 class EndOfStreamEvent:
     """End of stream event."""
 
-    pass
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EndOfStreamEvent:
+        """Create a new event instance from its dictionary representation."""
+        return cls()
 
 
 @dataclasses.dataclass
@@ -34,28 +37,26 @@ class NewObjectEvent:
     key_type: str
     raw_key: list[Any]
     evict: bool
-    metadata: dict[str, Any] | None
-    topic: str
-    store_config: dict[str, Any]
+    metadata: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NewObjectEvent:
+        """Create a new event instance from its dictionary representation."""
+        return NewObjectEvent(**data)
 
     @classmethod
     def from_key(
         cls,
-        key: Any,
-        topic: str,
-        store_config: dict[str, Any],
-        *,
-        evict: bool = True,
-        metadata: dict[str, Any] | None = None,
+        key: tuple[Any, ...],
+        evict: bool,
+        metadata: dict[str, Any],
     ) -> NewObjectEvent:
-        """Create a new event from a key to a stored object."""
-        return NewObjectEvent(
+        """Create a new event from a key and metadata."""
+        return cls(
             key_type=get_class_path(type(key)),
             raw_key=list(key),
             evict=evict,
             metadata=metadata,
-            topic=topic,
-            store_config=store_config,
         )
 
     def get_key(self) -> Any:
@@ -64,25 +65,63 @@ class NewObjectEvent:
         return key_type(*self.raw_key)
 
 
-class _EventMapping(enum.Enum):
-    END_OF_STREAM = EndOfStreamEvent
-    NEW_OBJECT = NewObjectEvent
-
-
 Event = Union[EndOfStreamEvent, NewObjectEvent]
 """Event union type."""
 
 
-def event_to_json(event: Event) -> str:
-    """Convert event to JSON string."""
-    data = dataclasses.asdict(event)
+@dataclasses.dataclass
+class EventBatch:
+    """Batch of stream events."""
+
+    events: list[Event]
+    topic: str
+    store_config: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EventBatch:
+        """Create a new event instance from its dictionary representation."""
+        events = [dict_to_event(d) for d in data['events']]
+        return cls(
+            events=events,  # type: ignore[arg-type]
+            topic=data['topic'],
+            store_config=data['store_config'],
+        )
+
+
+class _EventMapping(enum.Enum):
+    END_OF_STREAM = EndOfStreamEvent
+    EVENT_BATCH = EventBatch
+    NEW_OBJECT = NewObjectEvent
+
+
+def event_to_dict(event: Event | EventBatch) -> dict[str, Any]:
+    """Convert event to dict."""
+    if isinstance(event, EventBatch):
+        data = {
+            'events': [event_to_dict(e) for e in event.events],
+            'topic': event.topic,
+            'store_config': event.store_config,
+        }
+    else:
+        data = dataclasses.asdict(event)
     data['event_type'] = _EventMapping(type(event)).name
-    return json.dumps(data)
+    return data
 
 
-def json_to_event(s: str) -> Event:
-    """Convert JSON string to event."""
-    data = json.loads(s)
+def dict_to_event(data: dict[str, Any]) -> Event | EventBatch:
+    """Convert dict to event."""
     event_type = data.pop('event_type')
-    event = _EventMapping[event_type].value(**data)
+    event = _EventMapping[event_type].value.from_dict(data)
     return event
+
+
+def event_to_bytes(event: Event | EventBatch) -> bytes:
+    """Convert event to byte-string."""
+    data = event_to_dict(event)
+    return json.dumps(data).encode()
+
+
+def bytes_to_event(s: bytes) -> Event | EventBatch:
+    """Convert byte-string to event."""
+    data = json.loads(s.decode())
+    return dict_to_event(data)

--- a/proxystore/stream/events.py
+++ b/proxystore/stream/events.py
@@ -34,7 +34,7 @@ class NewObjectEvent:
     key_type: str
     raw_key: list[Any]
     evict: bool
-    metadata: dict[str, Any]
+    metadata: dict[str, Any] | None
     topic: str
     store_config: dict[str, Any]
 
@@ -53,7 +53,7 @@ class NewObjectEvent:
             key_type=get_class_path(type(key)),
             raw_key=list(key),
             evict=evict,
-            metadata=metadata if metadata is not None else {},
+            metadata=metadata,
             topic=topic,
             store_config=store_config,
         )

--- a/proxystore/stream/exceptions.py
+++ b/proxystore/stream/exceptions.py
@@ -1,0 +1,8 @@
+"""Streaming exception types."""
+from __future__ import annotations
+
+
+class TopicClosedError(Exception):
+    """Object sent to topic that has already been closed."""
+
+    pass

--- a/proxystore/stream/filters.py
+++ b/proxystore/stream/filters.py
@@ -1,0 +1,36 @@
+"""Set of common stream filters."""
+from __future__ import annotations
+
+import random
+from typing import Any
+
+
+class NullFilter:
+    """Filter which never filters out objects."""
+
+    def __call__(self, metadata: dict[str, Any] | None) -> bool:
+        """Apply the filter to event metadata."""
+        return False
+
+
+class SamplingFilter:
+    """Filter that randomly filters out objects.
+
+    Args:
+        p: Probability of the filter return `True`. I.e., the object gets
+            filtered out.
+
+    Raises:
+        ValueError: if `p` is not in the range `[0, 1]`.
+    """
+
+    def __init__(self, p: float) -> None:
+        if p < 0 or p > 1:
+            raise ValueError(
+                f'Filter probability p must be in [0, 1]. Got p={p}.',
+            )
+        self._p = p
+
+    def __call__(self, metadata: dict[str, Any] | None) -> bool:
+        """Apply the filter to event metadata."""
+        return random.random() <= self._p

--- a/proxystore/stream/filters.py
+++ b/proxystore/stream/filters.py
@@ -8,7 +8,7 @@ from typing import Any
 class NullFilter:
     """Filter which never filters out objects."""
 
-    def __call__(self, metadata: dict[str, Any] | None) -> bool:
+    def __call__(self, metadata: dict[str, Any]) -> bool:
         """Apply the filter to event metadata."""
         return False
 
@@ -31,6 +31,6 @@ class SamplingFilter:
             )
         self._p = p
 
-    def __call__(self, metadata: dict[str, Any] | None) -> bool:
+    def __call__(self, metadata: dict[str, Any]) -> bool:
         """Apply the filter to event metadata."""
         return random.random() <= self._p

--- a/proxystore/stream/interface.py
+++ b/proxystore/stream/interface.py
@@ -158,6 +158,7 @@ class StreamProducer(Generic[T]):
         obj: T,
         *,
         evict: bool = True,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Send an item to the stream.
 
@@ -187,6 +188,9 @@ class StreamProducer(Generic[T]):
                 Set to `False` if a single object in the stream will be
                 consumed by multiple consumers. Note that when set to `False`,
                 data eviction must be handled manually.
+            metadata: Dictionary containing metadata about the object. This
+                can be used by the producer or consumer to filter new
+                object events.
 
         Raises:
             ValueError: if a store associated with `topic` is not found
@@ -209,6 +213,7 @@ class StreamProducer(Generic[T]):
             topic,
             store.config(),
             evict=evict,
+            metadata=metadata,
         )
         message = event_to_json(event).encode()
         self._publisher.send(topic, message)

--- a/proxystore/stream/protocols.py
+++ b/proxystore/stream/protocols.py
@@ -27,11 +27,14 @@ import sys
 from typing import Any
 from typing import Protocol
 from typing import runtime_checkable
+from typing import TypeVar
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
+
+T = TypeVar('T')
 
 
 @runtime_checkable
@@ -80,6 +83,6 @@ class Filter(Protocol):
     out of the stream and lost.
     """
 
-    def __call__(self, metadata: dict[str, Any] | None) -> bool:
+    def __call__(self, metadata: dict[str, Any]) -> bool:
         """Apply the filter to event metadata."""
         ...

--- a/proxystore/stream/protocols.py
+++ b/proxystore/stream/protocols.py
@@ -1,4 +1,6 @@
-"""Publisher and subscriber protocol definitions.
+"""Protocols used by the stream interfaces.
+
+## Publisher/Subscriber
 
 The [`Publisher`][proxystore.stream.protocols.Publisher] and
 [`Subscriber`][proxystore.stream.protocols.Subscriber] are
@@ -10,10 +12,19 @@ besides the interface. For example, implementations could choose to support
 any producer-to-consumer configurations (e.g., 1:1, 1:N, N:N).
 A set of shims implementing these protocols for third-party message brokers
 are provided in [`proxystore.stream.shims`][proxystore.stream.shims].
+
+## Plugins
+
+Additional protocols, such as the
+[`Filter`][proxystore.stream.protocols.Filter], are plugins used by the
+[`StreamProducer`][proxystore.stream.interface.StreamProducer] and/or
+[`StreamConsumer`][proxystore.stream.interface.StreamConsumer] that alter
+their behavior.
 """
 from __future__ import annotations
 
 import sys
+from typing import Any
 from typing import Protocol
 from typing import runtime_checkable
 
@@ -57,4 +68,18 @@ class Subscriber(Protocol):
 
     def close(self) -> None:
         """Close this subscriber."""
+        ...
+
+
+class Filter(Protocol):
+    """Filter protocol.
+
+    A filter takes as input the dictionary of metadata associated with a new
+    object event and returns a boolean indicating if the event should be
+    dropped. I.e., if the filter returns `True`, the event will be filtered
+    out of the stream and lost.
+    """
+
+    def __call__(self, metadata: dict[str, Any] | None) -> bool:
+        """Apply the filter to event metadata."""
         ...

--- a/tests/stream/filters_test.py
+++ b/tests/stream/filters_test.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from proxystore.stream.filters import NullFilter
+from proxystore.stream.filters import SamplingFilter
+
+
+def test_null_filter():
+    filter_ = NullFilter()
+    assert not filter_(None)
+    assert not filter_({})
+    assert not filter_({'field': True})
+
+
+def test_sampling_filter():
+    filter_ = SamplingFilter(0.2)
+
+    with mock.patch('random.random', return_value=0.1):
+        assert filter_(None)
+        assert filter_({})
+        assert filter_({'field': True})
+
+    with mock.patch('random.random', return_value=0.3):
+        assert not filter_(None)
+        assert not filter_({})
+        assert not filter_({'field': True})
+
+
+def test_sampling_filter_value_error():
+    with pytest.raises(ValueError, match='[0, 1]'):
+        SamplingFilter(-1)
+
+    with pytest.raises(ValueError, match='[0, 1]'):
+        SamplingFilter(1.1)

--- a/tests/stream/filters_test.py
+++ b/tests/stream/filters_test.py
@@ -10,7 +10,6 @@ from proxystore.stream.filters import SamplingFilter
 
 def test_null_filter():
     filter_ = NullFilter()
-    assert not filter_(None)
     assert not filter_({})
     assert not filter_({'field': True})
 
@@ -19,12 +18,10 @@ def test_sampling_filter():
     filter_ = SamplingFilter(0.2)
 
     with mock.patch('random.random', return_value=0.1):
-        assert filter_(None)
         assert filter_({})
         assert filter_({'field': True})
 
     with mock.patch('random.random', return_value=0.3):
-        assert not filter_(None)
         assert not filter_({})
         assert not filter_({'field': True})
 

--- a/tests/stream/interface_test.py
+++ b/tests/stream/interface_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import pathlib
 import queue
 import threading
@@ -15,8 +16,10 @@ from proxystore.proxy import Proxy
 from proxystore.store import get_store
 from proxystore.store import Store
 from proxystore.store import store_registration
-from proxystore.stream.events import json_to_event
+from proxystore.stream.events import bytes_to_event
+from proxystore.stream.events import EventBatch
 from proxystore.stream.events import NewObjectEvent
+from proxystore.stream.exceptions import TopicClosedError
 from proxystore.stream.interface import StreamConsumer
 from proxystore.stream.interface import StreamProducer
 from proxystore.stream.shims.queue import QueuePublisher
@@ -44,11 +47,16 @@ def store(
             yield store
 
 
-def test_basic_interface(store: Store[FileConnector]) -> None:
+@pytest.mark.parametrize('batch_size', (1, 2, 3))
+def test_simple_stream(batch_size: int, store: Store[FileConnector]) -> None:
     topic = 'default'
     publisher, subscriber = create_pubsub_pair(topic)
 
-    producer = StreamProducer[uuid.UUID](publisher, {topic: store})
+    producer = StreamProducer[uuid.UUID](
+        publisher,
+        {topic: store},
+        batch_size=batch_size,
+    )
     consumer = StreamConsumer[uuid.UUID](subscriber)
 
     objects = [uuid.uuid4() for _ in range(10)]
@@ -58,6 +66,7 @@ def test_basic_interface(store: Store[FileConnector]) -> None:
             producer.send('default', obj)
 
         # Let the consumer handle closing the store
+        producer.flush()
         producer.close(stores=False)
 
     def consume() -> None:
@@ -116,10 +125,22 @@ def test_producer_close_topic(store: Store[FileConnector]) -> None:
 
     with StreamProducer[str](publisher, {topic: store}) as producer:
         with StreamConsumer[str](subscriber) as consumer:
-            producer.close_topics('default')
+            producer.close_topics(topic)
 
             with pytest.raises(StopIteration):
                 consumer.next()
+
+
+def test_error_sending_to_closed_topic(store: Store[FileConnector]) -> None:
+    topic = 'default'
+    publisher, subscriber = create_pubsub_pair(topic)
+
+    with StreamProducer[str](publisher, {topic: store}) as producer:
+        producer.close_topics(topic)
+        with pytest.raises(TopicClosedError):
+            producer.send(topic, 'value')
+
+    subscriber.close()
 
 
 def test_use_and_register_default_store(tmp_path: pathlib.Path) -> None:
@@ -212,10 +233,38 @@ def test_consumer_evicts_filtered_objs(store: Store[FileConnector]) -> None:
     assert len(indices) == 5
     assert indices == list(range(0, 10, 2))
 
-    for event_str in events:
-        event = json_to_event(event_str)
+    for event_bytes in events:
+        batch = bytes_to_event(event_bytes)
+        assert isinstance(batch, EventBatch)
+        (event,) = batch.events
         assert isinstance(event, NewObjectEvent)
         assert not store.exists(event.get_key())
+
+    producer.close()
+    consumer.close()
+
+
+@pytest.mark.parametrize('batch_size', (1, 2, 3))
+def test_aggregator(batch_size: int, store: Store[FileConnector]) -> None:
+    topic = 'default'
+    publisher, subscriber = create_pubsub_pair(topic)
+
+    producer = StreamProducer[int](
+        publisher,
+        {topic: store},
+        aggregator=sum,
+        batch_size=batch_size,
+    )
+    consumer = StreamConsumer[int](subscriber)
+
+    count = 10
+    for _ in range(count):
+        producer.send(topic, 1, evict=True)
+    producer.close_topics(topic)
+
+    values = [extract(p) for p in consumer]
+    assert len(values) == math.ceil(count / batch_size)
+    assert sum(values) == count
 
     producer.close()
     consumer.close()

--- a/tests/stream/interface_test.py
+++ b/tests/stream/interface_test.py
@@ -4,15 +4,19 @@ import pathlib
 import queue
 import threading
 import uuid
+from typing import Any
 from typing import Generator
 
 import pytest
 
 from proxystore.connectors.file import FileConnector
+from proxystore.proxy import extract
 from proxystore.proxy import Proxy
 from proxystore.store import get_store
 from proxystore.store import Store
 from proxystore.store import store_registration
+from proxystore.stream.events import json_to_event
+from proxystore.stream.events import NewObjectEvent
 from proxystore.stream.interface import StreamConsumer
 from proxystore.stream.interface import StreamProducer
 from proxystore.stream.shims.queue import QueuePublisher
@@ -148,3 +152,70 @@ def test_missing_store_mapping_error(store: Store[FileConnector]) -> None:
             producer.send('other', 'value')
 
     subscriber.close()
+
+
+@pytest.mark.parametrize('toggle_side', (True, False))
+def test_filtering_stream(
+    toggle_side: bool,
+    store: Store[FileConnector],
+) -> None:
+    topic = 'default'
+    publisher, subscriber = create_pubsub_pair(topic)
+
+    def filter_(metadata: dict[str, Any] | None) -> bool:
+        assert metadata is not None
+        return metadata['index'] % 2 != 0
+
+    producer = StreamProducer[int](
+        publisher,
+        {topic: store},
+        filter_=filter_ if toggle_side else None,
+    )
+    consumer = StreamConsumer[int](
+        subscriber,
+        filter_=filter_ if not toggle_side else None,
+    )
+
+    for i in range(0, 10):
+        producer.send(topic, i, metadata={'index': i}, evict=False)
+
+    producer.close_topics(topic)
+
+    indices = [extract(p) for p in consumer]
+
+    assert indices == list(range(0, 10, 2))
+
+    producer.close()
+    consumer.close()
+
+
+def test_consumer_evicts_filtered_objs(store: Store[FileConnector]) -> None:
+    topic = 'default'
+    publisher, subscriber = create_pubsub_pair(topic)
+
+    def filter_(metadata: dict[str, Any] | None) -> bool:
+        assert metadata is not None
+        return metadata['index'] % 2 != 0
+
+    producer = StreamProducer[int](publisher, {topic: store})
+    consumer = StreamConsumer[int](subscriber, filter_=filter_)
+
+    for i in range(0, 10):
+        producer.send(topic, i, metadata={'index': i}, evict=True)
+
+    events = list(publisher._queues[topic].queue)  # type: ignore[union-attr]
+    assert len(events) == 10
+
+    producer.close_topics(topic)
+
+    indices = [extract(p) for p in consumer]
+    assert len(indices) == 5
+    assert indices == list(range(0, 10, 2))
+
+    for event_str in events:
+        event = json_to_event(event_str)
+        assert isinstance(event, NewObjectEvent)
+        assert not store.exists(event.get_key())
+
+    producer.close()
+    consumer.close()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Support aggregation, batching, and filtering in stream interfaces.

This required a fair amount of refactoring for the `StreamProducer`, `StreamConsumer`, and `Event` structures. As a result, neither of those interfaces a thread safe anymore because of the way batch buffers work.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #465

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
