### PR TITLE
Fix mypy plugin crashes by defaulting types to `Any` when internal assertions fail

### DIFF
--- a/tests/mypy_plugin_test.py
+++ b/tests/mypy_plugin_test.py
@@ -138,3 +138,19 @@ def test_proxy_bad_attribute_use() -> None:
 
     # Will fail because mypy should have inferred x is an int.
     expects_str(x)  # type: ignore[arg-type]
+
+
+def test_union_type_bad_attribute_crash() -> None:
+    # https://github.com/proxystore/proxystore/issues/559
+    def foo(x: T | Proxy[T]) -> T | Callable[[], T]:  # pragma: no cover
+        # Note: this function should not actually be called! It will error!
+        if isinstance(x, Proxy):
+            return x.__factory__  # In #559, mypy crashes on this line
+        else:
+            return x
+
+    x = Proxy(lambda: 42)
+    try:
+        _ = x.__factory__  # type: ignore[attr-defined]
+    except AttributeError:
+        pass


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Fix mypy plugin crashses by defaulting types to `Any` when internal assertions fail.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #559

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests, and verified the example in #559 no longer crashes and instead raises the *correct* (expected) errors.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
