### PR TITLE
Document and add utilities for taking ownership of returned proxies

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -31,6 +31,7 @@ from proxystore.store.factory import PollingStoreFactory
 from proxystore.store.factory import StoreFactory
 from proxystore.store.future import Future
 from proxystore.store.metrics import StoreMetrics
+from proxystore.store.ref import into_owned
 from proxystore.store.ref import OwnedProxy
 from proxystore.store.types import ConnectorKeyT
 from proxystore.store.types import ConnectorT
@@ -885,7 +886,7 @@ class Store(Generic[ConnectorT]):
         )
 
         if isinstance(possible_proxy, Proxy):
-            return OwnedProxy(possible_proxy.__factory__)
+            return into_owned(possible_proxy)
         return possible_proxy
 
     def put(

--- a/proxystore/store/ref.py
+++ b/proxystore/store/ref.py
@@ -399,6 +399,30 @@ def clone(proxy: OwnedProxy[T]) -> OwnedProxy[T]:
     return OwnedProxy(new_factory)
 
 
+def into_owned(proxy: Proxy[T]) -> OwnedProxy[T]:
+    """Convert a basic proxy into an owned proxy.
+
+    Warning:
+        It is the caller's responsibility to ensure that `proxy` has not been
+        copied already.
+
+    Note:
+        This will unset the `evict` flag on the proxy.
+
+    Raises:
+        ValueError: if `proxy` is already a
+            [`BaseRefProxy`][proxystore.store.ref.BaseRefProxy] instance.
+    """
+    if type(proxy) in (OwnedProxy, RefProxy, RefMutProxy):
+        # We don't use isinstance to prevent resolving the proxy.
+        raise ValueError(
+            'Only a base proxy can be converted into an owned proxy.',
+        )
+    factory = proxy.__factory__
+    factory.evict = False
+    return OwnedProxy(factory)
+
+
 def update(
     proxy: OwnedProxy[T] | RefMutProxy[T],
     *,

--- a/tests/store/ref_test.py
+++ b/tests/store/ref_test.py
@@ -12,6 +12,7 @@ from typing import TypeVar
 import pytest
 
 from proxystore.connectors.file import FileConnector
+from proxystore.proxy import is_resolved
 from proxystore.store import Store
 from proxystore.store import store_registration
 from proxystore.store.factory import StoreFactory
@@ -111,6 +112,28 @@ def test_mut_borrow_behaves_as_value(store: Store[FileConnector]) -> None:
     proxy = OwnedProxy(factory)
 
     borrowed = mut_borrow(proxy)
+    assert borrowed == 'value'
+
+
+def test_borrow_does_not_resolve(store: Store[FileConnector]) -> None:
+    factory = put_in_store('value', store)
+    proxy = OwnedProxy(factory)
+
+    assert not is_resolved(proxy)
+    borrowed = borrow(proxy)
+    assert not is_resolved(proxy)
+    assert not is_resolved(borrowed)
+    assert borrowed == 'value'
+
+
+def test_mut_borrow_does_not_resolve(store: Store[FileConnector]) -> None:
+    factory = put_in_store('value', store)
+    proxy = OwnedProxy(factory)
+
+    assert not is_resolved(proxy)
+    borrowed = mut_borrow(proxy)
+    assert not is_resolved(proxy)
+    assert not is_resolved(borrowed)
     assert borrowed == 'value'
 
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

When passing proxies to and from tasks executed on remote processes (e.g., via `ProcessPoolExecutor`, Parsl, Dask, etc.), returning an `OwnedProxy` from the task may not have the intended effect. Intuitively, you might think that this yields ownership from the invoked task that's creating the `OwnedProxy` to the client which is receiving the result of the task. However, when the invoked task's result gets serialized and then goes out of scope, the destructor of the `OwnedProxy` will evict the associated data. That means that when the client receives the `OwnedProxy`, it is now invalid.

The workaround is to return a `Proxy`, and then convert it to an `OwnedProxy` via `into_owned()` on the client side. This PR adds this helper function and documents this edge case in `submit()`.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
