### PR TITLE
Fix incorrect ns to ms conversion in `Metrics`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -315,7 +315,7 @@ class Store(Generic[ConnectorT]):
             key = self.connector.new_key()
 
         if self.metrics is not None:
-            ctime = connector_timer.elapsed_ns
+            ctime = connector_timer.elapsed_ms
             self.metrics.add_time('store.future.connector', key, ctime)
 
         factory: PollingStoreFactory[ConnectorT, T] = PollingStoreFactory(
@@ -332,7 +332,7 @@ class Store(Generic[ConnectorT]):
 
         timer.stop()
         if self.metrics is not None:
-            self.metrics.add_time('store.future', key, timer.elapsed_ns)
+            self.metrics.add_time('store.future', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): FUTURE {key} in '
@@ -351,13 +351,13 @@ class Store(Generic[ConnectorT]):
                 self.connector.evict(key)
 
             if self.metrics is not None:
-                ctime = connector_timer.elapsed_ns
+                ctime = connector_timer.elapsed_ms
                 self.metrics.add_time('store.evict.connector', key, ctime)
 
             self.cache.evict(key)
 
         if self.metrics is not None:
-            self.metrics.add_time('store.evict', key, timer.elapsed_ns)
+            self.metrics.add_time('store.evict', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): EVICT {key} in '
@@ -380,11 +380,11 @@ class Store(Generic[ConnectorT]):
                     res = self.connector.exists(key)
 
                 if self.metrics is not None:
-                    ctime = connector_timer.elapsed_ns
+                    ctime = connector_timer.elapsed_ms
                     self.metrics.add_time('store.exists.connector', key, ctime)
 
         if self.metrics is not None:
-            self.metrics.add_time('store.exists', key, timer.elapsed_ns)
+            self.metrics.add_time('store.exists', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): EXISTS {key} in '
@@ -424,7 +424,7 @@ class Store(Generic[ConnectorT]):
             timer.stop()
             if self.metrics is not None:
                 self.metrics.add_counter('store.get.cache_hits', key, 1)
-                self.metrics.add_time('store.get', key, timer.elapsed_ns)
+                self.metrics.add_time('store.get', key, timer.elapsed_ms)
 
             logger.debug(
                 f'Store(name="{self.name}"): GET {key} in '
@@ -436,7 +436,7 @@ class Store(Generic[ConnectorT]):
             value = self.connector.get(key)
 
         if self.metrics is not None:
-            ctime = connector_timer.elapsed_ns
+            ctime = connector_timer.elapsed_ms
             self.metrics.add_counter('store.get.cache_misses', key, 1)
             self.metrics.add_time('store.get.connector', key, ctime)
 
@@ -457,7 +457,7 @@ class Store(Generic[ConnectorT]):
                     ) from e
 
             if self.metrics is not None:
-                dtime = deserializer_timer.elapsed_ns
+                dtime = deserializer_timer.elapsed_ms
                 obj_size = len(value)
                 self.metrics.add_time('store.get.deserialize', key, dtime)
                 self.metrics.add_attribute(
@@ -472,7 +472,7 @@ class Store(Generic[ConnectorT]):
 
         timer.stop()
         if self.metrics is not None:
-            self.metrics.add_time('store.get', key, timer.elapsed_ns)
+            self.metrics.add_time('store.get', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): GET {key} in '
@@ -606,7 +606,7 @@ class Store(Generic[ConnectorT]):
                 proxy.__wrapped__ = obj
 
         if self.metrics is not None:
-            self.metrics.add_time('store.proxy', key, timer.elapsed_ns)
+            self.metrics.add_time('store.proxy', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): PROXY {key} in '
@@ -748,7 +748,7 @@ class Store(Generic[ConnectorT]):
                         proxy.__wrapped__ = obj
 
         if self.metrics is not None:
-            self.metrics.add_time('store.proxy_batch', keys, timer.elapsed_ns)
+            self.metrics.add_time('store.proxy_batch', keys, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): PROXY_BATCH ({len(proxies)} items) '
@@ -1026,12 +1026,12 @@ class Store(Generic[ConnectorT]):
 
         timer.stop()
         if self.metrics is not None:
-            ctime = connector_timer.elapsed_ns
-            stime = serialize_timer.elapsed_ns
+            ctime = connector_timer.elapsed_ms
+            stime = serialize_timer.elapsed_ms
             self.metrics.add_attribute('store.put.object_size', key, len(obj))
             self.metrics.add_time('store.put.serialize', key, stime)
             self.metrics.add_time('store.put.connector', key, ctime)
-            self.metrics.add_time('store.put', key, timer.elapsed_ns)
+            self.metrics.add_time('store.put', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): PUT {key} in '
@@ -1089,8 +1089,8 @@ class Store(Generic[ConnectorT]):
 
         timer.stop()
         if self.metrics is not None:
-            ctime = connector_timer.elapsed_ns
-            stime = serialize_timer.elapsed_ns
+            ctime = connector_timer.elapsed_ms
+            stime = serialize_timer.elapsed_ms
             sizes = sum(len(obj) for obj in _objs)
             self.metrics.add_attribute(
                 'store.put_batch.object_sizes',
@@ -1099,7 +1099,7 @@ class Store(Generic[ConnectorT]):
             )
             self.metrics.add_time('store.put_batch.serialize', keys, stime)
             self.metrics.add_time('store.put_batch.connector', keys, ctime)
-            self.metrics.add_time('store.put_batch', keys, timer.elapsed_ns)
+            self.metrics.add_time('store.put_batch', keys, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): PUT_BATCH ({len(keys)} items) in '
@@ -1170,12 +1170,12 @@ class Store(Generic[ConnectorT]):
 
         timer.stop()
         if self.metrics is not None:
-            ctime = connector_timer.elapsed_ns
-            stime = serialize_timer.elapsed_ns
+            ctime = connector_timer.elapsed_ms
+            stime = serialize_timer.elapsed_ms
             self.metrics.add_attribute('store.set.object_size', key, len(obj))
             self.metrics.add_time('store.set.serialize', key, stime)
             self.metrics.add_time('store.set.connector', key, ctime)
-            self.metrics.add_time('store.set', key, timer.elapsed_ns)
+            self.metrics.add_time('store.set', key, timer.elapsed_ms)
 
         logger.debug(
             f'Store(name="{self.name}"): SET {key} in '

--- a/proxystore/store/metrics.py
+++ b/proxystore/store/metrics.py
@@ -148,18 +148,18 @@ class StoreMetrics:
         else:
             counters[name] = value
 
-    def add_time(self, name: str, key: KeyT, time_ns: int) -> None:
+    def add_time(self, name: str, key: KeyT, time_ms: float) -> None:
         """Record a new time for an event.
 
         Args:
             name: Event or operation the time is for.
             key: Key associated with the event.
-            time_ns: The time in nanoseconds of the event.
+            time_ms: The time in milliseconds of the event.
         """
         times = self._metrics[_hash_key(key)].times
         if name not in times:
             times[name] = TimeStats()
-        times[name].add_time(time_ns / 1000)
+        times[name].add_time(time_ms)
 
     def aggregate_times(self) -> dict[str, TimeStats]:
         """Aggregate time statistics over all keys.

--- a/tests/store/metrics_test.py
+++ b/tests/store/metrics_test.py
@@ -64,8 +64,8 @@ def test_store_metrics_by_key() -> None:
         metrics.add_attribute('test-attribute', key, 'value')
         metrics.add_counter('test-counter', key, 1)
         metrics.add_counter('test-counter', key, 1)
-        metrics.add_time('test-timer', key, 1000)
-        metrics.add_time('test-timer', key, 2000)
+        metrics.add_time('test-timer', key, 1)
+        metrics.add_time('test-timer', key, 2)
 
         key_metrics = metrics.get_metrics(key)
         assert key_metrics is not None
@@ -108,8 +108,8 @@ def test_store_metrics_aggregate_times() -> None:
     keys = [('key1',), ('key2',), ('key3',)]
 
     for i, key in enumerate(keys):
-        metrics.add_time('time1', key, (1 + i) * 1000)
-        metrics.add_time('time2', key, (1 + i) * 10000)
+        metrics.add_time('time1', key, (1 + i) * 1)
+        metrics.add_time('time2', key, (1 + i) * 10)
 
     times = metrics.aggregate_times()
     assert times['time1'].count == len(keys)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Rather than just fix the conversion, I've changed the Metrics class to take ms directly as input because it also returns ms. This keeps the units consistent to prevent confusion in calling code.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #535

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated the unit tests and used the following script to validate (1) `main` records the time wrong and (2) this branch does it right.

```python
import os
import pprint
import tempfile
import time

from proxystore.connectors.file import FileConnector
from proxystore.store import Store

with tempfile.TemporaryDirectory() as tmp_dir:
    start = time.perf_counter_ns()
    with open(os.path.join(tmp_dir, 'test'), 'w') as f:
        f.write('value')
    end = time.perf_counter_ns()

    print('Write time (ms):', (end - start) / 1000_000)


with tempfile.TemporaryDirectory() as tmp_dir:
    with Store('test', FileConnector(tmp_dir), metrics=True) as store:
        key = store.put('value')
        store.get(key)

        pprint.pprint(store.metrics.get_metrics(key))import os
```
The times for `Write time (ms)` and `store.put.connector` should be similar (and not off by 1000x).

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
