### PR TITLE
Refactor serialization logic

### DIFF
--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -43,7 +43,7 @@ def test_cloudpickle_dumps_error() -> None:
     with mock.patch('cloudpickle.dumps', side_effect=Exception()):
         with pytest.raises(
             SerializationError,
-            match="Object of type <class 'function'> is not serializable.",
+            match="Object of type <class 'function'> is not supported.",
         ):
             serialize(lambda x: x + x)  # pragma: no cover
 
@@ -53,7 +53,7 @@ def test_pickle_loads_error() -> None:
     with mock.patch('pickle.loads', side_effect=Exception()):
         with pytest.raises(
             SerializationError,
-            match='Failed to deserialize object with pickle.',
+            match="Failed to deserialize object with identifier b'03'.",
         ):
             deserialize(v)
 
@@ -63,6 +63,6 @@ def test_cloudpickle_loads_error() -> None:
     with mock.patch('cloudpickle.loads', side_effect=Exception()):
         with pytest.raises(
             SerializationError,
-            match='Failed to deserialize object with cloudpickle.',
+            match="Failed to deserialize object with identifier b'04'.",
         ):
             deserialize(v)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Refactored serialization logic to support better integration of alternate serializers for specific types. Introduced a new _Serializer protocol and private serializers for bytes, strings, pickle, and cloudpickle.

- Added _BytesSerializer
- Added _StrSerializer
- Added _PickleSerializer
- Added _CloudPickleSerializer
- Updated tests to match new structure

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Partially addresses #591

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [x] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
