### PR TITLE
Fix and/or remove `DeprecationWarning` and `ExperimentalWarning`

### DIFF
--- a/proxystore/connectors/multi.py
+++ b/proxystore/connectors/multi.py
@@ -6,7 +6,6 @@ import dataclasses
 import logging
 import re
 import sys
-import warnings
 from types import TracebackType
 from typing import Any
 from typing import Dict
@@ -26,13 +25,6 @@ from proxystore import utils
 from proxystore.connectors.protocols import Connector
 from proxystore.utils.imports import get_object_path
 from proxystore.utils.imports import import_from_path
-from proxystore.warnings import ExperimentalWarning
-
-warnings.warn(
-    'MultiConnector is an experimental feature and may change in the future.',
-    category=ExperimentalWarning,
-    stacklevel=2,
-)
 
 logger = logging.getLogger(__name__)
 KeyT = TypeVar('KeyT', bound=NamedTuple)

--- a/proxystore/p2p/connection.py
+++ b/proxystore/p2p/connection.py
@@ -20,9 +20,6 @@ try:
     from aiortc.contrib.signaling import BYE
     from aiortc.contrib.signaling import object_from_string
     from aiortc.contrib.signaling import object_to_string
-    from cryptography.utils import CryptographyDeprecationWarning
-
-    warnings.simplefilter('ignore', CryptographyDeprecationWarning)
 except ImportError as e:  # pragma: no cover
     warnings.warn(
         f'{e}. To enable endpoint serving, install proxystore with '

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import sys
-import warnings
 from types import TracebackType
 from typing import Any
 from typing import cast
@@ -45,7 +44,6 @@ from proxystore.store.types import StoreConfig
 from proxystore.utils.imports import get_object_path
 from proxystore.utils.imports import import_from_path
 from proxystore.utils.timer import Timer
-from proxystore.warnings import ExperimentalWarning
 
 logger = logging.getLogger(__name__)
 
@@ -344,13 +342,6 @@ class Store(Generic[ConnectorT]):
                 f'the {DeferrableConnector.__name__} necessary to use the '
                 f'{Future.__name__} interface.',
             )
-
-        warnings.warn(
-            'The Store.future() and Future interfaces are experimental '
-            'and may change in future releases.',
-            category=ExperimentalWarning,
-            stacklevel=2,
-        )
 
         with Timer() as connector_timer:
             key = self.connector.new_key()

--- a/proxystore/utils/config.py
+++ b/proxystore/utils/config.py
@@ -8,21 +8,6 @@ from typing import TypeVar
 
 import tomli_w
 from pydantic import BaseModel
-from pydantic import VERSION
-
-if VERSION.startswith('2'):
-    pydantic_v2 = True
-else:  # pragma: no cover
-    pydantic_v2 = False
-
-    import warnings
-
-    warnings.warn(
-        'Pydantic V1 compatibility is deprecated and will be removed in '
-        'the future.',
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
@@ -46,10 +31,7 @@ def dump(
         fp: File-like bytes stream to write to.
         exclude_none: Skip writing none attributes.
     """
-    if pydantic_v2:
-        data_dict = model.model_dump(exclude_none=exclude_none)
-    else:  # pragma: no cover
-        data_dict = model.dict(exclude_none=exclude_none)
+    data_dict = model.model_dump(exclude_none=exclude_none)
     tomli_w.dump(data_dict, fp)
 
 
@@ -63,10 +45,7 @@ def dumps(model: BaseModel, *, exclude_none: bool = True) -> str:
     Returns:
         TOML string of data class.
     """
-    if pydantic_v2:
-        data_dict = model.model_dump(exclude_none=exclude_none)
-    else:  # pragma: no cover
-        data_dict = model.dict(exclude_none=exclude_none)
+    data_dict = model.model_dump(exclude_none=exclude_none)
     return tomli_w.dumps(data_dict)
 
 
@@ -94,7 +73,4 @@ def loads(model: type[BaseModelT], data: str) -> BaseModelT:
         Model initialized from TOML file.
     """
     data = tomllib.loads(data)
-    if pydantic_v2:
-        return model.model_validate(data, strict=True)
-    else:  # pragma: no cover
-        return model.parse_obj(data)
+    return model.model_validate(data, strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ timeout = 30
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "ignore::cryptography.utils.CryptographyDeprecationWarning",
     "ignore::proxystore.warnings.ExperimentalWarning",
     "ignore::DeprecationWarning:proxystore.*",
     "ignore::DeprecationWarning:testing.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ endpoints = [
     "aiosqlite",
     "uvicorn[standard]",
     "psutil",
-    "pydantic",
+    "pydantic>=2",
     "pystun3",
     "python-daemon",
     "quart>=0.18.0",

--- a/testing/relay_server.py
+++ b/testing/relay_server.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import AsyncGenerator
 from typing import NamedTuple
 
-import pytest
 import pytest_asyncio
 import websockets
 from websockets.server import WebSocketServer
@@ -27,7 +26,6 @@ class RelayServerInfo(NamedTuple):
 
 
 @pytest_asyncio.fixture()
-@pytest.mark.asyncio()
 async def relay_server() -> AsyncGenerator[RelayServerInfo, None]:
     """Fixture that runs relay server locally.
 

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -29,8 +29,7 @@ from testing.compat import randbytes
 from testing.utils import open_port
 
 
-@pytest_asyncio.fixture
-@pytest.mark.asyncio()
+@pytest_asyncio.fixture()
 async def quart_app() -> AsyncGenerator[quart.typing.TestAppProtocol, None]:
     async with Endpoint(
         name='my-endpoint',


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

See commit history.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #558

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [x] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

All tests pass. Fewer warnings are raised.

There is still the following warning:
```
  /home/jgpaul/workspace/proxystore/.tox/py311/lib/python3.11/site-packages/google_crc32c/__config__.py:18: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources
```
But this is because `google_crc32c` has not made a PyPI release in two years.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
