### PR TITLE
Handle and pass on SIGINT propagated by Uvicorn after cleanup

### DIFF
--- a/proxystore/endpoint/commands.py
+++ b/proxystore/endpoint/commands.py
@@ -337,8 +337,9 @@ def start_endpoint(
     else:
         context = _attached_pid_manager(pid_file)
 
-    # TODO: handle sigterm/sigkill exit codes/graceful shutdown.
     with context:
+        # Note: serve will handle most interrupts which can be reasonably
+        # handled and return gracefully.
         serve(cfg, log_level=log_level, log_file=log_file)
 
     return 0


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Uvicorn 0.29.0 no longer captures, handles, and then surpresses SIGINT. Rather, SIGINT is repropagated by Uvicorn so we need to capture it again and pass. It is safe to pass because we let Uvicorn handle clean up for the endpoint.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #XX

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

I tested with this script on the old and new versions of uvicorn by starting the script and then sending each signal type with `kill -s SIGTERM [PID]`.
```python
import logging
import uuid

from proxystore.endpoint.config import EndpointConfig
from proxystore.endpoint.serve import serve

from testing.utils import open_port

logging.basicConfig()

config = EndpointConfig(
    name='test',
    uuid=str(uuid.uuid4()),
    host='localhost',
    port=open_port(),
)

serve(config, log_level='DEBUG')
```

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
