### PR TITLE
Add queue-based Redis shim for streaming

### DIFF
--- a/proxystore/stream/shims/redis.py
+++ b/proxystore/stream/shims/redis.py
@@ -22,6 +22,12 @@ import redis
 class RedisPublisher:
     """Redis pub/sub publisher shim.
 
+    Note:
+        In Redis pub/sub, all subscribers will receive *all* messages, and
+        messages will be dropped if no subscribers are present. The
+        [`RedisQueuePublisher`][proxystore.stream.shims.redis.RedisQueuePublisher]
+        provides message persistence and single consumption messages.
+
     Args:
         hostname: Redis server hostname.
         port: Redis server port.
@@ -121,4 +127,104 @@ class RedisSubscriber:
         """Close this subscriber."""
         self._pubsub_client.unsubscribe()
         self._pubsub_client.close()
+        self._redis_client.close()
+
+
+class RedisQueuePublisher:
+    """Redis queue publisher shim.
+
+    Note:
+        Only a single subscriber will be able to read each message sent to the
+        queue. The
+        [`RedisPublisher`][proxystore.stream.shims.redis.RedisPublisher]
+        uses pub/sub and supports broadcasting messages to all active
+        subscribers.
+
+    Args:
+        hostname: Redis server hostname.
+        port: Redis server port.
+        kwargs: Extra keyword arguments to pass to
+            [`redis.Redis()`][redis.Redis].
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        **kwargs: Any,
+    ) -> None:
+        self._redis_client = redis.StrictRedis(
+            host=hostname,
+            port=port,
+            **kwargs,
+        )
+
+    def close(self) -> None:
+        """Close this publisher."""
+        self._redis_client.close()
+
+    def send(self, topic: str, message: bytes) -> None:
+        """Publish a message to the stream.
+
+        Args:
+            topic: Stream topic to publish message to.
+            message: Message as bytes to publish to the stream.
+        """
+        self._redis_client.rpush(topic, message)
+
+
+class RedisQueueSubscriber:
+    """Redis queue subscriber shim.
+
+    This shim is an iterable object which will yield [`bytes`][bytes]
+    messages from the queue, blocking on the next message, forever.
+
+    Args:
+        hostname: Redis server hostname.
+        port: Redis server port.
+        topic: Topic to subscribe to (I.e., the name of the key corresponding
+            to a Redis list).
+        timeout: Timeout for waiting on the next item. If `None`, the timeout
+            will be set to one second but will loop indefinitely.
+        kwargs: Extra keyword arguments to pass to
+            [`redis.Redis()`][redis.Redis].
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        topic: str,
+        *,
+        timeout: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._redis_client = redis.StrictRedis(
+            host=hostname,
+            port=port,
+            **kwargs,
+        )
+        self._topic = topic
+        self._timeout = timeout
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> bytes:
+        timeout = self._timeout if self._timeout is not None else 1
+        while True:
+            output = self._redis_client.blpop(self._topic, timeout=timeout)
+            if output is None and self._timeout is not None:
+                raise TimeoutError(
+                    f'Timeout waiting on Redis queue with key {self._topic}.',
+                )
+            elif output is None:  # pragma: no cover
+                # Testing this case with a mocked RedisClient is tricky
+                # because we just end up in a while True loop.
+                continue
+            else:
+                return output[1]
+
+    def close(self) -> None:
+        """Close this subscriber."""
         self._redis_client.close()

--- a/testing/mocked/redis.py
+++ b/testing/mocked/redis.py
@@ -31,6 +31,18 @@ class MockStrictRedis:
             queue.Queue() if pubsub_queue is None else pubsub_queue
         )
 
+    def blpop(
+        self,
+        *keys: str,
+        timeout: int = 0,
+    ) -> tuple[str | bytes, ...] | None:
+        result: list[str | bytes] = []
+        for key in keys:
+            if key not in self.data or len(self.data[key]) == 0:
+                return None
+            result.extend([key, self.data[key].pop(0)])
+        return tuple(result)
+
     def close(self) -> None:
         """Close the client."""
         pass
@@ -76,6 +88,12 @@ class MockStrictRedis:
     def pubsub(self) -> MockPubSub:
         """Create a pubsub client."""
         return MockPubSub(self)
+
+    def rpush(self, key: str, *values: bytes) -> None:
+        """Push values onto list."""
+        if key not in self.data:
+            self.data[key] = []
+        self.data[key].extend(values)
 
     def set(self, key: str, value: bytes) -> None:
         """Set value in MockStrictRedis."""

--- a/tests/stream/shims/redis_test.py
+++ b/tests/stream/shims/redis_test.py
@@ -8,6 +8,8 @@ from unittest import mock
 import pytest
 
 from proxystore.stream.shims.redis import RedisPublisher
+from proxystore.stream.shims.redis import RedisQueuePublisher
+from proxystore.stream.shims.redis import RedisQueueSubscriber
 from proxystore.stream.shims.redis import RedisSubscriber
 from testing.mocked.redis import Message
 from testing.mocked.redis import MockStrictRedis
@@ -43,3 +45,37 @@ def test_basic_publish_subscribe() -> None:
     subscriber.close()
 
     assert messages == received
+
+
+def test_basic_queue_publish_subscribe() -> None:
+    publisher = RedisQueuePublisher('localhost', 0)
+    subscriber = RedisQueueSubscriber('localhost', 0, 'default')
+
+    messages = [f'message_{i}'.encode() for i in range(3)]
+
+    for message in messages:
+        publisher.send('default', message)
+
+    publisher.close()
+
+    received = []
+    for _, message in zip(messages, subscriber):
+        received.append(message)
+
+    subscriber.close()
+
+    assert messages == received
+
+
+def test_basic_queue_empty() -> None:
+    subscriber = RedisQueueSubscriber('localhost', 0, 'default', timeout=1)
+
+    with pytest.raises(TimeoutError):
+        next(subscriber)
+
+
+def test_basic_queue_timeout() -> None:
+    subscriber = RedisQueueSubscriber('localhost', 0, 'default', timeout=1)
+
+    with pytest.raises(TimeoutError):
+        next(subscriber)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The existing `RedisSubscriber/Publisher` use Redis Pub/Sub, which has the downside of dropping messages when no subscriber is present. The `RedisQueueSubscriber/Publisher` are an alternative that uses a Redis list and `rpush`/`blpop` to implement a persistent queue where messages will not be dropped.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests which test against a mock Redis client, and used the following script to test against a real Redis server running locally.

```python
import uuid
from proxystore.stream.shims.redis import RedisQueueSubscriber
from proxystore.stream.shims.redis import RedisQueuePublisher

host = '127.0.0.1'
port = 6379
queue = str(uuid.uuid4())

publisher = RedisQueuePublisher(host, port)
subscriber = RedisQueueSubscriber(host, port, queue)

values = [b'value1', b'value2', b'value3']

for value in values:
    publisher.send(queue, value)

for expected, found in zip(values, subscriber):
    assert found == expected

print('Finished basic test')

try:
    print('Waiting with no timeout... ctrl-c to stop')
    next(subscriber)
except KeyboardInterrupt:
    print('Continuing')

subscriber = RedisQueueSubscriber(host, port, queue, timeout=1)

try:
    print('Waiting with timeout 1')
    next(subscriber)
except TimeoutError:
    print('TimeoutError raised as expected')

print('Done.'
```

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
