### PR TITLE
Improve flexibility of `Lifetime` protocol and add `StaticLifetime` implementation

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -1022,7 +1022,7 @@ class Store(Generic[ConnectorT]):
             key = self.connector.put(obj, **kwargs)
 
         if lifetime is not None:
-            lifetime.add_key(key)
+            lifetime.add_key(key, store=self)
 
         timer.stop()
         if self.metrics is not None:
@@ -1085,7 +1085,7 @@ class Store(Generic[ConnectorT]):
             keys = self.connector.put_batch(_objs, **kwargs)
 
         if lifetime is not None:
-            lifetime.add_key(*keys)
+            lifetime.add_key(*keys, store=self)
 
         timer.stop()
         if self.metrics is not None:

--- a/tests/store/lifetimes_test.py
+++ b/tests/store/lifetimes_test.py
@@ -16,6 +16,7 @@ from proxystore.store.lifetimes import ContextLifetime
 from proxystore.store.lifetimes import LeaseLifetime
 from proxystore.store.lifetimes import Lifetime
 from proxystore.store.lifetimes import register_lifetime_atexit
+from proxystore.store.lifetimes import StaticLifetime
 
 
 def test_context_lifetime_protocol(store: Store[LocalConnector]) -> None:
@@ -143,3 +144,57 @@ def test_register_lifetime_atexit(
     assert not store.exists(key)
 
     atexit.unregister(callback)
+
+
+def test_static_lifetime_is_singleton() -> None:
+    assert StaticLifetime() is StaticLifetime()
+
+
+def test_add_key_without_store_error() -> None:
+    with pytest.raises(ValueError, match='requires the store parameter'):
+        StaticLifetime().add_key(())
+
+
+def test_static_lifetime_add_bad_proxy() -> None:
+    proxy: Proxy[list[Any]] = Proxy(list)
+
+    with pytest.raises(ProxyStoreFactoryError):
+        StaticLifetime().add_proxy(proxy)
+
+
+def test_static_lifetime_cleanup(store: Store[LocalConnector]) -> None:
+    key1 = store.put('value1')
+    key2 = store.put('value2')
+    key3 = store.put('value3')
+    key4 = store.put('value4')
+    proxy1: Proxy[str] = store.proxy_from_key(key3)
+    proxy2: Proxy[str] = store.proxy_from_key(key4)
+
+    lifetime = StaticLifetime()
+    assert not lifetime.done()
+
+    lifetime.add_key(key1, key2, store=store)
+    lifetime.add_proxy(proxy1, proxy2)
+
+    # Will get back same lifetime object so both options to close work
+    # and are idempotent.
+    StaticLifetime().close()
+    lifetime.close()
+    assert lifetime.done()
+
+    assert not store.exists(key1)
+    assert not store.exists(key2)
+    assert not store.exists(key3)
+    assert not store.exists(key4)
+
+    # Cleanup singleton instance
+    StaticLifetime._instance = None
+
+
+def test_static_lifetime_close_store(store: Store[LocalConnector]) -> None:
+    store.put('value', lifetime=StaticLifetime())
+
+    StaticLifetime().close(close_stores=True)
+
+    # Cleanup singleton instance
+    StaticLifetime._instance = None

--- a/tests/store/lifetimes_test.py
+++ b/tests/store/lifetimes_test.py
@@ -135,7 +135,7 @@ def test_register_lifetime_atexit(
     lifetime = ContextLifetime(store)
     lifetime.add_key(key)
 
-    callback = register_lifetime_atexit(lifetime, close_store=close_store)
+    callback = register_lifetime_atexit(lifetime, close_stores=close_store)
 
     assert not lifetime.done()
     callback()


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Improves the flexibility of the `Lifetime` protocol (a breaking change). Add the `StaticLifetime` singleton which evicts associated objects at the end of the program.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #515

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests and used the following script with logging enabled to verify correctness.

```python
import logging

from proxystore.connectors.local import LocalConnector
from proxystore.store import Store, register_store
from proxystore.store.lifetimes import StaticLifetime

logging.basicConfig(level=logging.DEBUG)

store = Store('default', LocalConnector())
register_store(store)
store.put('value', lifetime=StaticLifetime())
store.proxy('value', lifetime=StaticLifetime())
```

```
$ python example.py
INFO:proxystore.store.base:Initialized Store("default", connector=LocalConnector(), serializer=default, deserializer=default, cache_size=16, metrics=False)
INFO:proxystore.store:Registered a store named default
DEBUG:proxystore.store.lifetimes:Registered atexit callback for <proxystore.store.lifetimes.StaticLifetime object at 0x7f271dd2cc10>
DEBUG:proxystore.store.lifetimes:Added keys to lifetime manager (name=static): LocalKey(id='2220b8f9-e11c-486f-affe-181943b20722')
DEBUG:proxystore.store.base:Store(name="default"): PUT LocalKey(id='2220b8f9-e11c-486f-affe-181943b20722') in 0.039 ms
DEBUG:proxystore.store.base:Store(name="default"): PUT LocalKey(id='dc050b19-f12f-4da4-a611-52f0d63925b8') in 0.008 ms
DEBUG:proxystore.store.lifetimes:Added keys to lifetime manager (name=static): LocalKey(id='dc050b19-f12f-4da4-a611-52f0d63925b8')
DEBUG:proxystore.store.base:Store(name="default"): PROXY LocalKey(id='dc050b19-f12f-4da4-a611-52f0d63925b8') in 0.064 ms
DEBUG:proxystore.store.base:Store(name="default"): EVICT LocalKey(id='dc050b19-f12f-4da4-a611-52f0d63925b8') in 0.002 ms
DEBUG:proxystore.store.base:Store(name="default"): EVICT LocalKey(id='2220b8f9-e11c-486f-affe-181943b20722') in 0.002 ms
INFO:proxystore.store.lifetimes:Closed lifetime manager and evicted 2 associated objects (name=static)
```

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
