### PR TITLE
Add backwards compatibility for Pydantic V1

### DIFF
--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -11,7 +11,12 @@ from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import field_validator
+
+try:
+    from pydantic import field_validator
+except ImportError:  # pragma: no cover
+    # Pydantic v1 compatibility
+    from pydantic import validator as field_validator
 
 from proxystore.endpoint.constants import MAX_OBJECT_SIZE_DEFAULT
 from proxystore.utils.config import dump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ endpoints = [
     "aiosqlite",
     "uvicorn[standard]",
     "psutil",
-    "pydantic>=2.0.0",
+    "pydantic",
     "pystun3",
     "python-daemon",
     "quart>=0.18.0",


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Add backwards compatibility for Pydantic V1. While running some benchmarks, it's become clear that Pydantic V1 compatibility is still more important than I expected. Specifically, the `globus_compute_common` and `colmena` packages used by the benchmark suite are still pinned to `pydantic<2.0.0`.

There are no breaking changes here.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [x] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

I manually ran the test suite in a venv with pydantic V1 installed. Note that all of the pydantic V1 branches are `pragma: no cover`. While maybe suboptimal, I have marked V1 compatibility as deprecated and I don't think it's worth the extra time of running the test suite twice with each version.

I don't anticipate the compatibility code be changed (or really much of the config load/dump at all), but if it does changes we'll have to be careful about testing against both versions.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
