### PR TITLE
Populate target objects by default in `Store`

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -100,7 +100,7 @@ class Store(Generic[ConnectorT]):
         deserializer: DeserializerT | None = None,
         cache_size: int = 16,
         metrics: bool = False,
-        populate_target: bool = False,
+        populate_target: bool = True,
         register: bool = False,
     ) -> None:
         if cache_size < 0:

--- a/tests/integration/endpoints_test.py
+++ b/tests/integration/endpoints_test.py
@@ -191,7 +191,10 @@ def _produce_remote(
     ):
         store = Store('store', EndpointConnector(endpoints))
         # Send port to other process to compare
-        proxy: Proxy[Any] = store.proxy(store.connector.endpoint_port)
+        proxy: Proxy[Any] = store.proxy(
+            store.connector.endpoint_port,
+            populate_target=False,
+        )
         queue.put(proxy)
 
 

--- a/tests/store/scopes_test.py
+++ b/tests/store/scopes_test.py
@@ -32,6 +32,7 @@ def store(
         'stream-test-fixture',
         FileConnector(str(tmp_path)),
         cache_size=0,
+        populate_target=False,
     ) as store:
         with store_registration(store):
             yield store

--- a/tests/store/store_metrics_test.py
+++ b/tests/store/store_metrics_test.py
@@ -20,7 +20,12 @@ def store(
     # We use FileConnector here instead of LocalConnector (as in the rest of
     # the tests) because FileConnector operations take *some* amount of time.
     path = str(tmp_path)
-    with Store('test', connector=FileConnector(path), metrics=True) as store:
+    with Store(
+        'test',
+        connector=FileConnector(path),
+        metrics=True,
+        populate_target=False,
+    ) as store:
         with store_registration(store):
             yield store
 

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -99,7 +99,7 @@ def test_factory_serialization_async(store: Store[LocalConnector]) -> None:
 
 
 def test_proxy(store: Store[LocalConnector]) -> None:
-    p = store.proxy([1, 2, 3])
+    p = store.proxy([1, 2, 3], populate_target=False)
     assert not is_resolved(p)
     assert isinstance(p, Proxy)
     assert p == [1, 2, 3]
@@ -148,7 +148,7 @@ def test_proxy_from_key_mutex_options_error(
 
 
 def test_proxy_missing_key(store: Store[LocalConnector]) -> None:
-    proxy = store.proxy([1, 2, 3])
+    proxy = store.proxy([1, 2, 3], populate_target=False)
     key = get_key(proxy)
     store.evict(key)
     assert not store.exists(key)
@@ -184,7 +184,12 @@ def test_proxy_resolve_none_type(store: Store[LocalConnector]) -> None:
 
 
 def test_proxy_recreates_store() -> None:
-    with Store('test', LocalConnector(), cache_size=0) as store:
+    with Store(
+        'test',
+        LocalConnector(),
+        cache_size=0,
+        populate_target=False,
+    ) as store:
         register_store(store)
 
         p: Proxy[list[int]] = store.proxy([1, 2, 3])
@@ -235,7 +240,10 @@ def test_proxy_mutex_options_error(store: Store[LocalConnector]) -> None:
 
 def test_proxy_batch(store: Store[LocalConnector]) -> None:
     values = ['test_value1', 'test_value2', 'test_value3']
-    proxies: list[Proxy[str]] = store.proxy_batch(values)
+    proxies: list[Proxy[str]] = store.proxy_batch(
+        values,
+        populate_target=False,
+    )
     for p, v in zip(proxies, values):
         assert not is_resolved(p)
         assert p == v

--- a/tests/store/utils_test.py
+++ b/tests/store/utils_test.py
@@ -29,7 +29,7 @@ def test_get_key_from_proxy_not_created_by_store() -> None:
 
 
 def test_async_resolve() -> None:
-    with Store('store', LocalConnector()) as store:
+    with Store('store', LocalConnector(), populate_target=False) as store:
         with store_registration(store):
             value = 'value'
             p = store.proxy(value)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Previously, populate_target defaulted to False in the Store. This changes the default to True, meaning that all proxies created by a Store will already be resolved. This will reduce unnecessary resolves of a proxy within the same process that created the proxy.

I consider this a breaking change because any code that assumed a created proxy was not resolved will break. However, this is certainly an edge case (and most likely only prevalent in tests) so I don't expect this to impact most users. If anything, it will remove an unnecessary resolve leading to slightly better performance.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #557

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated tests which expected a certain setting of `populate_target`.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
