### PR TITLE
Migrate from `kafka-python` to `confluent_kafka`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,7 +167,7 @@ plugins:
             - https://requests.readthedocs.io/en/latest/objects.inv
             - https://extensions.proxystore.dev/main/objects.inv
             - https://redis-py.readthedocs.io/en/stable/objects.inv
-            - https://kafka-python.readthedocs.io/en/master/objects.inv
+            - https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/objects.inv
             - https://distributed.dask.org/en/latest/objects.inv
           options:
             annotations_path: brief

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ endpoints = [
 extensions = [
     "proxystore-ex",
 ]
-kafka = ["kafka-python>=2.0.2"]
+kafka = ["confluent-kafka"]
 redis = ["redis>=3.4"]
 zmq = ["pyzmq"]
 dev = [

--- a/testing/scripts/kafka_pubsub.py
+++ b/testing/scripts/kafka_pubsub.py
@@ -19,7 +19,7 @@ import sys
 import time
 from typing import Sequence
 
-import kafka
+import confluent_kafka
 
 from proxystore.stream.shims.kafka import KafkaPublisher
 from proxystore.stream.shims.kafka import KafkaSubscriber
@@ -29,7 +29,7 @@ MESSAGES = [f'message_{i}'.encode() for i in range(10)]
 
 def publish(broker: str, delay: float) -> None:
     """Publish messages to the stream."""
-    producer = kafka.KafkaProducer(bootstrap_servers=[broker])
+    producer = confluent_kafka.Producer({'bootstrap.servers': broker})
     publisher = KafkaPublisher(producer)
 
     for message in MESSAGES:
@@ -43,7 +43,10 @@ def publish(broker: str, delay: float) -> None:
 
 def subscribe(broker: str) -> None:
     """Subscribe to messages from the stream."""
-    consumer = kafka.KafkaConsumer('default', bootstrap_servers=[broker])
+    consumer = confluent_kafka.Consumer(
+        {'bootstrap.servers': broker, 'group.id': 'default'},
+    )
+    consumer.subscribe(['default'])
     subscriber = KafkaSubscriber(consumer)
 
     print('Listening for messages...')

--- a/tests/stream/shims/kafka_test.py
+++ b/tests/stream/shims/kafka_test.py
@@ -1,30 +1,10 @@
 from __future__ import annotations
 
-import sys
-
-import pytest
-
-try:
-    import kafka
-
-    from proxystore.stream.shims.kafka import KafkaPublisher
-    from proxystore.stream.shims.kafka import KafkaSubscriber
-    from testing.mocked.kafka import make_producer_consumer_pair
-
-    kafka_available = True
-except ImportError:  # pragma: no cover
-    kafka_available = False
-
-if kafka_available:  # pragma: no branch
-    kafka_version = tuple(kafka.__version__.split('.'))
-
-skip_py312 = not kafka_available or (
-    sys.version_info >= (3, 12) and kafka_version <= (2, 0, 2)
-)
-skip_py312_reason = 'kafka-python<=2.0.2 is not compatible with Python 3.12'
+from proxystore.stream.shims.kafka import KafkaPublisher
+from proxystore.stream.shims.kafka import KafkaSubscriber
+from testing.mocked.kafka import make_producer_consumer_pair
 
 
-@pytest.mark.skipif(skip_py312, reason=skip_py312_reason)
 def test_basic_publish_subscribe() -> None:
     producer, consumer = make_producer_consumer_pair('default')
     publisher = KafkaPublisher(producer)

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,7 @@ commands =
     coverage erase
     coverage run -m pytest {posargs}
     coverage combine --quiet
-    py{38,39,310,311}: coverage report
-    # kafka-python 2.0.2 does not work on Python 3.12 so those tests get
-    # skipped and we need to omit the files from coverage
-    py312: coverage report --omit proxystore/stream/shims/kafka.py,tests/stream/shims/kafka_test.py,testing/mocked/kafka.py
+    coverage report
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

As mentioned in 562, `kafka-python` is no longer maintained and while there is a new fork, it is unclear how well that will be maintained either. This switches the Kafka stream shims to `confluent-kafka`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #562 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [x] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated unit tests and validated the shim with `testing/scripts/kafka_pubsub.py`.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
