### PR TITLE
Support caching target attributes in `Proxy` to avoid resolving when using `hash()` or `isinstance()`

### DIFF
--- a/docs/guides/object-lifetimes.md
+++ b/docs/guides/object-lifetimes.md
@@ -43,6 +43,7 @@ If you run into these errors, try:
 * Avoid use of datastructures or functions which unnecessarily resolve proxies.
 * If avoiding use of the datastructures or functions causing the problem is not possible, consider using the `populate_target=True` flag when creating the proxy.
   The `populate_target` flag will return a proxy that is already resolved so the factory, which would evict the target object, does not need to be called until the proxy is serialized and then deserialized and resolved on a different process.
+  The flag will also cache the class type and hash value of the target such that the proxy can be used in datastructures which rely on [`hash()`][hash] or in [`isinstance`][isinstance] checks without needing to resolve the proxy.
 
 ## Lifetimes
 

--- a/proxystore/proxy/__init__.py
+++ b/proxystore/proxy/__init__.py
@@ -81,8 +81,8 @@ def _proxy_trampoline(
     default_hash: DefaultHashType = None,
 ) -> Proxy[T]:
     proxy = Proxy(factory)
-    object.__setattr__(proxy, '__default_class__', default_class)
-    object.__setattr__(proxy, '__default_hash__', default_hash)
+    object.__setattr__(proxy, '__proxy_default_class__', default_class)
+    object.__setattr__(proxy, '__proxy_default_hash__', default_hash)
     return proxy
 
 
@@ -192,19 +192,20 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
         ```
 
     Attributes:
-        __factory__: Factory function which resolves to the target object.
-        __target__: The target object once resolved.
-        __resolved__: `True` if `__target__` is set.
-        __wrapped__: A property that either returns `__target__` if it
-            exists else calls `__factory__`, saving the result to `__target__`
-            and returning said result.
-        __default_class__: Optional default class type value to use when a
-            proxy is in the unresolved state. This avoids needing to resolve
+        __proxy_factory__: Factory function which resolves to the target
+            object.
+        __proxy_target__: The target object once resolved.
+        __proxy_resolved__: `True` if `__proxy_target__` is set.
+        __proxy_wrapped__: A property that either returns `__proxy_target__`
+            if it exists else calls `__proxy_factory__`, saving the result to
+            `__proxy_target__` and returning said result.
+        __proxy_default_class__: Optional default class type value to use when
+            a proxy is in the unresolved state. This avoids needing to resolve
             the proxy to perform [`isinstance`][isinstance] checks. This value
             is always ignored while the proxy is resolved because `__class__`
             is a writable property of the cached target and could be altered.
-        __default_hash__: Optional default hash value to use when a proxy is
-            in the unresolved state and [`hash()`][hash] is called. This
+        __proxy_default_hash__: Optional default hash value to use when a proxy
+            is in the unresolved state and [`hash()`][hash] is called. This
             avoids needing to resolve the proxy for simple operations like
             dictionary updates. This value is always ignored while the proxy
             is resolved because the cached target may be modified which
@@ -214,9 +215,9 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
         factory: Callable object that returns the underlying object when
             called. The factory should be pure meaning that every call
             of the factory returns the same object.
-        cache_defaults: Precompute and cache the `__default_class__` and
-            `__default_hash__` attributes of the proxy instance from `target`.
-            Ignored if `target` is not provided.
+        cache_defaults: Precompute and cache the `__proxy_default_class__` and
+            `__proxy_default_hash__` attributes of the proxy instance from
+            `target`. Ignored if `target` is not provided.
         target: Optionally preset the target object.
 
     Raises:
@@ -224,16 +225,16 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
     """
 
     __slots__ = (
-        '__target__',
-        '__factory__',
-        '__default_class__',
-        '__default_hash__',
+        '__proxy_target__',
+        '__proxy_factory__',
+        '__proxy_default_class__',
+        '__proxy_default_hash__',
     )
 
-    __target__: T
-    __factory__: FactoryType[T]
-    __default_class__: DefaultClassType
-    __default_hash__: DefaultHashType
+    __proxy_target__: T
+    __proxy_factory__: FactoryType[T]
+    __proxy_default_class__: DefaultClassType
+    __proxy_default_hash__: DefaultHashType
 
     def __init__(
         self,
@@ -244,13 +245,13 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
     ) -> None:
         if not callable(factory):
             raise TypeError('Factory must be callable.')
-        object.__setattr__(self, '__factory__', factory)
+        object.__setattr__(self, '__proxy_factory__', factory)
 
         default_class: DefaultClassType = None
         default_hash: DefaultHashType = None
 
         if target is not None:
-            object.__setattr__(self, '__target__', target)
+            object.__setattr__(self, '__proxy_target__', target)
             if cache_defaults:
                 default_class = target.__class__
                 try:
@@ -258,87 +259,87 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
                 except TypeError as e:
                     default_hash = e
 
-        object.__setattr__(self, '__default_class__', default_class)
-        object.__setattr__(self, '__default_hash__', default_hash)
+        object.__setattr__(self, '__proxy_default_class__', default_class)
+        object.__setattr__(self, '__proxy_default_hash__', default_hash)
 
     @property
-    def __resolved__(self) -> bool:
+    def __proxy_resolved__(self) -> bool:
         try:
-            object.__getattribute__(self, '__target__')
+            object.__getattribute__(self, '__proxy_target__')
         except AttributeError:
             return False
         else:
             return True
 
     @property
-    def __wrapped__(self) -> T:
+    def __proxy_wrapped__(self) -> T:
         try:
-            return cast(T, object.__getattribute__(self, '__target__'))
+            return cast(T, object.__getattribute__(self, '__proxy_target__'))
         except AttributeError:
             try:
-                factory = object.__getattribute__(self, '__factory__')
+                factory = object.__getattribute__(self, '__proxy_factory__')
             except AttributeError as exc:
                 raise ValueError(
-                    "Proxy hasn't been initiated: __factory__ is missing.",
+                    'Proxy is not initialized: __proxy_factory__ is missing.',
                 ) from exc
             target = factory()
-            object.__setattr__(self, '__target__', target)
+            object.__setattr__(self, '__proxy_target__', target)
             return target
 
-    @__wrapped__.deleter
-    def __wrapped__(self) -> None:
-        object.__delattr__(self, '__target__')
+    @__proxy_wrapped__.deleter
+    def __proxy_wrapped__(self) -> None:
+        object.__delattr__(self, '__proxy_target__')
 
-    @__wrapped__.setter
-    def __wrapped__(self, target: T) -> None:
-        object.__setattr__(self, '__target__', target)
+    @__proxy_wrapped__.setter
+    def __proxy_wrapped__(self, target: T) -> None:
+        object.__setattr__(self, '__proxy_target__', target)
 
     @property
     def __name__(self) -> str:
-        return self.__wrapped__.__name__  # type: ignore[attr-defined]
+        return self.__proxy_wrapped__.__name__  # type: ignore[attr-defined]
 
     @__name__.setter
     def __name__(self, value: str) -> None:
-        self.__wrapped__.__name__ = value  # type: ignore[attr-defined]
+        self.__proxy_wrapped__.__name__ = value  # type: ignore[attr-defined]
 
     @property
     def __class__(self) -> Any:
-        default = object.__getattribute__(self, '__default_class__')
-        if not self.__resolved__ and default is not None:
+        default = object.__getattribute__(self, '__proxy_default_class__')
+        if not self.__proxy_resolved__ and default is not None:
             return default
         else:
-            return self.__wrapped__.__class__
+            return self.__proxy_wrapped__.__class__
 
     @__class__.setter
     def __class__(self, value: Any) -> None:  # pragma: no cover
-        self.__wrapped__.__class__ = value
+        self.__proxy_wrapped__.__class__ = value
 
     def __dir__(self) -> Any:
-        return dir(self.__wrapped__)
+        return dir(self.__proxy_wrapped__)
 
     def __str__(self) -> str:
-        return str(self.__wrapped__)
+        return str(self.__proxy_wrapped__)
 
     def __bytes__(self) -> bytes:
-        return bytes(self.__wrapped__)  # type: ignore[call-overload]
+        return bytes(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __repr__(self) -> str:
         try:
-            target = object.__getattribute__(self, '__target__')
+            target = object.__getattribute__(self, '__proxy_target__')
         except AttributeError:
             return (
                 f'<{type(self).__name__} at 0x{id(self):x} with '
-                f'factory {self.__factory__!r}>'
+                f'factory {self.__proxy_factory__!r}>'
             )
         else:
             return (
                 f'<{type(self).__name__} at 0x{id(self):x} '
                 f'wrapping {target!r} at 0x{id(target):x} with '
-                f'factory {self.__factory__!r}>'
+                f'factory {self.__proxy_factory__!r}>'
             )
 
     def __fspath__(self) -> Any:
-        wrapped = self.__wrapped__
+        wrapped = self.__proxy_wrapped__
         if isinstance(wrapped, (bytes, str)):
             return wrapped
         else:
@@ -349,249 +350,252 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
                 return fspath()
 
     def __reversed__(self) -> Any:
-        return reversed(self.__wrapped__)  # type: ignore[call-overload]
+        return reversed(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __round__(self) -> Any:
-        return round(self.__wrapped__)  # type: ignore[call-overload]
+        return round(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __lt__(self, other: Any) -> bool:
-        return self.__wrapped__ < other
+        return self.__proxy_wrapped__ < other
 
     def __le__(self, other: Any) -> bool:
-        return self.__wrapped__ <= other
+        return self.__proxy_wrapped__ <= other
 
     def __eq__(self, other: Any) -> bool:
-        return self.__wrapped__ == other
+        return self.__proxy_wrapped__ == other
 
     def __ne__(self, other: Any) -> bool:
-        return self.__wrapped__ != other
+        return self.__proxy_wrapped__ != other
 
     def __gt__(self, other: Any) -> bool:
-        return self.__wrapped__ > other
+        return self.__proxy_wrapped__ > other
 
     def __ge__(self, other: Any) -> bool:
-        return self.__wrapped__ >= other
+        return self.__proxy_wrapped__ >= other
 
     def __hash__(self) -> int:
-        default = object.__getattribute__(self, '__default_hash__')
-        if not self.__resolved__ and default is not None:
+        default = object.__getattribute__(self, '__proxy_default_hash__')
+        if not self.__proxy_resolved__ and default is not None:
             if isinstance(default, Exception):
                 raise default
             else:
                 return default
         else:
-            return hash(self.__wrapped__)
+            return hash(self.__proxy_wrapped__)
 
     def __bool__(self) -> bool:
-        return bool(self.__wrapped__)
+        return bool(self.__proxy_wrapped__)
 
     def __setattr__(self, name: str, value: Any) -> None:
         if hasattr(type(self), name):
             object.__setattr__(self, name, value)
         else:
-            setattr(self.__wrapped__, name, value)
+            setattr(self.__proxy_wrapped__, name, value)
 
     def __getattr__(self, name: str) -> Any:
-        if name in ('__wrapped__', '__factory__'):
+        if name in ('__proxy_wrapped__', '__proxy_factory__'):
             raise AttributeError(name)
         else:
-            return getattr(self.__wrapped__, name)
+            return getattr(self.__proxy_wrapped__, name)
 
     def __delattr__(self, name: str) -> None:
         if hasattr(type(self), name):
             object.__delattr__(self, name)
         else:
-            delattr(self.__wrapped__, name)
+            delattr(self.__proxy_wrapped__, name)
 
     def __add__(self, other: Any) -> Any:
-        return self.__wrapped__ + other
+        return self.__proxy_wrapped__ + other
 
     def __sub__(self, other: Any) -> Any:
-        return self.__wrapped__ - other
+        return self.__proxy_wrapped__ - other
 
     def __mul__(self, other: Any) -> Any:
-        return self.__wrapped__ * other
+        return self.__proxy_wrapped__ * other
 
     def __matmul__(self, other: Any) -> Any:
-        return self.__wrapped__ @ other
+        return self.__proxy_wrapped__ @ other
 
     def __truediv__(self, other: Any) -> Any:
-        return operator.truediv(self.__wrapped__, other)
+        return operator.truediv(self.__proxy_wrapped__, other)
 
     def __floordiv__(self, other: Any) -> Any:
-        return self.__wrapped__ // other
+        return self.__proxy_wrapped__ // other
 
     def __mod__(self, other: Any) -> Any:
-        return self.__wrapped__ % other
+        return self.__proxy_wrapped__ % other
 
     def __divmod__(self, other: Any) -> Any:
-        return divmod(self.__wrapped__, other)
+        return divmod(self.__proxy_wrapped__, other)
 
     def __pow__(self, other: Any, *args: Any) -> Any:
-        return pow(self.__wrapped__, other, *args)  # type: ignore[call-overload]
+        return pow(self.__proxy_wrapped__, other, *args)  # type: ignore[call-overload]
 
     def __lshift__(self, other: Any) -> Any:
-        return self.__wrapped__ << other
+        return self.__proxy_wrapped__ << other
 
     def __rshift__(self, other: Any) -> Any:
-        return self.__wrapped__ >> other
+        return self.__proxy_wrapped__ >> other
 
     def __and__(self, other: Any) -> Any:
-        return self.__wrapped__ & other
+        return self.__proxy_wrapped__ & other
 
     def __xor__(self, other: Any) -> Any:
-        return self.__wrapped__ ^ other
+        return self.__proxy_wrapped__ ^ other
 
     def __or__(self, other: Any) -> Any:
-        return self.__wrapped__ | other
+        return self.__proxy_wrapped__ | other
 
     def __radd__(self, other: Any) -> Any:
-        return other + self.__wrapped__
+        return other + self.__proxy_wrapped__
 
     def __rsub__(self, other: Any) -> Any:
-        return other - self.__wrapped__
+        return other - self.__proxy_wrapped__
 
     def __rmul__(self, other: Any) -> Any:
-        return other * self.__wrapped__
+        return other * self.__proxy_wrapped__
 
     def __rmatmul__(self, other: Any) -> Any:
-        return other @ self.__wrapped__
+        return other @ self.__proxy_wrapped__
 
     def __rtruediv__(self, other: Any) -> Any:
-        return operator.truediv(other, self.__wrapped__)
+        return operator.truediv(other, self.__proxy_wrapped__)
 
     def __rfloordiv__(self, other: Any) -> Any:
-        return other // self.__wrapped__
+        return other // self.__proxy_wrapped__
 
     def __rmod__(self, other: Any) -> Any:
-        return other % self.__wrapped__
+        return other % self.__proxy_wrapped__
 
     def __rdivmod__(self, other: Any) -> Any:
-        return divmod(other, self.__wrapped__)
+        return divmod(other, self.__proxy_wrapped__)
 
     def __rpow__(self, other: Any, *args: Any) -> Any:
-        return pow(other, self.__wrapped__, *args)
+        return pow(other, self.__proxy_wrapped__, *args)
 
     def __rlshift__(self, other: Any) -> Any:
-        return other << self.__wrapped__
+        return other << self.__proxy_wrapped__
 
     def __rrshift__(self, other: Any) -> Any:
-        return other >> self.__wrapped__
+        return other >> self.__proxy_wrapped__
 
     def __rand__(self, other: Any) -> Any:
-        return other & self.__wrapped__
+        return other & self.__proxy_wrapped__
 
     def __rxor__(self, other: Any) -> Any:
-        return other ^ self.__wrapped__
+        return other ^ self.__proxy_wrapped__
 
     def __ror__(self, other: Any) -> Any:
-        return other | self.__wrapped__
+        return other | self.__proxy_wrapped__
 
     def __iadd__(self, other: Any) -> Self:
-        self.__wrapped__ += other
+        self.__proxy_wrapped__ += other
         return self
 
     def __isub__(self, other: Any) -> Self:
-        self.__wrapped__ -= other
+        self.__proxy_wrapped__ -= other
         return self
 
     def __imul__(self, other: Any) -> Self:
-        self.__wrapped__ *= other
+        self.__proxy_wrapped__ *= other
         return self
 
     def __imatmul__(self, other: Any) -> Self:
-        self.__wrapped__ @= other
+        self.__proxy_wrapped__ @= other
         return self
 
     def __itruediv__(self, other: Any) -> Self:
-        self.__wrapped__ = operator.itruediv(self.__wrapped__, other)
+        self.__proxy_wrapped__ = operator.itruediv(
+            self.__proxy_wrapped__,
+            other,
+        )
         return self
 
     def __ifloordiv__(self, other: Any) -> Self:
-        self.__wrapped__ //= other
+        self.__proxy_wrapped__ //= other
         return self
 
     def __imod__(self, other: Any) -> Self:
-        self.__wrapped__ %= other
+        self.__proxy_wrapped__ %= other
         return self
 
     def __ipow__(self, other: Any) -> Self:  # type: ignore[misc]
-        self.__wrapped__ **= other
+        self.__proxy_wrapped__ **= other
         return self
 
     def __ilshift__(self, other: Any) -> Self:
-        self.__wrapped__ <<= other
+        self.__proxy_wrapped__ <<= other
         return self
 
     def __irshift__(self, other: Any) -> Self:
-        self.__wrapped__ >>= other
+        self.__proxy_wrapped__ >>= other
         return self
 
     def __iand__(self, other: Any) -> Self:
-        self.__wrapped__ &= other
+        self.__proxy_wrapped__ &= other
         return self
 
     def __ixor__(self, other: Any) -> Self:
-        self.__wrapped__ ^= other
+        self.__proxy_wrapped__ ^= other
         return self
 
     def __ior__(self, other: Any) -> Self:
-        self.__wrapped__ |= other
+        self.__proxy_wrapped__ |= other
         return self
 
     def __neg__(self) -> Any:
-        return -self.__wrapped__  # type: ignore[operator]
+        return -self.__proxy_wrapped__  # type: ignore[operator]
 
     def __pos__(self) -> Any:
-        return +self.__wrapped__  # type: ignore[operator]
+        return +self.__proxy_wrapped__  # type: ignore[operator]
 
     def __abs__(self) -> Any:
-        return abs(self.__wrapped__)  # type: ignore[arg-type]
+        return abs(self.__proxy_wrapped__)  # type: ignore[arg-type]
 
     def __invert__(self) -> Any:
-        return ~self.__wrapped__  # type: ignore[operator]
+        return ~self.__proxy_wrapped__  # type: ignore[operator]
 
     def __int__(self) -> int:
-        return int(self.__wrapped__)  # type: ignore[call-overload]
+        return int(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __float__(self) -> float:
-        return float(self.__wrapped__)  # type: ignore[arg-type]
+        return float(self.__proxy_wrapped__)  # type: ignore[arg-type]
 
     def __index__(self) -> int:
-        if hasattr(self.__wrapped__, '__index__'):
-            return operator.index(self.__wrapped__)
+        if hasattr(self.__proxy_wrapped__, '__index__'):
+            return operator.index(self.__proxy_wrapped__)
         else:
-            return int(self.__wrapped__)  # type: ignore[call-overload]
+            return int(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __len__(self) -> int:
-        return len(self.__wrapped__)  # type: ignore[arg-type]
+        return len(self.__proxy_wrapped__)  # type: ignore[arg-type]
 
     def __contains__(self, value: Any) -> bool:
-        return value in self.__wrapped__  # type: ignore[operator]
+        return value in self.__proxy_wrapped__  # type: ignore[operator]
 
     def __getitem__(self, key: Any) -> Any:
-        return self.__wrapped__[key]  # type: ignore[index]
+        return self.__proxy_wrapped__[key]  # type: ignore[index]
 
     def __setitem__(self, key: Any, value: Any) -> None:
-        self.__wrapped__[key] = value  # type: ignore[index]
+        self.__proxy_wrapped__[key] = value  # type: ignore[index]
 
     def __delitem__(self, key: Any) -> None:
-        del self.__wrapped__[key]  # type: ignore[attr-defined]
+        del self.__proxy_wrapped__[key]  # type: ignore[attr-defined]
 
     def __enter__(self) -> Any:
-        return self.__wrapped__.__enter__()  # type: ignore[attr-defined]
+        return self.__proxy_wrapped__.__enter__()  # type: ignore[attr-defined]
 
     def __exit__(self, *args: Any, **kwargs: Any) -> None:
-        return self.__wrapped__.__exit__(*args, **kwargs)  # type: ignore[attr-defined]
+        return self.__proxy_wrapped__.__exit__(*args, **kwargs)  # type: ignore[attr-defined]
 
     def __iter__(self) -> Iterator[Any]:
-        return iter(self.__wrapped__)  # type: ignore[call-overload]
+        return iter(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __next__(self) -> Any:
-        return next(self.__wrapped__)  # type: ignore[call-overload]
+        return next(self.__proxy_wrapped__)  # type: ignore[call-overload]
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
-        return self.__wrapped__(*args, **kwargs)  # type: ignore[operator]
+        return self.__proxy_wrapped__(*args, **kwargs)  # type: ignore[operator]
 
     def __reduce__(
         self,
@@ -602,9 +606,12 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
         ],
         tuple[FactoryType[T], DefaultClassType, DefaultHashType],
     ]:
-        factory = object.__getattribute__(self, '__factory__')
-        default_class = object.__getattribute__(self, '__default_class__')
-        default_hash = object.__getattribute__(self, '__default_hash__')
+        factory = object.__getattribute__(self, '__proxy_factory__')
+        default_class = object.__getattribute__(
+            self,
+            '__proxy_default_class__',
+        )
+        default_hash = object.__getattribute__(self, '__proxy_default_hash__')
         return _proxy_trampoline, (factory, default_class, default_hash)
 
     def __reduce_ex__(
@@ -620,34 +627,47 @@ class Proxy(as_metaclass(ProxyMetaType), Generic[T]):  # type: ignore[misc]
         return self.__reduce__()
 
     def __aiter__(self) -> Any:
-        return self.__wrapped__.__aiter__()  # type: ignore[attr-defined]
+        return self.__proxy_wrapped__.__aiter__()  # type: ignore[attr-defined]
 
     async def __anext__(self) -> Any:  # pragma: no cover
-        return await self.__wrapped__.__anext__()  # type: ignore[attr-defined]
+        return await self.__proxy_wrapped__.__anext__()  # type: ignore[attr-defined]
 
     def __await__(self) -> Any:  # pragma: no cover
-        obj_type = type(self.__wrapped__)
+        obj_type = type(self.__proxy_wrapped__)
         if (
             obj_type is CoroutineType
             or obj_type is GeneratorType
             and bool(
-                self.__wrapped__.gi_code.co_flags  # type: ignore[attr-defined]
+                self.__proxy_wrapped__.gi_code.co_flags  # type: ignore[attr-defined]
                 & CO_ITERABLE_COROUTINE,
             )
-            or isinstance(self.__wrapped__, Awaitable)
+            or isinstance(self.__proxy_wrapped__, Awaitable)
         ):
-            return _do_await(self.__wrapped__).__await__()
+            return _do_await(self.__proxy_wrapped__).__await__()
         else:
-            return _do_yield_from(self.__wrapped__)
+            return _do_yield_from(self.__proxy_wrapped__)
 
     def __aenter__(self) -> Any:
-        return self.__wrapped__.__aenter__()  # type: ignore[attr-defined]
+        return self.__proxy_wrapped__.__aenter__()  # type: ignore[attr-defined]
 
     def __aexit__(self, *args: Any, **kwargs: Any) -> Any:
-        return self.__wrapped__.__aexit__(*args, **kwargs)  # type: ignore[attr-defined]
+        return self.__proxy_wrapped__.__aexit__(*args, **kwargs)  # type: ignore[attr-defined]
 
 
 ProxyType: TypeAlias = Union[Proxy[T], T]
+
+
+def get_factory(proxy: Proxy[T]) -> FactoryType[T]:
+    """Get the factory contained in a proxy.
+
+    Args:
+        proxy: Proxy instance to get the factory from.
+
+    Returns:
+        The factory, a callable object which, when invoked, returns an object
+        of type `T`.
+    """
+    return proxy.__proxy_factory__
 
 
 def extract(proxy: Proxy[T]) -> T:
@@ -662,7 +682,7 @@ def extract(proxy: Proxy[T]) -> T:
     Returns:
         Object wrapped by proxy.
     """
-    return proxy.__wrapped__
+    return proxy.__proxy_wrapped__
 
 
 def is_resolved(proxy: Proxy[T]) -> bool:
@@ -675,7 +695,7 @@ def is_resolved(proxy: Proxy[T]) -> bool:
         `True` if `proxy` is resolved (i.e., the `factory` has been called) \
         and `False` otherwise.
     """
-    return proxy.__resolved__
+    return proxy.__proxy_resolved__
 
 
 def resolve(proxy: Proxy[T]) -> None:
@@ -684,7 +704,7 @@ def resolve(proxy: Proxy[T]) -> None:
     Args:
         proxy: Proxy instance to force resolve.
     """
-    proxy.__wrapped__  # noqa: B018
+    proxy.__proxy_wrapped__  # noqa: B018
 
 
 class ProxyLocker(Generic[T]):

--- a/proxystore/proxy/__init__.py
+++ b/proxystore/proxy/__init__.py
@@ -50,6 +50,7 @@ from typing import Callable
 from typing import cast
 from typing import Generic
 from typing import Iterator
+from typing import Optional
 from typing import SupportsIndex
 from typing import TypeVar
 from typing import Union
@@ -71,8 +72,8 @@ from proxystore.proxy._utils import ProxyMetaType
 
 T = TypeVar('T')
 FactoryType: TypeAlias = Callable[[], T]
-DefaultClassType: TypeAlias = type | None
-DefaultHashType: TypeAlias = Exception | int | None
+DefaultClassType: TypeAlias = Optional[type]
+DefaultHashType: TypeAlias = Optional[Union[Exception, int]]
 
 
 def _proxy_trampoline(

--- a/proxystore/proxy/_utils.py
+++ b/proxystore/proxy/_utils.py
@@ -26,41 +26,41 @@ class _ProxyMethods:
     # that, we copy the properties into the derived class type itself
     # via a meta class. In that way the properties will always take
     # precedence.
-    __wrapped__: Any
+    __proxy_wrapped__: Any
 
     # The Proxy class is re-exported from proxystore/proxy/__init__.py
     # and this module is hidden from the docs so we set the Proxy class's
     # module to proxystore.proxy.
     @proxy_property(default='proxystore.proxy')
     def __module__(self) -> str:  # type: ignore[override]
-        return self.__wrapped__.__module__
+        return self.__proxy_wrapped__.__module__
 
     @__module__.setter
     def __module__set(self, value: str) -> None:
-        self.__wrapped__.__module__ = value
+        self.__proxy_wrapped__.__module__ = value
 
     @proxy_property(default='<Proxy Placeholder Docstring>')
     def __doc__(self) -> str:  # type: ignore[override]
-        return self.__wrapped__.__doc__
+        return self.__proxy_wrapped__.__doc__
 
     @__doc__.setter
     def __doc__set(self, value: str) -> None:
-        self.__wrapped__.__doc__ = value
+        self.__proxy_wrapped__.__doc__ = value
 
     @property
     def __annotations__(self) -> dict[str, Any]:
-        return self.__wrapped__.__annotations__
+        return self.__proxy_wrapped__.__annotations__
 
     @__annotations__.setter
     def __annotations__(self, value: dict[str, Any]) -> None:
-        self.__wrapped__.__annotations__ = value
+        self.__proxy_wrapped__.__annotations__ = value
 
     # We similar use a property for __dict__. We need __dict__ to be
     # explicit to ensure that vars() works as expected.
 
     @property
     def __dict__(self) -> dict[str, Any]:  # type: ignore[override]
-        return self.__wrapped__.__dict__
+        return self.__proxy_wrapped__.__dict__
 
     # Need to also propagate the special __weakref__ attribute for case
     # where decorating classes which will define this. If do not define
@@ -69,7 +69,7 @@ class _ProxyMethods:
 
     @property
     def __weakref__(self) -> Any:
-        return self.__wrapped__.__weakref__
+        return self.__proxy_wrapped__.__weakref__
 
 
 class ProxyMetaType(type):

--- a/proxystore/store/__init__.py
+++ b/proxystore/store/__init__.py
@@ -11,6 +11,7 @@ from typing import Sequence
 from typing import TypeVar
 
 from proxystore.connectors.protocols import Connector
+from proxystore.proxy import get_factory
 from proxystore.proxy import Proxy
 from proxystore.store.base import Store
 from proxystore.store.exceptions import ProxyStoreFactoryError
@@ -54,7 +55,7 @@ def get_store(val: str | Proxy[T]) -> Store[Any] | None:
     """
     if isinstance(val, Proxy):
         # If the object is a proxy, get the factory that will access the store
-        factory = val.__factory__
+        factory = get_factory(val)
         if isinstance(factory, StoreFactory):
             return factory.get_store()
         else:

--- a/proxystore/store/lifetimes.py
+++ b/proxystore/store/lifetimes.py
@@ -36,6 +36,7 @@ if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
+from proxystore.proxy import get_factory
 from proxystore.proxy import Proxy
 from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.factory import StoreFactory
@@ -225,7 +226,7 @@ class ContextLifetime:
         """
         keys: list[ConnectorKeyT] = []
         for proxy in proxies:
-            factory = proxy.__factory__
+            factory = get_factory(proxy)
             if isinstance(factory, StoreFactory):
                 keys.append(factory.key)
             else:
@@ -479,7 +480,7 @@ class StaticLifetime:
             RuntimeError: If this lifetime has ended.
         """
         for proxy in proxies:
-            factory = proxy.__factory__
+            factory = get_factory(proxy)
             if isinstance(factory, StoreFactory):
                 self.add_key(factory.key, store=factory.get_store())
             else:

--- a/proxystore/store/ref.py
+++ b/proxystore/store/ref.py
@@ -117,28 +117,29 @@ class BaseRefProxy(Proxy[T]):
        [`clone()`][proxystore.store.ref.clone] should be used instead.
     """
 
-    __factory__: FactoryType[T]
+    __proxy_factory__: FactoryType[T]
+    __proxy_valid__: bool
 
     def __init__(self, factory: FactoryType[T]) -> None:
-        object.__setattr__(self, '__valid__', True)
+        object.__setattr__(self, '__proxy_valid__', True)
         super().__init__(factory)
 
     @property
-    def __wrapped__(self) -> T:
-        if not object.__getattribute__(self, '__valid__'):
+    def __proxy_wrapped__(self) -> T:
+        if not object.__getattribute__(self, '__proxy_valid__'):
             raise ReferenceInvalidError(
                 'Reference has been invalidated. This is likely because it '
                 'was pickled and transferred to a different process.',
             )
-        return super().__wrapped__
+        return super().__proxy_wrapped__
 
-    @__wrapped__.deleter
-    def __wrapped__(self) -> None:
-        object.__delattr__(self, '__target__')
+    @__proxy_wrapped__.deleter
+    def __proxy_wrapped__(self) -> None:
+        object.__delattr__(self, '__proxy_target__')
 
-    @__wrapped__.setter
-    def __wrapped__(self, target: T) -> None:
-        object.__setattr__(self, '__target__', target)
+    @__proxy_wrapped__.setter
+    def __proxy_wrapped__(self, target: T) -> None:
+        object.__setattr__(self, '__proxy_target__', target)
 
     def __copy__(self) -> NoReturn:
         raise NotImplementedError(
@@ -171,31 +172,38 @@ class OwnedProxy(BaseRefProxy[T]):
             to resolve the target object from the store.
     """
 
+    __proxy_ref_count__: int
+    __proxy_ref_mut_count__: int
+    __proxy_finalizer__: Any
+
     def __init__(self, factory: FactoryType[T]) -> None:
-        object.__setattr__(self, '__ref_count__', 0)
-        object.__setattr__(self, '__ref_mut_count__', 0)
+        object.__setattr__(self, '__proxy_ref_count__', 0)
+        object.__setattr__(self, '__proxy_ref_mut_count__', 0)
         object.__setattr__(
             self,
-            '__finalizer__',
+            '__proxy_finalizer__',
             atexit.register(_WeakRefFinalizer(self, '__del__')),
         )
         super().__init__(factory)
 
     def __del__(self) -> None:
-        atexit.unregister(object.__getattribute__(self, '__finalizer__'))
-        if object.__getattribute__(self, '__valid__'):
-            ref_count = object.__getattribute__(self, '__ref_count__')
-            ref_mut_count = object.__getattribute__(self, '__ref_mut_count__')
+        atexit.unregister(object.__getattribute__(self, '__proxy_finalizer__'))
+        if object.__getattribute__(self, '__proxy_valid__'):
+            ref_count = object.__getattribute__(self, '__proxy_ref_count__')
+            ref_mut_count = object.__getattribute__(
+                self,
+                '__proxy_ref_mut_count__',
+            )
             if ref_count > 0 or ref_mut_count > 0:
                 raise RuntimeError(
                     'Cannot safely delete OwnedProxy because there still '
                     f'exists {ref_count} RefProxy and {ref_mut_count} '
                     'RefMutProxy.',
                 )
-            factory = object.__getattribute__(self, '__factory__')
+            factory = object.__getattribute__(self, '__proxy_factory__')
             store = factory.get_store()
             store.evict(factory.key)
-            object.__setattr__(self, '__valid__', False)
+            object.__setattr__(self, '__proxy_valid__', False)
 
     def __reduce__(  # type: ignore[override]
         self,
@@ -203,9 +211,9 @@ class OwnedProxy(BaseRefProxy[T]):
         Callable[[FactoryType[T]], OwnedProxy[T]],
         tuple[FactoryType[T]],
     ]:
-        object.__setattr__(self, '__valid__', False)
+        object.__setattr__(self, '__proxy_valid__', False)
         return _owned_proxy_trampoline, (
-            object.__getattribute__(self, '__factory__'),
+            object.__getattribute__(self, '__proxy_factory__'),
         )
 
     def __reduce_ex__(  # type: ignore[override]
@@ -236,39 +244,42 @@ class RefProxy(BaseRefProxy[T]):
             be `None`.
     """
 
+    __proxy_finalizer__: Any
+    __proxy_owner__: OwnedProxy[T]
+
     def __init__(
         self,
         factory: FactoryType[T],
         *,
         owner: OwnedProxy[T] | None = None,
     ) -> None:
-        object.__setattr__(self, '__owner__', owner)
+        object.__setattr__(self, '__proxy_owner__', owner)
         object.__setattr__(
             self,
-            '__finalizer__',
+            '__proxy_finalizer__',
             atexit.register(_WeakRefFinalizer(self, '__del__')),
         )
         super().__init__(factory)
 
     def __del__(self) -> None:
-        atexit.unregister(object.__getattribute__(self, '__finalizer__'))
+        atexit.unregister(object.__getattribute__(self, '__proxy_finalizer__'))
         # If owner is None, then this RefMutProxy was likely serialized
         # and sent to a different process. As such, it is the responsibility
         # of that code to take over reference counting.
-        owner = object.__getattribute__(self, '__owner__')
+        owner = object.__getattribute__(self, '__proxy_owner__')
         if owner is not None:
-            ref_count = object.__getattribute__(owner, '__ref_count__')
+            ref_count = object.__getattribute__(owner, '__proxy_ref_count__')
             assert ref_count >= 1
-            object.__setattr__(owner, '__ref_count__', ref_count - 1)
-        object.__setattr__(self, '__owner__', None)
-        object.__setattr__(self, '__valid__', False)
+            object.__setattr__(owner, '__proxy_ref_count__', ref_count - 1)
+        object.__setattr__(self, '__proxy_owner__', None)
+        object.__setattr__(self, '__proxy_valid__', False)
 
     def __reduce__(  # type: ignore[override]
         self,
     ) -> tuple[Callable[[FactoryType[T]], RefProxy[T]], tuple[FactoryType[T]]]:
-        object.__setattr__(self, '__valid__', False)
+        object.__setattr__(self, '__proxy_valid__', False)
         return _ref_proxy_trampoline, (
-            object.__getattribute__(self, '__factory__'),
+            object.__getattribute__(self, '__proxy_factory__'),
         )
 
     def __reduce_ex__(  # type: ignore[override]
@@ -296,35 +307,38 @@ class RefMutProxy(BaseRefProxy[T]):
             be `None`.
     """  # noqa: E501
 
+    __proxy_finalizer__: Any
+    __proxy_owner__: OwnedProxy[T]
+
     def __init__(
         self,
         factory: FactoryType[T],
         *,
         owner: OwnedProxy[T] | None = None,
     ) -> None:
-        object.__setattr__(self, '__owner__', owner)
+        object.__setattr__(self, '__proxy_owner__', owner)
         object.__setattr__(
             self,
-            '__finalizer__',
+            '__proxy_finalizer__',
             atexit.register(_WeakRefFinalizer(self, '__del__')),
         )
         super().__init__(factory)
 
     def __del__(self) -> None:
-        atexit.unregister(object.__getattribute__(self, '__finalizer__'))
+        atexit.unregister(object.__getattribute__(self, '__proxy_finalizer__'))
         # If owner is None, then this RefMutProxy was likely serialized
         # and sent to a different process. As such, it is the responsibility
         # of that code to take over reference counting.
-        owner = object.__getattribute__(self, '__owner__')
+        owner = object.__getattribute__(self, '__proxy_owner__')
         if owner is not None:
             ref_mut_count = object.__getattribute__(
                 owner,
-                '__ref_mut_count__',
+                '__proxy_ref_mut_count__',
             )
             assert ref_mut_count == 1
-            object.__setattr__(owner, '__ref_mut_count__', 0)
-        object.__setattr__(self, '__owner__', None)
-        object.__setattr__(self, '__valid__', False)
+            object.__setattr__(owner, '__proxy_ref_mut_count__', 0)
+        object.__setattr__(self, '__proxy_owner__', None)
+        object.__setattr__(self, '__proxy_valid__', False)
 
     def __reduce__(  # type: ignore[override]
         self,
@@ -332,9 +346,9 @@ class RefMutProxy(BaseRefProxy[T]):
         Callable[[FactoryType[T]], RefMutProxy[T]],
         tuple[FactoryType[T]],
     ]:
-        object.__setattr__(self, '__valid__', False)
+        object.__setattr__(self, '__proxy_valid__', False)
         return _ref_mut_proxy_trampoline, (
-            object.__getattribute__(self, '__factory__'),
+            object.__getattribute__(self, '__proxy_factory__'),
         )
 
     def __reduce_ex__(  # type: ignore[override]
@@ -370,16 +384,16 @@ def borrow(
     """
     if not isinstance(proxy, OwnedProxy):
         raise ReferenceNotOwnedError('Only owned references can be borrowed.')
-    if object.__getattribute__(proxy, '__ref_mut_count__') > 0:
+    if object.__getattribute__(proxy, '__proxy_ref_mut_count__') > 0:
         raise MutableBorrowError('Proxy was already borrowed as mutable.')
     object.__setattr__(
         proxy,
-        '__ref_count__',
-        object.__getattribute__(proxy, '__ref_count__') + 1,
+        '__proxy_ref_count__',
+        object.__getattribute__(proxy, '__proxy_ref_count__') + 1,
     )
-    ref_proxy = RefProxy(proxy.__factory__, owner=proxy)
+    ref_proxy = RefProxy(proxy.__proxy_factory__, owner=proxy)
     if populate_target and is_resolved(proxy):
-        ref_proxy.__wrapped__ = proxy.__wrapped__
+        ref_proxy.__proxy_wrapped__ = proxy.__proxy_wrapped__
     return ref_proxy
 
 
@@ -407,18 +421,18 @@ def mut_borrow(
     """
     if not isinstance(proxy, OwnedProxy):
         raise ReferenceNotOwnedError('Only owned references can be borrowed.')
-    if object.__getattribute__(proxy, '__ref_mut_count__') > 0:
+    if object.__getattribute__(proxy, '__proxy_ref_mut_count__') > 0:
         raise MutableBorrowError('Proxy was already borrowed as mutable.')
-    if object.__getattribute__(proxy, '__ref_count__') > 0:
+    if object.__getattribute__(proxy, '__proxy_ref_count__') > 0:
         raise MutableBorrowError('Proxy was already borrowed as immutable.')
     object.__setattr__(
         proxy,
-        '__ref_mut_count__',
-        object.__getattribute__(proxy, '__ref_mut_count__') + 1,
+        '__proxy_ref_mut_count__',
+        object.__getattribute__(proxy, '__proxy_ref_mut_count__') + 1,
     )
-    ref_proxy = RefMutProxy(proxy.__factory__, owner=proxy)
+    ref_proxy = RefMutProxy(proxy.__proxy_factory__, owner=proxy)
     if populate_target and is_resolved(proxy):
-        ref_proxy.__wrapped__ = proxy.__wrapped__
+        ref_proxy.__proxy_wrapped__ = proxy.__proxy_wrapped__
     return ref_proxy
 
 
@@ -433,7 +447,7 @@ def clone(proxy: OwnedProxy[T]) -> OwnedProxy[T]:
     """
     if not isinstance(proxy, OwnedProxy):
         raise ReferenceNotOwnedError('Only owned references can be cloned.')
-    factory = proxy.__factory__
+    factory = proxy.__proxy_factory__
     store = factory.get_store()
     data = store.connector.get(factory.key)
     new_key = store.connector.put(data)
@@ -477,7 +491,7 @@ def into_owned(
         raise ValueError(
             'Only a base proxy can be converted into an owned proxy.',
         )
-    factory = proxy.__factory__
+    factory = proxy.__proxy_factory__
     if not isinstance(factory, StoreFactory):
         raise ProxyStoreFactoryError(
             'The proxy must contain a factory with type '
@@ -487,7 +501,7 @@ def into_owned(
     factory.evict = False
     owned_proxy = OwnedProxy(factory)
     if populate_target and is_resolved(proxy):
-        owned_proxy.__wrapped__ = proxy.__wrapped__
+        owned_proxy.__proxy_wrapped__ = proxy.__proxy_wrapped__
     return owned_proxy
 
 
@@ -524,8 +538,8 @@ def update(
     if not isinstance(proxy, (OwnedProxy, RefMutProxy)):
         raise ReferenceNotOwnedError('Reference is an immutable borrow.')
     if isinstance(proxy, OwnedProxy) and (
-        object.__getattribute__(proxy, '__ref_mut_count__') > 0
-        or object.__getattribute__(proxy, '__ref_count__') > 0
+        object.__getattribute__(proxy, '__proxy_ref_mut_count__') > 0
+        or object.__getattribute__(proxy, '__proxy_ref_count__') > 0
     ):
         raise MutableBorrowError(
             'OwnedProxy has been borrowed. Cannot mutate.',
@@ -533,11 +547,11 @@ def update(
     if not is_resolved(proxy):
         return
 
-    store = proxy.__factory__.get_store()
+    store = proxy.__proxy_factory__.get_store()
     try:
         store._set(
-            proxy.__factory__.key,
-            proxy.__wrapped__,
+            proxy.__proxy_factory__.key,
+            proxy.__proxy_wrapped__,
             serializer=serializer,
         )
     except NotImplementedError as e:  # pragma: no cover

--- a/proxystore/store/scopes.py
+++ b/proxystore/store/scopes.py
@@ -51,10 +51,10 @@ def mark_refs_out_of_scope(
             owner.
     """
     for ref in refs:
-        if not object.__getattribute__(ref, '__valid__'):
+        if not object.__getattribute__(ref, '__proxy_valid__'):
             # We've already encountered and handled this reference
             continue
-        owner = object.__getattribute__(ref, '__owner__')
+        owner = object.__getattribute__(ref, '__proxy_owner__')
         if owner is None:
             raise RuntimeError(
                 f'Cannot mark {owner!r} as out of scope because it has '
@@ -62,19 +62,22 @@ def mark_refs_out_of_scope(
             )
 
         if isinstance(ref, RefProxy):
-            ref_count = object.__getattribute__(owner, '__ref_count__')
-            object.__setattr__(owner, '__ref_count__', ref_count - 1)
+            ref_count = object.__getattribute__(owner, '__proxy_ref_count__')
+            object.__setattr__(owner, '__proxy_ref_count__', ref_count - 1)
         elif isinstance(ref, RefMutProxy):
-            ref_count = object.__getattribute__(owner, '__ref_mut_count__')
-            object.__setattr__(owner, '__ref_mut_count__', ref_count - 1)
+            ref_count = object.__getattribute__(
+                owner,
+                '__proxy_ref_mut_count__',
+            )
+            object.__setattr__(owner, '__proxy_ref_mut_count__', ref_count - 1)
         else:
             raise AssertionError('Unreachable.')
 
         # Remove ref's reference to owner so it no longer keeps owner alive
-        object.__setattr__(ref, '__owner__', None)
+        object.__setattr__(ref, '__proxy_owner__', None)
         # Mark ref as invalid in case the user tries to use it after it
         # has already "gone out of scope."
-        object.__setattr__(ref, '__valid__', False)
+        object.__setattr__(ref, '__proxy_valid__', False)
 
 
 def _make_out_of_scope_callback(

--- a/proxystore/store/types.py
+++ b/proxystore/store/types.py
@@ -51,6 +51,8 @@ class StoreConfig(TypedDict):
         deserializer: Optional deserializer.
         cache_size: Cache size.
         metrics: Enable recording operation metrics.
+        populate_target: Set the default value for the `populate_target`
+            parameter of proxy methods.
         register: Auto-register the store.
     """
 
@@ -61,4 +63,5 @@ class StoreConfig(TypedDict):
     deserializer: NotRequired[DeserializerT | None]
     cache_size: NotRequired[int]
     metrics: NotRequired[bool]
+    populate_target: NotRequired[bool]
     register: NotRequired[bool]

--- a/proxystore/store/utils.py
+++ b/proxystore/store/utils.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Tuple
 from typing import TypeVar
 
+from proxystore.proxy import get_factory
 from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.store import base
@@ -30,7 +31,7 @@ def get_key(proxy: Proxy[T]) -> ConnectorKeyT:
         ProxyStoreFactoryError: If the proxy's factory is not an instance of
             [`StoreFactory`][proxystore.store.base.StoreFactory].
     """
-    factory = proxy.__factory__
+    factory = get_factory(proxy)
     if isinstance(factory, base.StoreFactory):
         return factory.key
     else:
@@ -68,7 +69,7 @@ def resolve_async(proxy: Proxy[T]) -> None:
         ProxyStoreFactoryError: If the proxy's factory is not an instance of
             [`StoreFactory`][proxystore.store.base.StoreFactory].
     """
-    factory = proxy.__factory__
+    factory = get_factory(proxy)
     if isinstance(factory, base.StoreFactory):
         if not is_resolved(proxy):
             factory.resolve_async()

--- a/tests/mypy_plugin_test.py
+++ b/tests/mypy_plugin_test.py
@@ -27,15 +27,15 @@ def test_proxy_slots_types() -> None:
     proxy = Proxy(factory_int)
 
     assert_type(proxy, Proxy[int])
-    assert_type(proxy.__factory__, Callable[[], int])
-    assert_type(proxy.__resolved__, bool)
-    assert_type(proxy.__wrapped__, int)
+    assert_type(proxy.__proxy_factory__, Callable[[], int])
+    assert_type(proxy.__proxy_resolved__, bool)
+    assert_type(proxy.__proxy_wrapped__, int)
 
     if TYPE_CHECKING:
-        # Accessing __target__ directly will raise an AttributeError because
-        # at runtime because it must be done through
-        # object.__getattribute__(proxy, '__target__').
-        assert_type(proxy.__target__, int)
+        # Accessing __proxy_target__ directly will raise an AttributeError
+        # because at runtime because it must be done through
+        # object.__getattribute__(proxy, '__proxy_target__').
+        assert_type(proxy.__proxy_target__, int)
 
 
 def test_proxy_class_attribute_types() -> None:

--- a/tests/proxy/proxy_type_test.py
+++ b/tests/proxy/proxy_type_test.py
@@ -818,3 +818,48 @@ def test_resolved_str() -> None:
     assert obj.__resolved__ is False
     str(obj)
     assert obj.__resolved__ is True
+
+
+def test_preset_target() -> None:
+    target = 'value'
+    proxy = Proxy(lambda: target, target=target)  # pragma: no cover
+    assert proxy.__resolved__
+
+
+def test_precompute_defaults() -> None:
+    target = 'value'
+
+    proxy = Proxy(
+        lambda: target,  # pragma: no cover
+        cache_defaults=True,
+        target=target,
+    )
+    del proxy.__wrapped__
+
+    assert not proxy.__resolved__
+    assert hash(proxy) == hash(target)
+    assert not proxy.__resolved__
+    assert isinstance(proxy, str)
+    assert not proxy.__resolved__
+    assert not isinstance(proxy, list)
+    assert not proxy.__resolved__
+
+
+def test_precompute_unhashable() -> None:
+    target = [1, 2, 3]
+
+    proxy = Proxy(
+        lambda: target,  # pragma: no cover
+        cache_defaults=True,
+        target=target,
+    )
+    del proxy.__wrapped__
+
+    assert not proxy.__resolved__
+    try:
+        hash(proxy)
+    except TypeError:
+        pass
+    assert not proxy.__resolved__
+    assert isinstance(proxy, list)
+    assert not proxy.__resolved__

--- a/tests/proxy/proxy_utils_test.py
+++ b/tests/proxy/proxy_utils_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from proxystore.factory import SimpleFactory
 from proxystore.proxy import extract
+from proxystore.proxy import get_factory
 from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.proxy import ProxyLocker
@@ -69,6 +70,12 @@ def test_proxy_utils() -> None:
     assert not is_resolved(p)
     resolve(p)
     assert is_resolved(p)
+
+
+def test_get_factory() -> None:
+    factory = SimpleFactory('value')
+    proxy = Proxy(factory)
+    assert get_factory(proxy) is factory
 
 
 def test_proxy_locker():

--- a/tests/store/ref_test.py
+++ b/tests/store/ref_test.py
@@ -435,3 +435,31 @@ def test_del_invalid_owned_proxy(store: Store[FileConnector]) -> None:
     del proxy
 
     assert new_proxy == 'value'
+
+
+def test_clone_deepcopy(store: Store[FileConnector]) -> None:
+    value = [1, 2, 3]
+    factory = put_in_store(value, store)
+    proxy = OwnedProxy(factory, target=value)
+    assert is_resolved(proxy)
+
+    cloned = clone(proxy)
+    assert is_resolved(cloned)
+    cloned.append(4)
+    assert cloned == [1, 2, 3, 4]
+    assert proxy == [1, 2, 3]
+
+
+def test_owned_proxy_cache_defaults(store: Store[FileConnector]) -> None:
+    value = 'value'
+    factory = put_in_store(value, store)
+    proxy = OwnedProxy(factory, cache_defaults=True, target=value)
+    del proxy.__proxy_wrapped__
+
+    assert not is_resolved(proxy)
+    assert isinstance(proxy, str)
+    assert not is_resolved(proxy)
+
+    assert not is_resolved(proxy)
+    assert hash(proxy) == hash(value)
+    assert not is_resolved(proxy)

--- a/tests/store/ref_test.py
+++ b/tests/store/ref_test.py
@@ -214,7 +214,7 @@ def test_pickle_ref_proxy(store: Store[FileConnector]) -> None:
     # new_borrowed, because it was pickled and unpickled, does not have a
     # reference to is owned proxy so deleting new_borrowed will not
     # decrement the ref count on proxy.
-    assert object.__getattribute__(proxy, '__ref_count__') == 1
+    assert object.__getattribute__(proxy, '__proxy_ref_count__') == 1
 
 
 def test_pickle_ref_mut_proxy(store: Store[FileConnector]) -> None:
@@ -235,7 +235,7 @@ def test_pickle_ref_mut_proxy(store: Store[FileConnector]) -> None:
     # new_borrowed, because it was pickled and unpickled, does not have a
     # reference to is owned proxy so deleting new_borrowed will not
     # decrement the ref count on proxy.
-    assert object.__getattribute__(proxy, '__ref_mut_count__') == 1
+    assert object.__getattribute__(proxy, '__proxy_ref_mut_count__') == 1
 
 
 def test_copy_not_implemented_error(store: Store[FileConnector]) -> None:
@@ -388,7 +388,7 @@ def test_borrow_populate(
     borrowed = borrow(proxy, populate_target=populate_target)
     assert is_resolved(borrowed) == populate_target
 
-    del proxy.__wrapped__
+    del proxy.__proxy_wrapped__
     borrowed = borrow(proxy, populate_target=populate_target)
     assert not is_resolved(borrowed)
 
@@ -406,7 +406,7 @@ def test_mut_borrow_populate(
     assert is_resolved(borrowed) == populate_target
 
     del borrowed
-    del proxy.__wrapped__
+    del proxy.__proxy_wrapped__
     borrowed = mut_borrow(proxy, populate_target=populate_target)
     assert not is_resolved(borrowed)
 

--- a/tests/store/scopes_test.py
+++ b/tests/store/scopes_test.py
@@ -99,13 +99,13 @@ def test_mark_refs_out_of_scope_duplicates(
 def test_mark_refs_out_of_scope_no_owner(store: Store[FileConnector]) -> None:
     proxy = store.owned_proxy('value')
     borrowed = borrow(proxy)
-    object.__setattr__(borrowed, '__owner__', None)
+    object.__setattr__(borrowed, '__proxy_owner__', None)
 
     with pytest.raises(RuntimeError, match='no reference to its owner'):
         mark_refs_out_of_scope(borrowed)
 
     # Restore owner so cleanup can be done correctly
-    object.__setattr__(borrowed, '__owner__', proxy)
+    object.__setattr__(borrowed, '__proxy_owner__', proxy)
 
 
 def test_make_out_of_scope_callback(store: Store[FileConnector]) -> None:

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -7,9 +7,11 @@ import pytest
 
 import proxystore
 from proxystore.connectors.local import LocalConnector
+from proxystore.proxy import get_factory
 from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.proxy import ProxyLocker
+from proxystore.proxy import resolve
 from proxystore.serialize import deserialize
 from proxystore.serialize import serialize
 from proxystore.store import get_store
@@ -158,9 +160,9 @@ def test_proxy_missing_key(store: Store[LocalConnector]) -> None:
     store.evict(key)
     assert not store.exists(key)
 
-    assert isinstance(proxy.__factory__, StoreFactory)
+    assert isinstance(get_factory(proxy), StoreFactory)
     with pytest.raises(ProxyResolveMissingKeyError):
-        proxy.__factory__.resolve()
+        resolve(proxy)
 
     proxy = store.proxy_from_key(key=key)
     with pytest.raises(ProxyResolveMissingKeyError):

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Generator
 
 import pytest
 
-import proxystore
 from proxystore.connectors.local import LocalConnector
 from proxystore.proxy import get_factory
 from proxystore.proxy import is_resolved
@@ -24,17 +22,6 @@ from proxystore.store.factory import StoreFactory
 from proxystore.store.lifetimes import ContextLifetime
 from proxystore.store.ref import OwnedProxy
 from proxystore.store.utils import get_key
-
-
-@pytest.fixture(autouse=True)
-def _verify_no_registered_stores() -> Generator[None, None, None]:
-    yield
-
-    if len(proxystore.store._stores) > 0:  # pragma: no cover
-        raise RuntimeError(
-            'Test left at least one store registered: '
-            f'{tuple(proxystore.store._stores.keys())}.',
-        )
 
 
 def test_factory_resolve(store: Store[LocalConnector]) -> None:

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -365,3 +365,20 @@ def test_owned_proxy_skip_nonproxiable(store: Store[LocalConnector]) -> None:
 def test_owned_proxy_nonproxiable_error(store: Store[LocalConnector]) -> None:
     with pytest.raises(NonProxiableTypeError):
         store.owned_proxy(None, skip_nonproxiable=False)
+
+
+@pytest.mark.parametrize('populate_target', (True, False))
+def test_default_populate_target(populate_target: bool) -> None:
+    with Store(
+        'test-default-populate-target',
+        LocalConnector(),
+        populate_target=populate_target,
+    ) as store:
+        proxy = store.proxy('value')
+        assert is_resolved(proxy) == populate_target
+
+        proxy = store.proxy('value', populate_target=True)
+        assert is_resolved(proxy)
+
+        proxy = store.proxy('value', populate_target=False)
+        assert not is_resolved(proxy)

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -114,6 +114,12 @@ def test_proxy_populate_target(store: Store[LocalConnector]) -> None:
     assert isinstance(p, Proxy)
     assert p == [1, 2, 3]
 
+    # populate_target should also set cache_defaults on the proxy
+    del p.__proxy_wrapped__
+    assert not is_resolved(p)
+    assert isinstance(p, list)
+    assert not is_resolved(p)
+
 
 def test_proxy_from_key(store: Store[LocalConnector]) -> None:
     key = store.put([1, 2, 3])
@@ -249,6 +255,13 @@ def test_proxy_batch_populate_target(store: Store[LocalConnector]) -> None:
     for p, v in zip(proxies, values):
         assert p == v
 
+    # populate_target should also set cache_defaults on the proxy
+    del proxies[0].__proxy_wrapped__
+    assert not is_resolved(proxies[0])
+    assert isinstance(proxies[0], str)
+    assert hash(proxies[0]) == hash(values[0])
+    assert not is_resolved(proxies[0])
+
 
 def test_proxy_batch_custom_serializer(store: Store[LocalConnector]) -> None:
     values = [b'test_value1', b'test_value2', b'test_value3']
@@ -326,6 +339,21 @@ def test_locked_proxy_mutex_options_error(
 
 def test_owned_proxy(store: Store[LocalConnector]) -> None:
     assert isinstance(store.owned_proxy([1, 2, 3]), OwnedProxy)
+
+
+def test_owned_proxy_populate_target(store: Store[LocalConnector]) -> None:
+    value = 'test_value'
+    p = store.owned_proxy(value, populate_target=True)
+    assert is_resolved(p)
+    assert isinstance(p, Proxy)
+    assert p == value
+
+    # populate_target should also set cache_defaults on the proxy
+    del p.__proxy_wrapped__
+    assert not is_resolved(p)
+    assert isinstance(p, str)
+    assert hash(p) == hash(value)
+    assert not is_resolved(p)
 
 
 def test_owned_proxy_skip_nonproxiable(store: Store[LocalConnector]) -> None:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

This PR adds the `cache_defaults` and `target` parameters to `Proxy`. When used together, the proxy caches default values of `__class__` and `__hash__` so that `hash(proxy)` and `isinstance(proxy, ...)` can be used without needing the resolve the proxy. The `populate_target` flag of `Store` methods now defaults to also setting `cache_defaults=True`.

Because this change added more special attributes to the `Proxy` class, I renamed all special attributes (`__wrapped__`, `__factory__`, `__resolved__`, etc.) to be prefixed by `__proxy_*` to better distinguish what is a property of `Proxy` versus the target. This is not considered a breaking change because those properties are an internal implementation detail of the `Proxy` class.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #549

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests for the features.

I also validated against this Dask example:
```python
import logging
import tempfile

from dask.distributed import Client
from proxystore.connectors.file import FileConnector
from proxystore.store import Store

logging.basicConfig(level=logging.DEBUG)

if __name__ == '__main__':
    with tempfile.TemporaryDirectory() as tmp_dir:
        with Store('default', FileConnector(tmp_dir)) as store:
            client = Client(processes=True)

            x = list(range(100))
            p = store.proxy(x, populate_target=True)
            y = client.submit(sum, p)

            print(f'Result: {y.result()}')

            client.close()
```
Here, when `populate_target=False`, the proxy will be resolved three times: on the client when the proxy is serialized, on the scheduler when Dask does its input management, and on the worker when the proxy is actually used. With `populate_target=True`, the proxy is only resolved once on the worker when actually used.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
