### PR TITLE
Add `Lifetime` support for managing shared objects

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -35,3 +35,14 @@
 .md-tabs__link {
   font-weight: 600;
 }
+
+/* Center Markdown Tables (requires md_in_html extension) */
+/* https://github.com/squidfunk/mkdocs-material/issues/3430#issuecomment-1005973474 */
+.center-table {
+    text-align: center;
+}
+
+.md-typeset .center-table :is(td,th):not([align]) {
+    /* Reset alignment for table cells */
+    text-align: initial;
+}

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,6 +8,7 @@
 * [Globus Compute](globus-compute.md)
 * [Endpoints Overview](endpoints.md)
 * [Endpoints Debugging](endpoints-debugging.md)
+* [Object Lifetimes](object-lifetimes.md)
 * [Performance Tracking](performance.md)
 * [Proxy Futures](proxy-futures.md)
 * [Relay Serving](relay-serving.md)

--- a/docs/guides/object-lifetimes.md
+++ b/docs/guides/object-lifetimes.md
@@ -1,0 +1,210 @@
+# Object Lifetimes
+
+*Last updated 20 March 2024*
+
+The [`Store`][proxystore.store.base.Store], by default, leaves the responsibility of manageing shared objects to the application.
+For example, a object put into a [`Store`][proxystore.store.base.Store] will persist there until the key is manually evicted.
+Some [`Connectors`][proxystore.connectors.protocols.Connector], and therefore [`Stores`][proxystore.store.base.Store], delete all of their objects when closed but this is not a specified requirement of the protocol.
+
+ProxyStore, however, provides optional mechanisms for more automated management of shared objects.
+
+<div class="center-table" markdown>
+
+| Method | Supports keys? | Supports proxies? |
+| :----- | :------------: | :--------------: |
+| [Ephemeral Proxies](#ephemeral-proxies) | ✗ | ✓ |
+| [Lifetimes](#lifetimes) | ✓ | ✓ |
+| [Ownership](#ownership) | ✗ | ✓ |
+
+</div>
+
+*Note: Currently, these methods are mutually exclusive with each other.*
+
+## Ephemeral Proxies
+
+Setting the `evict=True` flag when creating a proxy of an object with
+[`Store.proxy()`][proxystore.store.base.Store.proxy],
+[`Store.proxy_batch()`][proxystore.store.base.Store.proxy_batch],
+[`Store.proxy_from_key()`][proxystore.store.base.Store.proxy_from_key], or
+[`Store.locked_proxy()`][proxystore.store.base.Store.locked_proxy]
+marks the proxy as ephemeral (one-time use).
+The factory will evict the object from the store when the proxy's factory is invoked for the first time to resolve the proxy.
+This is useful when the a proxy will be created once and consumed once by an application.
+
+A common side-effect of `evict=True` is obscure [`ProxyResolveMissingKeyError`][proxystore.store.exceptions.ProxyResolveMissingKeyError] tracebacks.
+This commonly happens when a proxy is unintentionally resolved by another component of the program.
+For example, certain serializers may attempt to inspect the proxy to optimize serialization but resolve the proxy in the process, or datastructures like [`set()`][set] access the `__hash__` method of the proxy which will resolve the proxy.
+These accidental resolves will automatically evict the target object so later resolves of the proxy will fail.
+
+If you run into these errors, try:
+
+* Enabling `DEBUG` level logging to determine where unintentional proxy resolution is occurring.
+  The [`Store`][proxystore.store.base.Store] will log every `GET` and `EVICT` operation on a key.
+* Avoid use of datastructures or functions which unnecessarily resolve proxies.
+* If avoiding use of the datastructures or functions causing the problem is not possible, consider using the `populate_target=True` flag when creating the proxy.
+  The `populate_target` flag will return a proxy that is already resolved so the factory, which would evict the target object, does not need to be called until the proxy is serialized and then deserialized and resolved on a different process.
+
+## Lifetimes
+
+Shared objects in a [`Store`][proxystore.store.base.Store] can be associated with a [`Lifetime`][proxystore.store.lifetimes.Lifetime].
+Lifetimes provide a management mechanism for keeping track of objects and cleaning them up when appropriate.
+
+### Contextual Lifetime
+
+The [`ContextLifetime`][proxystore.store.lifetimes.ContextLifetime] provides a simple interface for managing shared objects.
+Objects added to a [`Store`][proxystore.store.base.Store] can be associated with the lifetime via the `lifetime` parameter supported by most [`Store`][proxystore.store.base.Store] methods.
+Objects associated with the lifetime are evicted when the lifetime is closed/ended.
+
+```python linenums="1" title="Contextual Lifetime"
+from proxystore.store.base import Store
+from proxystore.store.lifetimes import ContextLifetime
+
+store = Store(...)
+
+lifetime = ContextLifetime(store)  # (1)!
+
+key = store.put('value', lifetime=lifetime)  # (2)!
+proxy = store.proxy('value', lifetime=lifetime)  # (3)!
+
+lifetime.close()  # (4)!
+assert not store.exists(key)
+
+store.close()  # (5)!
+```
+
+1. The [`ContextLifetime`][proxystore.store.lifetimes.ContextLifetime] and all its associated objects must be associated with the same [`Store`][proxystore.store.base.Store].
+2. A new key can be automatically associated with a lifetime.
+3. The target object of a proxy can be automatically associated with a lifetime.
+4. Ending a lifetime will cause all of its associated objects to be evicted.
+5. The [`Store`][proxystore.store.base.Store] should be closed after any associated lifetimes because lifetimes use the [`Store`][proxystore.store.base.Store] for cleanup.
+
+The [`ContextLifetime`][proxystore.store.lifetimes.ContextLifetime] can be used as a context manager.
+
+```python linenums="1" title="Contextual Lifetime"
+from proxystore.store.base import Store
+from proxystore.store.lifetimes import ContextLifetime
+
+store = Store(...)
+
+with ContextLifetime(store) as lifetime:
+    key = store.put('value', lifetime=lifetime)
+    proxy = store.proxy('value', lifetime=lifetime)
+
+assert not store.exists(key)
+
+store.close()  # (5)!
+```
+
+### Leased Lifetime
+
+The [`LeaseLifetime`][proxystore.store.lifetimes.LeaseLifetime] provides time-based object lifetimes.
+Each [`LeaseLifetime`][proxystore.store.lifetimes.LeaseLifetime] has an associated expiration time after which any associated objects will be evicted.
+The lease can be extended as needed with [`extend()`][proxystore.store.lifetimes.LeaseLifetime.extend] or ended early [`close()`][proxystore.store.lifetimes.LeaseLifetime.close].
+
+```python linenums="1" title="Leased Lifetime"
+
+from proxystore.store.base import Store
+from proxystore.store.lifetimes import LeaseLifetime
+
+with Store(...) as store:
+    lifetime = LeaseLifetime(store, expiry=10)  # (1)!
+
+    key = store.put('value', lifetime=lifetime)
+    proxy = store.proxy('value', lifetime=lifetime)
+
+    lifetime.extend(5)  # (2)!
+
+    time.sleep(20)  #(3)!
+
+    assert lifetime.done()  #(4)!
+    assert not store.exists(key)
+```
+
+1. Create a new lifetime with a current lease of ten seconds.
+2. Extend the lease by another five seconds.
+3. Sleep for longer than our current lease.
+4. Lease has expired so the lifetime has ended and associated objects have been evicted.
+
+### Static Lifetime
+
+A static lifetime indicates that the associated objects should live for the remainder of the lifetime of the running process which created the object.
+ProxyStore does not yet support a `StaticLifetime` class, but static lifetimes can be achieved with the use of a [`ContextLifetime`][proxystore.store.lifetimes.ContextLifetime] and an [atexit][atexit] handler.
+
+```python linenums="1" title="Static Lifetime"
+from proxystore.store.base import Store
+from proxystore.store.lifetimes import ContextLifetime
+from proxystore.store.lifetimes import register_lifetime_atexit
+
+store = Store(...)
+
+lifetime = ContextLifetime(store)  # (1)!
+register_lifetime_atexit(lifetime, close_store=True)  # (2)!
+
+key = store.put('value', lifetime=lifetime)  # (3)!
+proxy = store.proxy('value', lifetime=lifetime)
+```
+
+1. Create and use a [`ContextLifetime`][proxystore.store.lifetimes.ContextLifetime] as normal.
+2. Register an [atexit][atexit] handler with [`register_lifetime_atexit`][proxystore.store.lifetimes.register_lifetime_atexit].
+   The `close_store` flag is `True` by default and will close the [`Store`][proxystore.store.base.Store] after the lifetime has been cleaned up.
+3. Objects associated with the lifetime will be cleaned up when the program exits.
+
+Additional tips:
+
+1. The lifetime can be closed early if needed.
+2. Closing the [`Store`][proxystore.store.base.Store] at the end of the program but before the [atexit][atexit] handler has executed can cause undefined behaviour.
+   Let the handler perform all cleanup.
+3. [atexit][atexit] does not guarantee that the handler will be called in some unexpected process shutdown cases.
+
+## Ownership
+
+An [`OwnedProxy`][proxystore.store.ref.OwnedProxy], created by [`Store.owned_proxy()`][proxystore.store.base.Store.owned_proxy], provides an alternative to the default [`Proxy`][proxystore.proxy.Proxy] which enforces Rust-like ownership and borrowing rules for objects in a [`Store`][proxystore.store.base.Store].
+
+1. Each *target* object of type `T` in the global store has an associated [`OwnedProxy[T]`][proxystore.store.ref.OwnedProxy].
+2. There can only be one [`OwnedProxy[T]`][proxystore.store.ref.OwnedProxy] for any *target* in the global store.
+3. When an [`OwnedProxy[T]`][proxystore.store.ref.OwnedProxy] goes out of scope (e.g., gets garbage collected), the associated *target* is removed from the global store.
+
+An [`OwnedProxy[T]`][proxystore.store.ref.OwnedProxy] can be borrowed without relinquishing ownership.
+This requires two additional rules.
+
+1. At any given time, you can have either one mutable reference to the *target*, a [`RefMutProxy[T]`][proxystore.store.ref.RefMutProxy], or any number of immutable references, a [`RefProxy[T]`][proxystore.store.ref.RefProxy].
+2. References must always be valid. I.e., you cannot delete an [`OwnedProxy[T]`][proxystore.store.ref.OwnedProxy] while it has been borrowed via a [`RefProxy[T]`][proxystore.store.ref.RefProxy] or [`RefMutProxy[T]`][proxystore.store.ref.RefMutProxy].
+
+Reference proxy types can be created and used using:
+[`borrow()`][proxystore.store.ref.borrow],
+[`mut_borrow()`][proxystore.store.ref.mut_borrow],
+[`clone()`][proxystore.store.ref.clone],
+[`into_owned()`][proxystore.store.ref.into_owned], and
+[`update()`][proxystore.store.ref.update].
+
+The [`submit()`][proxystore.store.scopes.submit] associates proxy references with the scope of a function executed by a function executor, such as a [`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor] or FaaS system.
+This wrapper function ensures that immutable or mutable borrows of a value passed to a function are appropriately removed once the function completes.
+
+```python linenums="1" title="Reference Lifetime Scopes"
+from concurrent.futures import Future
+from concurrent.futures import ProcessPoolExecutor
+from proxystore.store.base import Store
+from proxystore.store.ref import borrow
+
+store = Store(...)
+proxy = store.owned_proxy('value')
+borrowed = borrow(proxy)  # (1)!
+
+with ProcessPoolExecutor() as pool:
+    future: Future[int] = submit(
+        pool.submit,  # (2)!
+        args=(sum, borrowed),  # (3)!
+    )
+    assert future.result() == 6  # (4)!
+
+del proxy  # (5)!
+
+store.close()
+```
+
+1. Borrow an [`OwnedProxy`][proxystore.store.ref.OwnedProxy] as a [`RefProxy`][proxystore.store.ref.RefProxy].
+2. [`submit()`][proxystore.store.scopes.submit] will call `pool.submit()` with the specified `args` and `kwargs`.
+   Here, [`sum`][sum] will be the function invoked on a single argument `borrowed` which is a proxy of a list of integers.
+3. The `args` and `kwargs` will be scanned for any proxy reference types, and a callback will be added to the returned future that marks the input proxy references as out-of-scope once the future completes.
+4. Once the future is completed, the `borrowed` reference is marked out-of-scope and the reference count of borrows managed internally in `proxy` is decremented.
+5. The [`OwnedProxy`][proxystore.store.ref.OwnedProxy], `proxy`, which owns the target value is safe to delete and get garbage collected because there are no remaining reference proxies which have borrowed the target value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
       - Globus Compute: guides/globus-compute.md
       - Endpoints Overview: guides/endpoints.md
       - Endpoints Debugging: guides/endpoints-debugging.md
+      - Object Lifetimes: guides/object-lifetimes.md
       - Performance Tracking: guides/performance.md
       - Proxy Futures: guides/proxy-futures.md
       - Relay Serving: guides/relay-serving.md

--- a/proxystore/store/lifetimes.py
+++ b/proxystore/store/lifetimes.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import Any
 from typing import Protocol
 from typing import runtime_checkable
+from typing import TYPE_CHECKING
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -14,10 +15,12 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 from proxystore.proxy import Proxy
-from proxystore.store.base import Store
 from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.factory import StoreFactory
 from proxystore.store.types import ConnectorKeyT
+
+if TYPE_CHECKING:
+    from proxystore.store.base import Store
 
 
 @runtime_checkable

--- a/proxystore/store/lifetimes.py
+++ b/proxystore/store/lifetimes.py
@@ -1,0 +1,152 @@
+"""Lifetime managers for objects in shared stores."""
+
+from __future__ import annotations
+
+import sys
+from types import TracebackType
+from typing import Any
+from typing import Protocol
+from typing import runtime_checkable
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+from proxystore.proxy import Proxy
+from proxystore.store.base import Store
+from proxystore.store.exceptions import ProxyStoreFactoryError
+from proxystore.store.factory import StoreFactory
+from proxystore.store.types import ConnectorKeyT
+
+
+@runtime_checkable
+class Lifetime(Protocol):
+    """Lifetime protocol.
+
+    Attributes:
+        store: [`Store`][proxystore.store.base.Store] instance use to create
+            the objects associated with this lifetime and that will be used
+            to evict them when the lifetime has ended.
+    """
+
+    store: Store[Any]
+
+    def close(self) -> None:
+        """End the lifetime and evict all associated objects."""
+        ...
+
+    def done(self) -> bool:
+        """Check if lifetime has ended."""
+        ...
+
+    def add_key(self, *keys: ConnectorKeyT) -> None:
+        """Associate a new object with the lifetime.
+
+        Warning:
+            All keys should have been created by the same
+            [`Store`][proxystore.store.base.Store] that this lifetime was
+            initialized with.
+
+        Args:
+            keys: One or more keys of objects to associate with this lifetime.
+        """
+        ...
+
+    def add_proxy(self, *proxies: Proxy[Any]) -> None:
+        """Associate a new object with the lifetime.
+
+        Warning:
+            All proxies should have been created by the same
+            [`Store`][proxystore.store.base.Store] that this lifetime was
+            initialized with.
+
+        Args:
+            proxies: One or more proxies of objects to associate with this
+                lifetime.
+
+        Raises:
+            ProxyStoreFactoryError: If the proxy's factory is not an instance
+                of [`StoreFactory`][proxystore.store.base.StoreFactory].
+        """
+        ...
+
+
+class ContextLifetime:
+    """Basic lifetime manager.
+
+    Basic object lifetime manager with context manager support.
+
+    Args:
+        store: [`Store`][proxystore.store.base.Store] instance use to create
+            the objects associated with this lifetime and that will be used
+            to evict them when the lifetime has ended.
+    """
+
+    def __init__(self, store: Store[Any]) -> None:
+        self.store = store
+        self._done = False
+        self._keys: set[ConnectorKeyT] = set()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """End the lifetime and evict all associated objects."""
+        for key in self._keys:
+            self.store.evict(key)
+        self._done = True
+
+    def done(self) -> bool:
+        """Check if lifetime has ended."""
+        return self._done
+
+    def add_key(self, *keys: ConnectorKeyT) -> None:
+        """Associate a new object with the lifetime.
+
+        Warning:
+            All keys should have been created by the same
+            [`Store`][proxystore.store.base.Store] that this lifetime was
+            initialized with.
+
+        Args:
+            keys: One or more keys of objects to associate with this lifetime.
+        """
+        self._keys.update(keys)
+
+    def add_proxy(self, *proxies: Proxy[Any]) -> None:
+        """Associate a new object with the lifetime.
+
+        Warning:
+            All proxies should have been created by the same
+            [`Store`][proxystore.store.base.Store] that this lifetime was
+            initialized with.
+
+        Args:
+            proxies: One or more proxies of objects to associate with this
+                lifetime.
+
+        Raises:
+            ProxyStoreFactoryError: If the proxy's factory is not an instance
+                of [`StoreFactory`][proxystore.store.base.StoreFactory].
+        """
+        keys: list[ConnectorKeyT] = []
+        for proxy in proxies:
+            factory = proxy.__factory__
+            if isinstance(factory, StoreFactory):
+                keys.append(factory.key)
+            else:
+                raise ProxyStoreFactoryError(
+                    'The proxy must contain a factory with type '
+                    f'{type(StoreFactory).__name__}. {type(factory).__name__} '
+                    'is not supported.',
+                )
+        self.add_key(*keys)

--- a/proxystore/store/lifetimes.py
+++ b/proxystore/store/lifetimes.py
@@ -1,4 +1,8 @@
-"""Lifetime managers for objects in shared stores."""
+"""Lifetime managers for objects in shared stores.
+
+Learn more about managing object lifetimes in the
+[Object Lifetimes](../../guides/object-lifetimes.md) guide.
+"""
 
 from __future__ import annotations
 

--- a/proxystore/store/lifetimes.py
+++ b/proxystore/store/lifetimes.py
@@ -304,11 +304,17 @@ class LeaseLifetime(ContextLifetime):
     def _timer_callback(self) -> None:
         if time.time() >= self._expiry:
             self.close()
-        else:
+        else:  # pragma: no cover
+            # Excluded from coverage because some MacOS GitHub actions runners
+            # are slow enough that the timer always ends after the expiry
+            # in the tests cases. We could make the expiry very long, but
+            # that would just slow down the test suite.
             self._start_timer()
 
     def _start_timer(self) -> None:
-        if self._timer is not None:
+        if self._timer is not None:  # pragma: no cover
+            # Excluded from coverage for the same reason as in
+            # _timer_callback().
             self._timer.cancel()
         interval = max(0, self._expiry - time.time())
         self._timer = threading.Timer(interval, self._timer_callback)

--- a/tests/store/lifetimes_test.py
+++ b/tests/store/lifetimes_test.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxystore.connectors.local import LocalConnector
+from proxystore.proxy import Proxy
+from proxystore.store.base import Store
+from proxystore.store.exceptions import ProxyStoreFactoryError
+from proxystore.store.lifetimes import ContextLifetime
+from proxystore.store.lifetimes import Lifetime
+
+
+def test_context_lifetime_protocol(store: Store[LocalConnector]) -> None:
+    lifetime = ContextLifetime(store)
+    assert isinstance(lifetime, Lifetime)
+    lifetime.close()
+
+
+def test_context_lifetime_cleanup(store: Store[LocalConnector]) -> None:
+    key1 = store.put('value1')
+    key2 = store.put('value2')
+    key3 = store.put('value3')
+    key4 = store.put('value4')
+    proxy1: Proxy[str] = store.proxy_from_key(key3)
+    proxy2: Proxy[str] = store.proxy_from_key(key4)
+
+    with ContextLifetime(store) as lifetime:
+        assert not lifetime.done()
+
+        lifetime.add_key(key1, key2)
+        lifetime.add_proxy(proxy1, proxy2)
+
+    assert lifetime.done()
+
+    assert not store.exists(key1)
+    assert not store.exists(key2)
+    assert not store.exists(key3)
+    assert not store.exists(key4)
+
+
+def test_context_lifetime_add_bad_proxy(store: Store[LocalConnector]) -> None:
+    proxy: Proxy[list[Any]] = Proxy(list)
+
+    with ContextLifetime(store) as lifetime:
+        with pytest.raises(ProxyStoreFactoryError):
+            lifetime.add_proxy(proxy)

--- a/tests/store/lifetimes_test.py
+++ b/tests/store/lifetimes_test.py
@@ -107,7 +107,9 @@ def test_lease_lifetime_extend(
 ) -> None:
     lifetime = LeaseLifetime(store, expiry=0.001)
     lifetime.extend(expiry)
-    time.sleep(0.003)
+
+    time.sleep(0.005)
+
     assert lifetime.done()
 
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Extends the `Store` to support associating newly created shared objects with a `Lifetime`, and adds two `Lifetime` implementations: the `ContextLifetime` and `LeasedLifetime`.

The original issue for this PR (#482) discussed supporting lifetimes in the context of proxy references (e.g., `OwnedProxy`, `RefProxy`, and `RefMutProxy`), but after working through the implementation, I decided it was better to take the approach of lifetimes being an alternate to proxy references because proxy references already encode a notion of lifetime.

It would be interesting to unify these in the future, so I've opened another issue to track that.

A new guide, "Object Lifetimes," has been created which discusses differences between and gives examples of the three mechanisms in ProxyStore for managing objects.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #482 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [x] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
