### PR TITLE
Prevent evicting the target object when invalidated `OwnedProxy` instances are garbage collected

### DIFF
--- a/tests/store/ref_test.py
+++ b/tests/store/ref_test.py
@@ -409,3 +409,16 @@ def test_into_owned_populate(
 
     owned = into_owned(proxy, populate_target=populate_target)
     assert is_resolved(owned) == populate_target
+
+
+def test_del_invalid_owned_proxy(store: Store[FileConnector]) -> None:
+    factory = put_in_store('value', store)
+    proxy = OwnedProxy(factory)
+
+    proxy_pkl = pickle.dumps(proxy)
+    new_proxy = pickle.loads(proxy_pkl)
+
+    # Should do nothing because old proxy was made invalid
+    del proxy
+
+    assert new_proxy == 'value'


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

An `OwnedProxy` can be invalidated when being serialized and sent to another process. However, garbage collecting the original `OwnedProxy` will evict the target object. This PR fixes this to avoid garbage collecting the target object in invalid `OwnedProxy`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #521

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
