### PR TITLE
Fix `submit()` resolving `RefProxy` and `RefMutProxy` arguments

### DIFF
--- a/proxystore/store/ref.py
+++ b/proxystore/store/ref.py
@@ -244,6 +244,7 @@ class RefProxy(BaseRefProxy[T]):
         super().__init__(factory)
 
     def __del__(self) -> None:
+        atexit.unregister(object.__getattribute__(self, '__finalizer__'))
         # If owner is None, then this RefMutProxy was likely serialized
         # and sent to a different process. As such, it is the responsibility
         # of that code to take over reference counting.
@@ -301,6 +302,7 @@ class RefMutProxy(BaseRefProxy[T]):
         super().__init__(factory)
 
     def __del__(self) -> None:
+        atexit.unregister(object.__getattribute__(self, '__finalizer__'))
         # If owner is None, then this RefMutProxy was likely serialized
         # and sent to a different process. As such, it is the responsibility
         # of that code to take over reference counting.

--- a/proxystore/store/scopes.py
+++ b/proxystore/store/scopes.py
@@ -51,6 +51,9 @@ def mark_refs_out_of_scope(
             owner.
     """
     for ref in refs:
+        if not object.__getattribute__(ref, '__valid__'):
+            # We've already encountered and handled this reference
+            continue
         owner = object.__getattribute__(ref, '__owner__')
         if owner is None:
             raise RuntimeError(
@@ -144,15 +147,15 @@ def submit(
     """
     kwargs = {} if kwargs is None else kwargs
 
-    refs: set[RefProxy[Any] | RefMutProxy[Any]] = {
+    refs: list[RefProxy[Any] | RefMutProxy[Any]] = [
         ref
         for ref in register_custom_refs
         if isinstance(ref, (RefProxy, RefMutProxy))
-    }
-    refs.update(
+    ]
+    refs.extend(
         arg for arg in args if isinstance(arg, (RefProxy, RefMutProxy))
     )
-    refs.update(
+    refs.extend(
         kwarg
         for kwarg in kwargs.values()
         if isinstance(kwarg, (RefProxy, RefMutProxy))


### PR DESCRIPTION
Inserting a proxy into a set resolves it because it calls __hash__.

<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

`submit()` was resolving `RefProxy` and `RefMutProxy` arguments because it adds those proxy types to a set. Inserting into a set calls `__hash__` which is forwarded to the target necessitating a resolve.

This was fixed by appending the proxies to a list, and ensuring the callback can appropriately handle lists of reference proxies with duplicates.

*I'm not happy about how much time I've lost debugging poor application performance due to this bug.*

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
