### PR TITLE
Support exponential backoff factor in `PollingStoreFactory`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -219,6 +219,8 @@ class Store(Generic[ConnectorT]):
         serializer: SerializerT | None = None,
         deserializer: DeserializerT | None = None,
         polling_interval: float = 1,
+        polling_backoff_factor: float = 1,
+        polling_interval_limit: float | None = None,
         polling_timeout: float | None = None,
     ) -> Future[T]:
         """Create a future to an object.
@@ -269,10 +271,15 @@ class Store(Generic[ConnectorT]):
                 store instance.
             deserializer: Optionally override the default deserializer for the
                 store instance.
-            polling_interval: Seconds to sleep between polling the store for
-                the object when getting the result of the future.
-            polling_timeout: Optional maximum number of seconds to poll for
-                when getting the result of the future.
+            polling_interval: Initial seconds to sleep between polling the
+                store for the object.
+            polling_backoff_factor: Multiplicative factor applied to the
+                polling_interval applied after each unsuccessful poll.
+            polling_interval_limit: Maximum polling interval allowed. Prevents
+                the backoff factor from increasing the current polling interval
+                to unreasonable values.
+            polling_timeout: Optional maximum number of seconds to poll for. If
+                the timeout is reached an error is raised.
 
         Returns:
             Future which can be used to get the result object at a later time \
@@ -304,6 +311,8 @@ class Store(Generic[ConnectorT]):
             deserializer=deserializer,
             evict=evict,
             polling_interval=polling_interval,
+            polling_backoff_factor=polling_backoff_factor,
+            polling_interval_limit=polling_interval_limit,
             polling_timeout=polling_timeout,
         )
         return Future(factory, serializer=serializer)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds the `polling_backoff_factor` and `polling_interval_limit` to `PollingStoreFactory` and `Store.future()`. The default values of these parameters maintain the previous functionality that the polling sleep interval is constant (the initial `polling_interval` value).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #497

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new test.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
