### PR TITLE
Rename `ProxyFuture` to `Future`

### DIFF
--- a/docs/guides/proxy-futures.md
+++ b/docs/guides/proxy-futures.md
@@ -4,7 +4,7 @@
 
 This guide walks through the use of the
 [`Store.future()`][proxystore.store.base.Store.future] interface and associated
-[`ProxyFuture`][proxystore.store.future.ProxyFuture].
+[`Future`][proxystore.store.future.Future].
 
 !!! note
 
@@ -16,10 +16,10 @@ This guide walks through the use of the
 !!! warning
 
     The [`Store.future()`][proxystore.store.base.Store.future] and
-    [`ProxyFuture`][proxystore.store.future.ProxyFuture] interfaces are
+    [`Future`][proxystore.store.future.Future] interfaces are
     experimental features and may change in future releases.
 
-The [`ProxyFuture`][proxystore.store.future.ProxyFuture] interface enables
+The [`Future`][proxystore.store.future.Future] interface enables
 a data producer to preemptively send a proxy to a data consumer before the
 target data has been created. The consumer of the target data proxy will
 block when the proxy is first used and resolved until the producer
@@ -27,17 +27,17 @@ has created the target data.
 
 Here is a trivial example using a [`Store`][proxystore.store.base.Store] and
 [`LocalConnector`][proxystore.connectors.local.LocalConnector]. The
-[`future.proxy()`][proxystore.store.future.ProxyFuture.proxy] method is used
+[`future.proxy()`][proxystore.store.future.Future.proxy] method is used
 to create a [`Proxy`][proxystore.proxy.Proxy] which will resolve to the
 result of the future.
 
 ```python linenums="1" title="example.py"
 from proxystore.connectors.local import LocalConnector
 from proxystore.store import Store
-from proxystore.store.future import ProxyFuture
+from proxystore.store.future import Future
 
 with Store('proxy-future-example', LocalConnector()) as store:
-    future: ProxyFuture[str] = store.future()
+    future: Future[str] = store.future()
     proxy = future.proxy()
 
     future.set_result('value')
@@ -65,11 +65,11 @@ with Store('proxy-future-example', LocalConnector()) as store:
     [`FileConnector`][proxystore.connectors.file.FileConnector], and
     [`RedisConnector`][proxystore.connectors.redis.RedisConnector].
 
-The power of [`ProxyFuture`][proxystore.store.future.ProxyFuture] comes when
+The power of [`Future`][proxystore.store.future.Future] comes when
 the data producer and consumer are executing independently in time and space
 (i.e., execution occurs in different processes, potentially on different
 systems, and in an undefined order). The
-[`ProxyFuture`][proxystore.store.future.ProxyFuture] enables the producer
+[`Future`][proxystore.store.future.Future] enables the producer
 and consumer to share a data dependency, while allowing the consumer to
 eagerly start execution before the data dependencies are fully satisfied.
 
@@ -81,12 +81,12 @@ at the same time. (We could even start `bar()` before `foo()`!)
 ```python linenums="1" title="client.py"
 from proxystore.connectors.redis import RedisConnector
 from proxystore.store import Store
-from proxystore.store.future import ProxyFuture
+from proxystore.store.future import Future
 
 class MyData:
     ...
 
-def foo(future: ProxyFuture[MyData]) -> None:
+def foo(future: Future[MyData]) -> None:
     data: MyData = compute(...)
     future.set_result(data)
 
@@ -99,7 +99,7 @@ def bar(data: MyData) -> None:
 
 
 with Store('proxy-future-example', RedisConnector(...)) as store:
-    future: ProxyFuture[MyData] = store.future()
+    future: Future[MyData] = store.future()
 
     # The invoke_remote function will execute the function with
     # the provided on arguments on an arbitrary remote process.

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -29,7 +29,7 @@ from proxystore.store.cache import LRUCache
 from proxystore.store.exceptions import NonProxiableTypeError
 from proxystore.store.factory import PollingStoreFactory
 from proxystore.store.factory import StoreFactory
-from proxystore.store.future import ProxyFuture
+from proxystore.store.future import Future
 from proxystore.store.metrics import StoreMetrics
 from proxystore.store.types import ConnectorKeyT
 from proxystore.store.types import ConnectorT
@@ -219,16 +219,16 @@ class Store(Generic[ConnectorT]):
         deserializer: DeserializerT | None = None,
         polling_interval: float = 1,
         polling_timeout: float | None = None,
-    ) -> ProxyFuture[T]:
+    ) -> Future[T]:
         """Create a future to an object.
 
         Example:
             ```python
             from proxystore.connectors.file import FileConnector
             from proxystore.store import Store
-            from proxystore.store.future import ProxyFuture
+            from proxystore.store.future import Future
 
-            def remote_foo(future: ProxyFuture) -> None:
+            def remote_foo(future: Future) -> None:
                 # Computation that generates a result value needed by
                 # the remote_bar function.
                 future.set_result(...)
@@ -257,12 +257,12 @@ class Store(Generic[ConnectorT]):
 
         Warning:
             This method and the
-            [`ProxyFuture.proxy()`][proxystore.store.future.ProxyFuture.proxy]
+            [`Future.proxy()`][proxystore.store.future.Future.proxy]
             are experimental features and may change in future releases.
 
         Args:
             evict: If a proxy returned by
-                [`ProxyFuture.proxy()`][proxystore.store.future.ProxyFuture.proxy]
+                [`Future.proxy()`][proxystore.store.future.Future.proxy]
                 should evict the object once resolved.
             serializer: Optionally override the default serializer for the
                 store instance.
@@ -286,11 +286,11 @@ class Store(Generic[ConnectorT]):
                 'The provided connector is type '
                 f'{type(self.connector).__name__} which does not implement '
                 f'the {DeferrableConnector.__name__} necessary to use the '
-                f'{ProxyFuture.__name__} interface.',
+                f'{Future.__name__} interface.',
             )
 
         warnings.warn(
-            'The Store.future() and ProxyFuture interfaces are experimental '
+            'The Store.future() and Future interfaces are experimental '
             'and may change in future releases.',
             category=ExperimentalWarning,
             stacklevel=2,
@@ -305,7 +305,7 @@ class Store(Generic[ConnectorT]):
             polling_interval=polling_interval,
             polling_timeout=polling_timeout,
         )
-        return ProxyFuture(factory, serializer=serializer)
+        return Future(factory, serializer=serializer)
 
     def evict(self, key: ConnectorKeyT) -> None:
         """Evict the object associated with the key.

--- a/proxystore/store/future.py
+++ b/proxystore/store/future.py
@@ -12,8 +12,8 @@ from proxystore.store.types import SerializerT
 T = TypeVar('T')
 
 
-class ProxyFuture(Generic[T]):
-    """Proxy-Future interface to a [`Store`][proxystore.store.base.Store].
+class Future(Generic[T]):
+    """Future interface to a [`Store`][proxystore.store.base.Store].
 
     Args:
         factory: Factory that can resolve the object once it is resolved.

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -9,7 +9,7 @@ import pytest
 from proxystore.connectors.local import LocalConnector
 from proxystore.proxy import Proxy
 from proxystore.store import Store
-from proxystore.store.future import ProxyFuture
+from proxystore.store.future import Future
 
 
 def test_negative_cache_size() -> None:
@@ -141,7 +141,7 @@ def test_set_custom_serializer(store: Store[LocalConnector]) -> None:
 
 
 def test_future(store: Store[LocalConnector]) -> None:
-    future: ProxyFuture[str] = store.future()
+    future: Future[str] = store.future()
     proxy = future.proxy()
     future.set_result('test_value')
     assert future.result() == 'test_value'
@@ -149,10 +149,10 @@ def test_future(store: Store[LocalConnector]) -> None:
 
 
 def test_future_in_threads(store: Store[LocalConnector]) -> None:
-    future: ProxyFuture[str] = store.future()
+    future: Future[str] = store.future()
 
     def _foo(
-        future: ProxyFuture[str],
+        future: Future[str],
         barrier: threading.Barrier,
     ) -> None:
         future.set_result('test_value')


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

It is somewhat misleading to call this a `ProxyFuture` because that could imply it is a proxy, but really it's just a `concurrent.futures` like interface with an extra method for create a proxy that will resolve to the result of the future.

This is a breaking change, but the `ProxyFuture` was added recently and it is unlikely most code is importing that object. 

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #484

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
