### PR TITLE
Clarify `populate_target=True` behavior with custom (de)serializers in `Store.proxy()`

### DIFF
--- a/docs/concepts/store.md
+++ b/docs/concepts/store.md
@@ -88,7 +88,7 @@ read-many. Thus, ProxyStore does not provide `update` semantics on keys.
 
 ## Serialization
 
-All [`Store`][proxystore.store.base.Store] operation uses ProxyStore's provided
+All [`Store`][proxystore.store.base.Store] operations use ProxyStore's provided
 serialization utilities ([`proxystore.serialize`][proxystore.serialize]) by default.
 However, the [`Store`][proxystore.store.base.Store] can be initialized with
 custom default serializers or deserializers of the form:
@@ -98,9 +98,6 @@ serializer = Callable[[Any], bytes]
 deserializer = Callable[[bytes], Any]
 ```
 Most methods also support specifying an alternative serializer or deserializer to the default.
-
-In some cases, data may already be serialized in which case an identity
-function can be passed as the serializer/deserializer (e.g., `#!python lambda x: x`).
 Implementing a custom serializer may be beneficial for complex structures
 where pickle/cloudpickle (the default serializers used by ProxyStore) are
 innefficient. E.g.,
@@ -126,6 +123,12 @@ mymodel = torch.nn.Module()
 store = Store(...)
 key = store.put(mymodel, serializer=serialize_torch_model)
 ```
+
+!!! tip
+
+    In some cases, data may already be serialized in which case an identity function can be passed as the serializer (e.g., `#!python lambda x: x`).
+    However, `populate_target=False` should also be set in this case to avoid prepopulating the proxy with the serialized target object.
+    See the [`Store`][proxystore.store.base.Store] docstring for more information.
 
 Rather than providing a custom serializer or deserializer to each method
 invocation, a default serializer and deserializer can be provided when

--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -55,7 +55,7 @@ _NON_PROXIABLE_TYPES = (bool, type(None))
 
 
 class Store(Generic[ConnectorT]):
-    """Key-value store interface for proxies.
+    r"""Key-value store interface for proxies.
 
     Tip:
         A [`Store`][proxystore.store.base.Store] instance can be used as a
@@ -67,6 +67,38 @@ class Store(Generic[ConnectorT]):
             key = store.put('value')
             store.get(key)
         ```
+
+    Warning:
+        The default value of `populate_target=True` can cause unexpected
+        behavior when providing custom serializer/deserializers because
+        neither the serializer nor deserializer will be applied to the target
+        object being cached in the resulting [`Proxy`][proxystore.proxy.Proxy].
+
+        ```python linenums="1"
+        import pickle
+        from proxystore.store import Store
+        from proxystore.connectors.local import LocalConnector
+
+        with Store('example', LocalConnector(), register=True) as store:
+            data = [1, 2, 3]
+            data_bytes = pickle.dumps(data)
+
+            data_proxy = store.proxy(
+                data_bytes,
+                serializer=lambda s: s,
+                deserializer=pickle.loads,
+                populate_target=True,
+            )
+
+            print(data_proxy)
+            # b'\x80\x04\x95\x0b\x00\x00\x00\x00\x00\x00\x00]\x94(K\x01K\x02K\x03e.'
+        ```
+
+        In this example, the serialized `data_bytes` was populated as the
+        target object in the resulting proxy so the proxy looks like a proxy
+        of bytes rather than the intended list of integers. To fix this, set
+        `populate_target=False` so the custom deserializer is correctly
+        applied to `data_bytes` when the proxy is resolved.
 
     Args:
         name: Name of the store instance.
@@ -89,7 +121,7 @@ class Store(Generic[ConnectorT]):
         ValueError: If `cache_size` is less than zero.
         StoreExistsError: If `register=True` and a store with `name` already
             exists.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -719,10 +751,7 @@ class Store(Generic[ConnectorT]):
                 return a proxy that (1) is already resolved, (2) can be used
                 in [`isinstance`][isinstance] checks without resolving, and (3)
                 is hashable without resolving if `obj` is a hashable type.
-                This is `False` by default because the returned proxy will
-                hold a reference to `obj` which will prevent garbage
-                collecting `obj`. If `None`, defaults to the store-wide
-                setting.
+                If `None`, defaults to the store-wide setting.
             skip_nonproxiable: Return non-proxiable types (e.g., built-in
                 constants like `bool` or `None`) rather than raising a
                 [`NonProxiableTypeError`][proxystore.store.exceptions.NonProxiableTypeError].
@@ -920,10 +949,7 @@ class Store(Generic[ConnectorT]):
                 return a proxy that (1) is already resolved, (2) can be used
                 in [`isinstance`][isinstance] checks without resolving, and (3)
                 is hashable without resolving if `obj` is a hashable type.
-                This is `False` by default because the returned proxy will
-                hold a reference to `obj` which will prevent garbage
-                collecting `obj`. If `None`, defaults to the store-wide
-                setting.
+                If `None`, defaults to the store-wide setting.
             skip_nonproxiable: Return non-proxiable types (e.g., built-in
                 constants like `bool` or `None`) rather than raising a
                 [`NonProxiableTypeError`][proxystore.store.exceptions.NonProxiableTypeError].
@@ -1010,10 +1036,7 @@ class Store(Generic[ConnectorT]):
                 return a proxy that (1) is already resolved, (2) can be used
                 in [`isinstance`][isinstance] checks without resolving, and (3)
                 is hashable without resolving if `obj` is a hashable type.
-                This is `False` by default because the returned proxy will
-                hold a reference to `obj` which will prevent garbage
-                collecting `obj`. If `None`, defaults to the store-wide
-                setting.
+                If `None`, defaults to the store-wide setting.
             skip_nonproxiable: Return non-proxiable types (e.g., built-in
                 constants like `bool` or `None`) rather than raising a
                 [`NonProxiableTypeError`][proxystore.store.exceptions.NonProxiableTypeError].


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Clarify `populate_target=True` behavior with custom (de)serializers in `Store.proxy()`. I noticed this when making this example in another issue: https://github.com/proxystore/proxystore/issues/583#issuecomment-2181419875.

Related to #557 

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [x] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a test case so we can track if behavior changes unexpectedly in the future.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
