### PR TITLE
Invalidate cache entry when using `Store._set()`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -884,6 +884,12 @@ class Store(Generic[ConnectorT]):
             This method only works if the `connector` is of type
             [`DeferrableConnector`][proxystore.connectors.protocols.DeferrableConnector].
 
+        Warning:
+            Associated [`Store`][proxystore.store.base.Store] instances in
+            other processes may still have the old version of the object
+            associated with `key` cached. This method is unable to invalidate
+            those caches.
+
         Args:
             key: Key to set the object on.
             obj: Object to put in the store.
@@ -922,6 +928,8 @@ class Store(Generic[ConnectorT]):
 
         with Timer() as connector_timer:
             self.connector.set(key, obj, **kwargs)
+
+        self.cache.evict(key)
 
         timer.stop()
         if self.metrics is not None:

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -117,11 +117,15 @@ def test_put_batch_custom_serializer(store: Store[LocalConnector]) -> None:
         assert store.exists(key)
 
 
-def test_set(store: Store[LocalConnector]) -> None:
-    key = store.connector.new_key()
-    assert not store.exists(key)
-    store._set(key, 'test_value')
-    assert store.get(key) == 'test_value'
+def test_set() -> None:
+    with Store('test-set', LocalConnector(), cache_size=1) as store:
+        key = store.connector.new_key()
+        assert not store.exists(key)
+        store._set(key, 'test_value')
+        assert store.get(key) == 'test_value'
+        assert store.is_cached(key)
+        store._set(key, 'new_value')
+        assert not store.is_cached(key)
 
 
 def test_set_bad_connector_type(store: Store[LocalConnector]) -> None:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Invalidate cache entry when using `Store._set()`.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update unit test.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
