### PR TITLE
Improve mypy plugin error messages

### DIFF
--- a/proxystore/utils/config.py
+++ b/proxystore/utils/config.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
 else:  # pragma: <3.11 cover
-    import tomli as tomllib
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
 
 BaseModelT = TypeVar('BaseModelT', bound=BaseModel)
@@ -72,5 +72,5 @@ def loads(model: type[BaseModelT], data: str) -> BaseModelT:
     Returns:
         Model initialized from TOML file.
     """
-    data = tomllib.loads(data)
-    return model.model_validate(data, strict=True)
+    data_dict = tomllib.loads(data)
+    return model.model_validate(data_dict, strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ plugins = [
     "pydantic.mypy",
 ]
 check_untyped_defs = true
+disable_error_code = "import-untyped"
 disallow_any_generics = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true

--- a/tests/mypy_plugin_test.py
+++ b/tests/mypy_plugin_test.py
@@ -146,7 +146,7 @@ def test_union_type_bad_attribute_crash() -> None:
     def foo(x: T | Proxy[T]) -> T | Callable[[], T]:  # pragma: no cover
         # Note: this function should not actually be called! It will error!
         if isinstance(x, Proxy):
-            return x.__factory__  # In #559, mypy crashes on this line
+            return x.__factory__  # In Issue #559, mypy crashes on this line
         else:
             return x
 
@@ -157,7 +157,32 @@ def test_union_type_bad_attribute_crash() -> None:
         pass
 
 
+def test_union_type_partial_attr() -> None:
+    class Foo:
+        x = 0
+
+    class Bar:
+        y = ''
+
+    union: Proxy[Foo] | Bar = Proxy(lambda: Foo())
+
+    try:
+        # Item "Proxy[Foo]" of "Proxy[Foo] | Bar" has no attribute "y"
+        assert isinstance(union.y, str)  # type: ignore[union-attr]
+    except AttributeError:
+        pass
+
+    # Item "Bar" of "Proxy[Foo] | Bar" has no attribute "x"  [union-attr]
+    assert isinstance(union.x, int)  # type: ignore[union-attr]
+
+
 def test_proxy_or_type() -> None:
+    value: ProxyOr[str] = 'hello'
+    assert value.startswith('hello')
+
+    value = Proxy(lambda: 'hello')
+    assert value.startswith('hello')
+
     class TestClass:
         value = 42
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The changes are based on https://www.youtube.com/watch?v=tH3Nul6jDQM which uses `find_member` rather than `analyze_member_access` and `ctx.api.fail` to raise custom error messages.

Previously, attribute lookup errors on a `Proxy[Foo]` would raise an error that did not make it clear the type was a `Proxy`: `"Foo" has no attribute "y"`. Now the error will now look like: `"OwnedProxy[Foo]" has no attribute "y"`.

Error on Union types have also been improved. For example: `Item "Proxy[Foo]" of "Proxy[Foo] | Bar" has no attribute "y"`.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added more unit tests, and validated with the following script.

```python
from dask.distributed import Client
from proxystore.connectors.file import FileConnector
from proxystore.store import Store
from proxystore.proxy import Proxy
from proxystore.store.ref import OwnedProxy

class Foo:
    x: str = 'hello'

    def bar(self) -> int:
        return 42

class Bar:
    y: str = 'hello'


def main() -> None:
    with Store(
        name='dask',
        connector=FileConnector('/tmp/proxystore-cache'),
        populate_target=True,
        register=True,
    ) as store:
        # proxy: Proxy[Foo] | Foo = store.proxy(Foo())
        proxy: Proxy[Foo] = store.proxy(Foo())
        reveal_type(proxy.x)

        # owned_proxy: OwnedProxy[Foo] | Foo = store.owned_proxy(Foo())
        owned_proxy: OwnedProxy[Foo] = store.owned_proxy(Foo())
        reveal_type(owned_proxy.x)

        reveal_type(owned_proxy.bar())

        reveal_type(owned_proxy.y)

        p: Proxy[Foo] | Bar = store.proxy(Foo())
        reveal_type(p.y)


if __name__ == '__main__':
    main()
```

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
