### PR TITLE
Make `StoreConfig` a Pydantic `BaseModel`

### DIFF
--- a/proxystore/store/__init__.py
+++ b/proxystore/store/__init__.py
@@ -14,15 +14,16 @@ from proxystore.connectors.protocols import Connector
 from proxystore.proxy import get_factory
 from proxystore.proxy import Proxy
 from proxystore.store.base import Store
+from proxystore.store.config import StoreConfig
 from proxystore.store.exceptions import ProxyStoreFactoryError
 from proxystore.store.exceptions import StoreExistsError
 from proxystore.store.factory import StoreFactory
 from proxystore.store.types import ConnectorT
-from proxystore.store.types import StoreConfig
 
 __all__ = [
     'Store',
     'StoreFactory',
+    'StoreConfig',
     'get_store',
     'register_store',
     'store_registration',
@@ -90,7 +91,7 @@ def get_or_create_store(
         [`Store`][proxystore.store.base.Store] instance.
     """
     with _stores_lock:
-        store = get_store(store_config['name'])
+        store = get_store(store_config.name)
         if store is None:
             store = Store.from_config(store_config)
             if register:

--- a/proxystore/store/config.py
+++ b/proxystore/store/config.py
@@ -1,0 +1,205 @@
+"""Store configuration model."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+from proxystore.connectors.protocols import Connector
+from proxystore.store.types import DeserializerT
+from proxystore.store.types import SerializerT
+from proxystore.utils.config import dump
+from proxystore.utils.config import load
+from proxystore.utils.imports import import_from_path
+
+_KNOWN_CONNECTORS = {
+    'proxystore.connectors.endpoint.EndpointConnector',
+    'proxystore.connectors.file.FileConnector',
+    'proxystore.connectors.globus.GlobusConnector',
+    'proxystore.connectors.local.LocalConnector',
+    'proxystore.connectors.multi.MultiConnector',
+    'proxystore.connectors.redis.RedisConnector',
+}
+
+
+class ConnectorConfig(BaseModel):
+    """Connector configuration.
+
+    Example:
+        ```python
+        from proxystore.connectors.redis import RedisConnector
+        from proxystore.store.config import ConnectorConfig
+
+        config = ConnectorConfig(
+            kind='redis',
+            options={'hostname': 'localhost', 'port': 1234},
+        )
+
+        connector = config.get_connector()
+        assert isinstance(connector, RedisConnector)
+        ```
+
+    Attributes:
+        kind: Fully-qualified path used to import a
+            [`Connector`][proxystore.connectors.protocols.Connector]
+            type or a shortened name for a builtin
+            [`Connector`][proxystore.connectors.protocols.Connector] type.
+            E.g., `'file'` or `'FileConnector'` are valid shortcuts for
+            `'proxystore.connectors.file.FileConnector'`.
+        options: Dictionary of keyword arguments to pass to the
+            [`Connector`][proxystore.connectors.protocols.Connector]
+            constructor.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+    kind: str
+    options: Dict[str, Any] = Field(default_factory=dict)  # noqa: UP006
+
+    def get_connector_type(self) -> type[Connector[Any]]:
+        """Resolve the class type for the specified connector.
+
+        This method works by first attempting to import the class
+        by treating `kind` as a fully-qualified path. For example,
+        if `kind='proxystore.connectors.local.LocalConnector'`, the
+        [`LocalConnector`][proxystore.connectors.local.LocalConnector] is
+        imported from
+        [`proxystore.connectors.local`][proxystore.connectors.local].
+
+        If the import fails, `kind` will be checked against a list of known
+        (i.e., builtin)
+        [`Connector`][proxystore.connectors.protocols.Connector] types.
+        `kind` will be psuedo-fuzzy matched against the class names of the
+        known [`Connector`][proxystore.connectors.protocols.Connector] types.
+        For example, `kind='local'` and `kind='LocalConnector'` will both
+        match to `'proxystore.connectors.local.LocalConnector'`.
+
+        Returns:
+            [`Connector`][proxystore.connectors.protocols.Connector] type.
+
+        Raises:
+            ValueError: If a
+                [`Connector`][proxystore.connectors.protocols.Connector]
+                named `kind` failed to import or if `kind` does not match
+                a builtin connector.
+        """
+        try:
+            return import_from_path(self.kind)
+        except ImportError as e:
+            for path in _KNOWN_CONNECTORS:
+                _, name = path.rsplit('.', 1)
+                name = name.lower()
+                choices = [name, name.replace('connector', '')]
+                if self.kind.lower() in choices:
+                    return import_from_path(path)
+            raise ValueError(f'Unknown connector type "{self.kind}".') from e
+
+    def get_connector(self) -> Connector[Any]:
+        """Get the connector specified by the configuration.
+
+        Returns:
+            A [`Connector`][proxystore.connectors.protocols.Connector] \
+            instance.
+        """
+        connector_type = self.get_connector_type()
+        return connector_type(**self.options)
+
+
+class StoreConfig(BaseModel):
+    """Store configuration.
+
+    Tip:
+        See the [`Store`][proxystore.store.base.Store] parameters for more
+        information about each configuration option.
+
+    Attributes:
+        name: Store name.
+        connector: Connector configuration.
+        serializer: Optional serializer.
+        deserializer: Optional deserializer.
+        cache_size: Cache size.
+        metrics: Enable recording operation metrics.
+        populate_target: Set the default value for the `populate_target`
+            parameter of proxy methods.
+        auto_register: Auto-register the store.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+    name: str
+    connector: ConnectorConfig
+    serializer: Optional[SerializerT] = Field(None)  # noqa: UP007
+    deserializer: Optional[DeserializerT] = Field(None)  # noqa: UP007
+    cache_size: int = Field(16)
+    metrics: bool = Field(False)
+    populate_target: bool = Field(True)
+    auto_register: bool = Field(False)
+
+    @classmethod
+    def from_toml(cls, filepath: str | pathlib.Path) -> Self:
+        """Create a configuration file from a TOML file.
+
+        Example:
+            See
+            [`write_toml()`][proxystore.store.config.StoreConfig.write_toml].
+
+        Args:
+            filepath: Path to TOML file to load.
+        """
+        with open(filepath, 'rb') as f:
+            return load(cls, f)
+
+    def write_toml(self, filepath: str | pathlib.Path) -> None:
+        """Write a configuration to a TOML file.
+
+        Example:
+            ```python
+            from proxystore.store.config import ConnectorConfig
+            from proxystore.store.config import StoreConfig
+
+            config = StoreConfig(
+                name='example',
+                connector=ConnectorConfig(
+                    kind='file',
+                    options={'store_dir': '/tmp/proxystore-cache'},
+                ),
+            )
+
+            config.write_toml('config.toml')
+            ```
+            The resulting TOML file contains the full configuration,
+            including default options, and can be loaded again
+            using `#!python StoreConfig.from_toml('config.toml')`.
+            ```toml title="config.toml"
+            name = "example"
+            cache_size = 16
+            metrics = false
+            populate_target = true
+            auto_register = false
+
+            [connector]
+            kind = "file"
+
+            [connector.options]
+            store_dir = "/tmp/proxystore-cache"
+            ```
+
+        Args:
+            filepath: Path to TOML file to write.
+        """
+        filepath = pathlib.Path(filepath)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        with open(filepath, 'wb') as f:
+            dump(self, f)

--- a/proxystore/store/executor.py
+++ b/proxystore/store/executor.py
@@ -73,8 +73,8 @@ else:  # pragma: <3.10 cover
 from proxystore.proxy import Proxy
 from proxystore.store import get_store
 from proxystore.store.base import Store
+from proxystore.store.config import StoreConfig
 from proxystore.store.types import ConnectorKeyT
-from proxystore.store.types import StoreConfig
 from proxystore.store.utils import get_key
 
 P = ParamSpec('P')
@@ -109,7 +109,7 @@ class _FunctionWrapper(Generic[P, R]):
             return result
 
     def get_store(self) -> Store[Any]:
-        store = get_store(self.store_config['name'])
+        store = get_store(self.store_config.name)
         if store is None:
             store = Store.from_config(self.store_config)
         return store

--- a/proxystore/store/factory.py
+++ b/proxystore/store/factory.py
@@ -13,11 +13,11 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 
 import proxystore
+from proxystore.store.config import StoreConfig
 from proxystore.store.exceptions import ProxyResolveMissingKeyError
 from proxystore.store.types import ConnectorKeyT
 from proxystore.store.types import ConnectorT
 from proxystore.store.types import DeserializerT
-from proxystore.store.types import StoreConfig
 from proxystore.utils.timer import Timer
 
 if TYPE_CHECKING:

--- a/proxystore/store/types.py
+++ b/proxystore/store/types.py
@@ -2,17 +2,10 @@
 
 from __future__ import annotations
 
-import sys
 from typing import Any
 from typing import Callable
 from typing import Tuple
-from typing import TypedDict
 from typing import TypeVar
-
-if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
-    from typing import NotRequired
-else:  # pragma: <3.11 cover
-    from typing_extensions import NotRequired
 
 from proxystore.connectors.protocols import Connector
 
@@ -24,44 +17,3 @@ SerializerT = Callable[[Any], bytes]
 """Serializer type alias."""
 DeserializerT = Callable[[bytes], Any]
 """Deserializer type alias."""
-
-
-class StoreConfig(TypedDict):
-    """Store configuration dictionary.
-
-    Warning:
-        Configuration dictionaries should not be constructed manually, but
-        instead created via
-        [`Store.config()`][proxystore.store.base.Store.config].
-
-    Tip:
-        See the [`Store`][proxystore.store.base.Store] parameters for more
-        information about each configuration option.
-
-    Attributes:
-        name: Store name.
-        connector_type: Fully qualified path to the
-            [`Connector`][proxystore.connectors.protocols.Connector]
-            implementation.
-        connector_config: Config created by
-            [`Connector.config()`][proxystore.connectors.protocols.Connector.config]
-            used to initialize a new connector instance with
-            [`Connector.from_config()`][proxystore.connectors.protocols.Connector.from_config].
-        serializer: Optional serializer.
-        deserializer: Optional deserializer.
-        cache_size: Cache size.
-        metrics: Enable recording operation metrics.
-        populate_target: Set the default value for the `populate_target`
-            parameter of proxy methods.
-        register: Auto-register the store.
-    """
-
-    name: str
-    connector_type: str
-    connector_config: dict[str, Any]
-    serializer: NotRequired[SerializerT | None]
-    deserializer: NotRequired[DeserializerT | None]
-    cache_size: NotRequired[int]
-    metrics: NotRequired[bool]
-    populate_target: NotRequired[bool]
-    register: NotRequired[bool]

--- a/proxystore/stream/events.py
+++ b/proxystore/stream/events.py
@@ -17,7 +17,7 @@ import json
 from typing import Any
 from typing import Union
 
-from proxystore.store.types import StoreConfig
+from proxystore.store.config import StoreConfig
 from proxystore.utils.imports import get_object_path
 from proxystore.utils.imports import import_from_path
 
@@ -86,7 +86,7 @@ class EventBatch:
         return cls(
             events=events,  # type: ignore[arg-type]
             topic=data['topic'],
-            store_config=data['store_config'],
+            store_config=StoreConfig(**data['store_config']),
         )
 
 
@@ -102,7 +102,7 @@ def event_to_dict(event: Event | EventBatch) -> dict[str, Any]:
         data = {
             'events': [event_to_dict(e) for e in event.events],
             'topic': event.topic,
-            'store_config': event.store_config,
+            'store_config': event.store_config.model_dump(),
         }
     else:
         data = dataclasses.asdict(event)

--- a/proxystore/stream/interface.py
+++ b/proxystore/stream/interface.py
@@ -35,7 +35,7 @@ from proxystore.store import get_store
 from proxystore.store import register_store
 from proxystore.store import unregister_store
 from proxystore.store.base import Store
-from proxystore.store.types import StoreConfig
+from proxystore.store.config import StoreConfig
 from proxystore.stream.events import bytes_to_event
 from proxystore.stream.events import EndOfStreamEvent
 from proxystore.stream.events import Event
@@ -479,7 +479,7 @@ class StreamConsumer(Generic[T]):
             return self._stores[event_info.topic]
 
         with _consumer_get_store_lock:
-            store = get_store(event_info.store_config['name'])
+            store = get_store(event_info.store_config.name)
             if store is None:
                 store = Store.from_config(event_info.store_config)
                 register_store(store)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "cloudpickle>=1.6.0",
     "cryptography>=39.0.1",
     "globus-sdk>=3.3.0",
+    "pydantic>=2",
+    "tomli ; python_version<'3.11'",
+    "tomli-w",
     "typing-extensions>=4.3.0",
 ]
 
@@ -48,18 +51,13 @@ endpoints = [
     "aiosqlite",
     "uvicorn[standard]",
     "psutil",
-    "pydantic>=2",
     "pystun3",
     "python-daemon",
     "quart>=0.18.0",
     "requests>=2.27.1",
-    "tomli ; python_version<'3.11'",
-    "tomli-w",
     "websockets>=10.0",
 ]
-extensions = [
-    "proxystore-ex",
-]
+extensions = ["proxystore-ex"]
 kafka = ["confluent-kafka"]
 redis = ["redis>=3.4"]
 zmq = ["pyzmq"]

--- a/tests/store/config_test.py
+++ b/tests/store/config_test.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from proxystore.connectors.file import FileConnector
+from proxystore.connectors.local import LocalConnector
+from proxystore.store.base import Store
+from proxystore.store.config import ConnectorConfig
+from proxystore.store.config import StoreConfig
+
+
+@pytest.mark.parametrize(
+    ('kind', 'expected'),
+    (
+        ('local', LocalConnector),
+        ('LOCAL', LocalConnector),
+        ('LocalConnector', LocalConnector),
+        ('proxystore.connectors.local.LocalConnector', LocalConnector),
+    ),
+)
+def test_get_connector_type(kind: str, expected: type) -> None:
+    config = ConnectorConfig(kind=kind)
+    assert config.get_connector_type() == expected
+
+
+def test_local_connector_config() -> None:
+    config = ConnectorConfig(kind='local')
+
+    connector = config.get_connector()
+    assert isinstance(connector, LocalConnector)
+    connector.close()
+
+
+def test_file_connector_config(tmp_path: pathlib.Path) -> None:
+    config = ConnectorConfig(kind='file', options={'store_dir': str(tmp_path)})
+
+    connector = config.get_connector()
+    assert isinstance(connector, FileConnector)
+    connector.close()
+
+
+def test_connector_config_bad_kind() -> None:
+    config = ConnectorConfig(kind='fake')
+
+    with pytest.raises(ValueError, match='fake'):
+        config.get_connector()
+
+
+def test_connector_config_bad_extras() -> None:
+    config = ConnectorConfig(kind='local', options={'wrong_arg': True})
+    assert config.options['wrong_arg']
+
+    with pytest.raises(TypeError, match='wrong_arg'):
+        config.get_connector()
+
+
+def test_to_from_config() -> None:
+    original = Store('test-to-from-config', LocalConnector(), register=False)
+    original_config = original.config()
+
+    new = Store.from_config(original_config)
+    assert new.name == original.name
+
+    original.close()
+    new.close()
+
+
+def test_store_config_from_toml(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / 'config.toml'
+    store_dir = tmp_path / 'cache'
+
+    with open(config_file, 'w') as f:
+        f.write(f"""\
+name = "test"
+cache_size = 0
+metrics = true
+populate_target = false
+
+[connector]
+kind = "file"
+options = {{ store_dir = "{store_dir}" }}
+""")
+
+    config = StoreConfig.from_toml(config_file)
+    assert config.name == 'test'
+    assert config.cache_size == 0
+    assert config.metrics
+    assert not config.populate_target
+
+    assert config.connector.kind == 'file'
+    assert config.connector.options['store_dir'] == str(store_dir)
+
+
+def test_store_config_write_toml(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / 'config.toml'
+    store_dir = tmp_path / 'cache'
+
+    config = StoreConfig(
+        name='test',
+        connector=ConnectorConfig(
+            kind='file',
+            options={'store_dir': str(store_dir)},
+        ),
+        cache_size=0,
+        metrics=True,
+        populate_target=False,
+    )
+
+    config.write_toml(config_file)
+    assert config_file.is_file()
+
+    new_config = StoreConfig.from_toml(config_file)
+    assert config == new_config

--- a/tests/store/metrics_test.py
+++ b/tests/store/metrics_test.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from typing import Any
 
 from proxystore.proxy import Proxy
+from proxystore.store.config import ConnectorConfig
+from proxystore.store.config import StoreConfig
 from proxystore.store.factory import StoreFactory
 from proxystore.store.metrics import Metrics
 from proxystore.store.metrics import StoreMetrics
 from proxystore.store.metrics import TimeStats
-from proxystore.store.types import StoreConfig
 
 
 def test_time_stats() -> None:
@@ -91,11 +92,7 @@ def test_metrics_by_proxy() -> None:
     proxy: Proxy[Any] = Proxy(
         StoreFactory(
             key,
-            StoreConfig(
-                name='test',
-                connector_type='test',
-                connector_config={},
-            ),
+            StoreConfig(name='test', connector=ConnectorConfig(kind='test')),
         ),
     )
 
@@ -113,8 +110,7 @@ def test_metrics_by_proxies() -> None:
                 key,
                 StoreConfig(
                     name='test',
-                    connector_type='test',
-                    connector_config={},
+                    connector=ConnectorConfig(kind='test'),
                 ),
             ),
         )

--- a/tests/stream/events_test.py
+++ b/tests/stream/events_test.py
@@ -4,7 +4,8 @@ from typing import NamedTuple
 
 import pytest
 
-from proxystore.store.types import StoreConfig
+from proxystore.store.config import ConnectorConfig
+from proxystore.store.config import StoreConfig
 from proxystore.stream.events import bytes_to_event
 from proxystore.stream.events import EndOfStreamEvent
 from proxystore.stream.events import Event
@@ -31,8 +32,7 @@ class _TestKey(NamedTuple):
             topic='default',
             store_config=StoreConfig(
                 name='test',
-                connector_type='test',
-                connector_config={},
+                connector=ConnectorConfig(kind='test'),
             ),
         ),
         NewObjectEvent.from_key(_TestKey('a', 123), True, {}),


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Make `StoreConfig` a Pydantic `BaseModel`. The `StoreConfig` now has `write_toml` and `from_toml` methods for saving and reusing `Store` configurations.

This should not be a breaking change because `StoreConfig` previously stated that it should not be instantiated directly, only via `Store.config()`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #584 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
