### PR TITLE
Add the `register` flag to auto-register a `Store` after initialization

### DIFF
--- a/docs/concepts/store.md
+++ b/docs/concepts/store.md
@@ -25,14 +25,13 @@ is generated, and then a new proxy, internalized with the factory, is returned.
 from proxystore.connectors.redis import RedisConnector
 from proxystore.proxy import Proxy
 from proxystore.store import Store
-from proxystore.store import register_store
 
 def my_function(x: MyDataType) -> ...:
     assert isinstance(x, MyDataType)  # (1)!
     # More computation...
 
-store = Store('my-store', RedisConnector(...)) # (2)!
-register_store(store)  # (3)!
+connector = RedisConnector()  # (2)!
+store = Store('my-store', connector, register=True)  # (3)!
 
 my_object = MyDataType(...) # (4)!
 p = store.proxy(my_object)
@@ -43,8 +42,8 @@ my_function(p) # (5)!
 
 1. `x` is resolved from "my-store" on the first use of `x`.
 2. The `Connector` defines the low-level communication method used by the `Store`.
-3. Registering `store` globally enables proxies to reuse the same instance
-   to improve performance.
+3. Passing the `register=True` will call [`register_store()`][proxystore.store.register_store] automatically to register the instance globally by name.
+   This enables proxies to reuse the same store instance to improve performance.
 4. Store the object and get a proxy.
 5. Always succeeds regardless of if `p` is the true object or a proxy.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -63,11 +63,13 @@ with an already running Redis server using proxies.
 ```python title="Basic ProxyStore Usage" linenums="1"
 from proxystore.connectors.redis import RedisConnector
 from proxystore.store import get_store
-from proxystore.store import register_store
 from proxystore.store import Store
 
-store = Store('my-store', RedisConnector(hostname='localhost', port=1234))
-register_store(store)
+store = Store(
+    'my-store',
+    RedisConnector(hostname='localhost', port=1234),
+    register=True,
+)
 
 store = get_store('my-store')  # (1)!
 
@@ -79,7 +81,7 @@ p = store.proxy(my_object)  # (3)!
 assert isinstance(p, type(my_object))  # (4)!
 ```
 
-1. A registered store can be retrieved by name.
+1. Passing `register=True` adds the store by name to a global registry, and registered store can be retrieved by name.
 2. Stores have basic get/put functionality.
 3. Place an object in the store and return a proxy.
 4. The proxy, when used, will behave as the target.

--- a/docs/guides/globus-compute.md
+++ b/docs/guides/globus-compute.md
@@ -88,10 +88,9 @@ Now we will update our script to use ProxyStore. This takes three steps:
    open connections, etc.).
 3. Proxy the function inputs.
 
-```python linenums="1" title="example.py" hl_lines="2 3 4 11 12 16 21"
+```python linenums="1" title="example.py" hl_lines="2 3 10 14 19"
 from globus_compute_sdk import Executor
 from proxystore.connectors.file import FileConnector
-from proxystore.store import register_store
 from proxystore.store import Store
 
 ENDPOINT_UUID = '5b994a7d-8d7c-48d1-baa1-0fda09ea1687'
@@ -99,23 +98,22 @@ ENDPOINT_UUID = '5b994a7d-8d7c-48d1-baa1-0fda09ea1687'
 def average(x: list[float]) -> float:
     return sum(x) / len(x)
 
-store = Store('my-store', FileConnector('./proxystore-cache'))  # (1)!
-register_store(store) # (2)!
+store = Store('my-store', FileConnector('./proxystore-cache'), register=True)  # (1)!
 
 with Executor(endpoint_id=ENDPOINT_UUID) as gce:
     x = list(range(1, 100000))
-    p = store.proxy(x) # (3)!
+    p = store.proxy(x) # (2)!
     future = gce.submit(average, p)
 
     print(future.result())
 
-store.close() # (4)!
+store.close() # (3)!
 ```
 
 1. Create a new store using the file system for mediated communication.
-2. Register the store instance so states (e.g., caches, etc.) can be shared.
-3. Proxy the input data.
-4. Close the `Store` to cleanup any resources.
+   Register the store instance so states (e.g., caches, etc.) can be shared.
+2. Proxy the input data.
+3. Close the `Store` to cleanup any resources.
 
 !!! tip
 

--- a/docs/guides/object-lifetimes.md
+++ b/docs/guides/object-lifetimes.md
@@ -133,23 +133,19 @@ The [`StaticLifetime`][proxystore.store.lifetimes.StaticLifetime], a singleton c
 ```python linenums="1" title="Static Lifetime"
 from proxystore.connectors.local import LocalConnector
 from proxystore.store import Store
-from proxystore.store import register_store
 from proxystore.store.lifetimes import StaticLifetime
 
-store = Store('default', LocalConnector())  # (1)!
-register_store(store)  # (2)!
+store = Store('default', LocalConnector(), register=True)  # (1)!
 
-key = store.put('value', lifetime=StaticLifetime())  # (3)!
-proxy = store.proxy('value', lifetime=StaticLifetime())  # (4)!
+key = store.put('value', lifetime=StaticLifetime())  # (2)!
+proxy = store.proxy('value', lifetime=StaticLifetime())  # (3)!
 ```
 
-1. The atexit handler will call `store.close()` at the end of the
-   program.
-2. Registering `store` is recommended to prevent another instance
-   being created internally.
-3. The object associated with `key` will be evicted at the end of
+1. The atexit handler will call `store.close()` at the end of the program.
+   Setting `register=True` is recommended to prevent another instance being created internally when a proxy is resolved.
+2. The object associated with `key` will be evicted at the end of
    the program.
-4. The object associated with `proxy` will be evicted at the end of
+3. The object associated with `proxy` will be evicted at the end of
    the program.
 
 Additional tips:

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -10,15 +10,14 @@ Metric collection is disabled by default and can be enabled by passing `#!python
 ```python linenums="1"
 import dataclasses
 from proxystore.connectors.file import FileConnector
-from proxystore.store import register_store
 from proxystore.store.base import Store
 
 store = Store(
    name='example-store',
    connector=FileConnector('/tmp/proxystore-dump'),
    metrics=True,  # (1)!
+   register=True,
 )
-register_store(store)
 assert store.metrics is not None
 ```
 
@@ -159,6 +158,7 @@ proxy internally resolved the factory so we also see metrics about the
 
     For metrics to appropriately be tracked when a proxy is resolved, the
     [`Store`][proxystore.store.base.Store] needs to be registered globally
+    by setting `register=True` in the constructor or by manually registering
     with [`register_store()`][proxystore.store.register_store]. Otherwise,
     the factory will initialize a second [`Store`][proxystore.store.base.Store]
     to register and record its metrics to the second instance.

--- a/proxystore/store/__init__.py
+++ b/proxystore/store/__init__.py
@@ -17,6 +17,7 @@ from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.exceptions import StoreExistsError
 from proxystore.store.factory import StoreFactory
 from proxystore.store.types import ConnectorT
+from proxystore.store.types import StoreConfig
 
 __all__ = [
     'Store',
@@ -72,7 +73,7 @@ def get_store(val: str | Proxy[T]) -> Store[Any] | None:
 
 
 def get_or_create_store(
-    store_config: dict[str, Any],
+    store_config: StoreConfig,
     *,
     register: bool = True,
 ) -> Store[Any]:

--- a/proxystore/store/__init__.py
+++ b/proxystore/store/__init__.py
@@ -93,7 +93,9 @@ def get_or_create_store(
         if store is None:
             store = Store.from_config(store_config)
             if register:
-                register_store(store)
+                # Set exists_ok here because the store may have initialized
+                # itself if register=True.
+                register_store(store, exist_ok=True)
         return store
 
 
@@ -118,11 +120,11 @@ def register_store(store: Store[Any], exist_ok: bool = False) -> None:
     with _stores_lock:
         if store.name in _stores and not exist_ok:
             raise StoreExistsError(
-                f'A store named {store.name} already exists.',
+                f'A store named "{store.name}" already exists.',
             )
 
         _stores[store.name] = store
-        logger.info(f'Registered a store named {store.name}')
+        logger.info(f'Registered a store named "{store.name}"')
 
 
 @contextlib.contextmanager

--- a/proxystore/store/__init__.py
+++ b/proxystore/store/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from typing import Any
 from typing import Generator
 from typing import Sequence
@@ -29,11 +30,12 @@ __all__ = [
 T = TypeVar('T')
 
 _stores: dict[str, Store[Any]] = {}
+_stores_lock = threading.RLock()
 logger = logging.getLogger(__name__)
 
 
 def get_store(val: str | Proxy[T]) -> Store[Any] | None:
-    """Get the backend store with name.
+    """Get a registered store by name.
 
     Args:
         val: name of the store to get or a [`Proxy`][proxystore.proxy.Proxy]
@@ -63,9 +65,35 @@ def get_store(val: str | Proxy[T]) -> Store[Any] | None:
     else:
         name = val
 
-    if name in _stores:
-        return _stores[name]
-    return None
+    with _stores_lock:
+        if name in _stores:
+            return _stores[name]
+        return None
+
+
+def get_or_create_store(
+    store_config: dict[str, Any],
+    *,
+    register: bool = True,
+) -> Store[Any]:
+    """Get a registered store or initialize a new instance from the config.
+
+    Args:
+        store_config: Store configuration used to reinitialize the store if
+            needed.
+        register: Optionally register the store if a new instance was
+            initialized.
+
+    Returns:
+        [`Store`][proxystore.store.base.Store] instance.
+    """
+    with _stores_lock:
+        store = get_store(store_config['name'])
+        if store is None:
+            store = Store.from_config(store_config)
+            if register:
+                register_store(store)
+        return store
 
 
 def register_store(store: Store[Any], exist_ok: bool = False) -> None:
@@ -86,11 +114,14 @@ def register_store(store: Store[Any], exist_ok: bool = False) -> None:
         StoreExistsError: If a store with the same name is already registered
             and `exist_ok` is false.
     """
-    if store.name in _stores and not exist_ok:
-        raise StoreExistsError(f'A store named {store.name} already exists.')
+    with _stores_lock:
+        if store.name in _stores and not exist_ok:
+            raise StoreExistsError(
+                f'A store named {store.name} already exists.',
+            )
 
-    _stores[store.name] = store
-    logger.info(f'Registered a store named {store.name}')
+        _stores[store.name] = store
+        logger.info(f'Registered a store named {store.name}')
 
 
 @contextlib.contextmanager
@@ -149,6 +180,7 @@ def unregister_store(name_or_store: str | Store[Any]) -> None:
     name = (
         name_or_store if isinstance(name_or_store, str) else name_or_store.name
     )
-    if name in _stores:
-        del _stores[name]
-        logger.info(f'Unregistered a store named {name}')
+    with _stores_lock:
+        if name in _stores:
+            del _stores[name]
+            logger.info(f'Unregistered a store named {name}')

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -29,6 +29,7 @@ from proxystore.proxy import ProxyLocker
 from proxystore.serialize import SerializationError
 from proxystore.store.cache import LRUCache
 from proxystore.store.exceptions import NonProxiableTypeError
+from proxystore.store.exceptions import StoreExistsError
 from proxystore.store.factory import PollingStoreFactory
 from proxystore.store.factory import StoreFactory
 from proxystore.store.future import Future
@@ -82,9 +83,12 @@ class Store(Generic[ConnectorT]):
         cache_size: Size of LRU cache (in # of objects). If 0,
             the cache is disabled. The cache is local to the Python process.
         metrics: Enable recording operation metrics.
+        register: Register the store instance after initialization.
 
     Raises:
         ValueError: If `cache_size` is less than zero.
+        StoreExistsError: If `register=True` and a store with `name` already
+            exists.
     """
 
     def __init__(
@@ -96,6 +100,7 @@ class Store(Generic[ConnectorT]):
         deserializer: DeserializerT | None = None,
         cache_size: int = 16,
         metrics: bool = False,
+        register: bool = False,
     ) -> None:
         if cache_size < 0:
             raise ValueError(
@@ -109,6 +114,20 @@ class Store(Generic[ConnectorT]):
         self._cache_size = cache_size
         self._serializer = serializer
         self._deserializer = deserializer
+        self._register = register
+
+        if self._register:
+            try:
+                proxystore.store.register_store(self)
+            except StoreExistsError as e:
+                if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+                    e.add_note(
+                        'Consider using get_store(name) rather than '
+                        'initializing a new instance with register=True.',
+                    )
+                else:  # pragma: <3.11 cover
+                    pass
+                raise
 
         logger.info(f'Initialized {self}')
 
@@ -164,6 +183,9 @@ class Store(Generic[ConnectorT]):
     def close(self, *args: Any, **kwargs: Any) -> None:
         """Close the connector associated with the store.
 
+        This will (1) close the connector and (2) unregister the store if
+        `register=True` was set during initialization.
+
         Warning:
             This method should only be called at the end of the program
             when the store will no longer be used, for example once all
@@ -175,6 +197,8 @@ class Store(Generic[ConnectorT]):
             kwargs: Keyword arguments to pass to
                 [`Connector.close()`][proxystore.connectors.protocols.Connector.close].
         """
+        if self._register:
+            proxystore.store.unregister_store(self.name)
         self.connector.close(*args, **kwargs)
 
     def config(self) -> StoreConfig:
@@ -198,6 +222,7 @@ class Store(Generic[ConnectorT]):
             deserializer=self._deserializer,
             cache_size=self._cache_size,
             metrics=self.metrics is not None,
+            register=self._register,
         )
 
     @classmethod

--- a/proxystore/store/factory.py
+++ b/proxystore/store/factory.py
@@ -17,6 +17,7 @@ from proxystore.store.exceptions import ProxyResolveMissingKeyError
 from proxystore.store.types import ConnectorKeyT
 from proxystore.store.types import ConnectorT
 from proxystore.store.types import DeserializerT
+from proxystore.store.types import StoreConfig
 from proxystore.utils.timer import Timer
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ class StoreFactory(Generic[ConnectorT, T]):
     def __init__(
         self,
         key: ConnectorKeyT,
-        store_config: dict[str, Any],
+        store_config: StoreConfig,
         *,
         evict: bool = False,
         deserializer: DeserializerT | None = None,
@@ -168,7 +169,7 @@ class PollingStoreFactory(StoreFactory[ConnectorT, T]):
     def __init__(
         self,
         key: ConnectorKeyT,
-        store_config: dict[str, Any],
+        store_config: StoreConfig,
         *,
         deserializer: DeserializerT | None = None,
         evict: bool = False,

--- a/proxystore/store/lifetimes.py
+++ b/proxystore/store/lifetimes.py
@@ -398,20 +398,17 @@ class StaticLifetime:
         ```python linenums="1" title="Static Lifetime"
         from proxystore.connectors.local import LocalConnector
         from proxystore.store import Store
-        from proxystore.store import register_store
         from proxystore.store.lifetimes import StaticLifetime
 
-        store = Store('default', LocalConnector())  # (1)!
-        register_store(store)  # (2)!
+        store = Store('default', LocalConnector(), register=True)  # (1)!
 
-        key = store.put('value', lifetime=StaticLifetime())  # (3)!
-        proxy = store.proxy('value', lifetime=StaticLifetime())  # (4)!
+        key = store.put('value', lifetime=StaticLifetime())  # (2)!
+        proxy = store.proxy('value', lifetime=StaticLifetime())  # (3)!
         ```
 
         1. The atexit handler will call `store.close()` at the end of the
-           program.
-        2. Registering `store` is recommended to prevent another instance
-           being created internally.
+           program. Setting `register=True` is recommended to prevent another
+           instance being created internally when a proxy is resolved.
         3. The object associated with `key` will be evicted at the end of
            the program.
         4. The object associated with `proxy` will be evicted at the end of
@@ -469,7 +466,7 @@ class StaticLifetime:
             This method will initialized new
             [`Store`][proxystore.store.base.Store] instances if the stores
             which were used to create the input proxies have not been
-            registered with
+            registered by setting the `register` flag or by calling
             [`register_store()`][proxystore.store.register_store].
 
         Args:

--- a/proxystore/store/types.py
+++ b/proxystore/store/types.py
@@ -51,6 +51,7 @@ class StoreConfig(TypedDict):
         deserializer: Optional deserializer.
         cache_size: Cache size.
         metrics: Enable recording operation metrics.
+        register: Auto-register the store.
     """
 
     name: str
@@ -60,3 +61,4 @@ class StoreConfig(TypedDict):
     deserializer: NotRequired[DeserializerT | None]
     cache_size: NotRequired[int]
     metrics: NotRequired[bool]
+    register: NotRequired[bool]

--- a/proxystore/store/types.py
+++ b/proxystore/store/types.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 from typing import Callable
 from typing import Tuple
+from typing import TypedDict
 from typing import TypeVar
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import NotRequired
+else:  # pragma: <3.11 cover
+    from typing_extensions import NotRequired
 
 from proxystore.connectors.protocols import Connector
 
@@ -17,3 +24,39 @@ SerializerT = Callable[[Any], bytes]
 """Serializer type alias."""
 DeserializerT = Callable[[bytes], Any]
 """Deserializer type alias."""
+
+
+class StoreConfig(TypedDict):
+    """Store configuration dictionary.
+
+    Warning:
+        Configuration dictionaries should not be constructed manually, but
+        instead created via
+        [`Store.config()`][proxystore.store.base.Store.config].
+
+    Tip:
+        See the [`Store`][proxystore.store.base.Store] parameters for more
+        information about each configuration option.
+
+    Attributes:
+        name: Store name.
+        connector_type: Fully qualified path to the
+            [`Connector`][proxystore.connectors.protocols.Connector]
+            implementation.
+        connector_config: Config created by
+            [`Connector.config()`][proxystore.connectors.protocols.Connector.config]
+            used to initialize a new connector instance with
+            [`Connector.from_config()`][proxystore.connectors.protocols.Connector.from_config].
+        serializer: Optional serializer.
+        deserializer: Optional deserializer.
+        cache_size: Cache size.
+        metrics: Enable recording operation metrics.
+    """
+
+    name: str
+    connector_type: str
+    connector_config: dict[str, Any]
+    serializer: NotRequired[SerializerT | None]
+    deserializer: NotRequired[DeserializerT | None]
+    cache_size: NotRequired[int]
+    metrics: NotRequired[bool]

--- a/proxystore/stream/events.py
+++ b/proxystore/stream/events.py
@@ -17,6 +17,7 @@ import json
 from typing import Any
 from typing import Union
 
+from proxystore.store.types import StoreConfig
 from proxystore.utils.imports import get_object_path
 from proxystore.utils.imports import import_from_path
 
@@ -76,7 +77,7 @@ class EventBatch:
 
     events: list[Event]
     topic: str
-    store_config: dict[str, Any]
+    store_config: StoreConfig
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EventBatch:

--- a/proxystore/stream/interface.py
+++ b/proxystore/stream/interface.py
@@ -35,6 +35,7 @@ from proxystore.store import get_store
 from proxystore.store import register_store
 from proxystore.store import unregister_store
 from proxystore.store.base import Store
+from proxystore.store.types import StoreConfig
 from proxystore.stream.events import bytes_to_event
 from proxystore.stream.events import EndOfStreamEvent
 from proxystore.stream.events import Event
@@ -353,7 +354,7 @@ class StreamProducer(Generic[T]):
 class _EventInfo(NamedTuple):
     event: NewObjectEvent
     topic: str
-    store_config: dict[str, Any]
+    store_config: StoreConfig
 
 
 class StreamConsumer(Generic[T]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from unittest import mock
 import pytest
 import uvloop
 
+import proxystore
+
 # Import fixtures from testing/ so they are known by pytest
 # and can be used with
 from testing.connectors import connectors
@@ -69,3 +71,14 @@ def event_loop_policy(
     policy = asyncio.get_event_loop_policy()
     with context:
         yield policy
+
+
+@pytest.fixture(autouse=True)
+def _verify_no_registered_stores() -> Generator[None, None, None]:
+    yield
+
+    if len(proxystore.store._stores) > 0:  # pragma: no cover
+        raise RuntimeError(
+            'Test left at least one store registered: '
+            f'{tuple(proxystore.store._stores.keys())}.',
+        )

--- a/tests/store/init_test.py
+++ b/tests/store/init_test.py
@@ -5,6 +5,7 @@ import pytest
 from proxystore.connectors.local import LocalConnector
 from proxystore.factory import SimpleFactory
 from proxystore.proxy import Proxy
+from proxystore.store import get_or_create_store
 from proxystore.store import get_store
 from proxystore.store import register_store
 from proxystore.store import store_registration
@@ -29,6 +30,25 @@ def test_register_unregister_store() -> None:
 
     # does not raise error
     unregister_store('not a valid store name')
+
+
+def test_get_or_create_store() -> None:
+    store = Store('test', connector=LocalConnector())
+
+    assert get_store(store.name) is None
+    new_store = get_or_create_store(store.config(), register=True)
+    assert get_store(store.name) is new_store
+    assert get_or_create_store(store.config()) is new_store
+
+    unregister_store(new_store)
+
+
+def test_get_or_create_store_no_register() -> None:
+    store = Store('test', connector=LocalConnector())
+
+    assert get_store(store.name) is None
+    get_or_create_store(store.config(), register=False)
+    assert get_store(store.name) is None
 
 
 def test_unregister_with_store() -> None:

--- a/tests/store/metrics_test.py
+++ b/tests/store/metrics_test.py
@@ -7,6 +7,7 @@ from proxystore.store.factory import StoreFactory
 from proxystore.store.metrics import Metrics
 from proxystore.store.metrics import StoreMetrics
 from proxystore.store.metrics import TimeStats
+from proxystore.store.types import StoreConfig
 
 
 def test_time_stats() -> None:
@@ -87,7 +88,16 @@ def test_metrics_by_proxy() -> None:
     metrics = StoreMetrics()
 
     key = ('test-key',)
-    proxy: Proxy[Any] = Proxy(StoreFactory(key, {}))
+    proxy: Proxy[Any] = Proxy(
+        StoreFactory(
+            key,
+            StoreConfig(
+                name='test',
+                connector_type='test',
+                connector_config={},
+            ),
+        ),
+    )
 
     metrics.add_attribute('test-attribute', key, 'value')
     assert metrics.get_metrics(proxy) == metrics.get_metrics(key)
@@ -97,7 +107,19 @@ def test_metrics_by_proxies() -> None:
     metrics = StoreMetrics()
 
     keys = [('key1',), ('key2',), ('key3',)]
-    proxies: list[Proxy[Any]] = [Proxy(StoreFactory(key, {})) for key in keys]
+    proxies: list[Proxy[Any]] = [
+        Proxy(
+            StoreFactory(
+                key,
+                StoreConfig(
+                    name='test',
+                    connector_type='test',
+                    connector_config={},
+                ),
+            ),
+        )
+        for key in keys
+    ]
 
     metrics.add_attribute('test-attribute', proxies, 'value')
     assert metrics.get_metrics(proxies) == metrics.get_metrics(keys)

--- a/tests/store/store_basics_test.py
+++ b/tests/store/store_basics_test.py
@@ -9,7 +9,9 @@ import pytest
 from proxystore.connectors.local import LocalConnector
 from proxystore.proxy import Proxy
 from proxystore.serialize import SerializationError
+from proxystore.store import get_store
 from proxystore.store import Store
+from proxystore.store.exceptions import StoreExistsError
 from proxystore.store.future import Future
 from proxystore.store.lifetimes import ContextLifetime
 
@@ -17,6 +19,19 @@ from proxystore.store.lifetimes import ContextLifetime
 def test_negative_cache_size() -> None:
     with pytest.raises(ValueError):
         Store('test', LocalConnector(), cache_size=-1)
+
+
+def test_init_and_register() -> None:
+    name = 'test-store'
+    assert get_store(name) is None
+    with Store(name, LocalConnector(), register=True) as store:
+        assert get_store(name) is store
+
+        with pytest.raises(StoreExistsError):
+            Store(name, LocalConnector(), register=True)
+
+    # Context manager close should unregister the store.
+    assert get_store(name) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/store/utils_test.py
+++ b/tests/store/utils_test.py
@@ -7,6 +7,7 @@ from proxystore.factory import SimpleFactory
 from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.store import Store
+from proxystore.store import store_registration
 from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.utils import get_key
 from proxystore.store.utils import resolve_async
@@ -29,19 +30,20 @@ def test_get_key_from_proxy_not_created_by_store() -> None:
 
 def test_async_resolve() -> None:
     with Store('store', LocalConnector()) as store:
-        value = 'value'
-        p = store.proxy(value)
+        with store_registration(store):
+            value = 'value'
+            p = store.proxy(value)
 
-        assert not is_resolved(p)
+            assert not is_resolved(p)
 
-        resolve_async(p)
-        assert p == value
+            resolve_async(p)
+            assert p == value
 
-        assert is_resolved(p)
+            assert is_resolved(p)
 
-        # Now async resolve should be a no-op
-        resolve_async(p)
-        assert p == value
+            # Now async resolve should be a no-op
+            resolve_async(p)
+            assert p == value
 
 
 def test_async_resolve_factory_error() -> None:

--- a/tests/stream/events_test.py
+++ b/tests/stream/events_test.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 import pytest
 
+from proxystore.store.types import StoreConfig
 from proxystore.stream.events import bytes_to_event
 from proxystore.stream.events import EndOfStreamEvent
 from proxystore.stream.events import Event
@@ -28,7 +29,11 @@ class _TestKey(NamedTuple):
                 EndOfStreamEvent(),
             ],
             topic='default',
-            store_config={},
+            store_config=StoreConfig(
+                name='test',
+                connector_type='test',
+                connector_config={},
+            ),
         ),
         NewObjectEvent.from_key(_TestKey('a', 123), True, {}),
     ),


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds the `register` flag to auto-register a `Store` after initialization. The default is `False` to remain backwards compatible, but the docs have been update to suggest use of the flag over `register_store`.

Per #547, I considered make `Store` a singleton when `register=True` but decided against it the singleton constructor would thrown away initialized `Connector` instances without closing them properly.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #547

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
