### PR TITLE
Exclude state by default in `LocalConnector` config

### DIFF
--- a/proxystore/connectors/local.py
+++ b/proxystore/connectors/local.py
@@ -37,15 +37,21 @@ class LocalConnector:
     Args:
         store_dict: Dictionary to store data in. If not specified,
             a new empty dict will be generated.
+        include_data_in_config: Include the data in the connector in the
+            connector's state. This is very innefficient and only useful for
+            testing.
     """
 
     def __init__(
         self,
         store_dict: dict[LocalKey, bytes] | None = None,
+        *,
+        include_data_in_config: bool = False,
     ) -> None:
-        self._store: dict[LocalKey, bytes] = {}
-        if store_dict is not None:
-            self._store = store_dict
+        self._store: dict[LocalKey, bytes] = (
+            {} if store_dict is None else store_dict
+        )
+        self._include_data_in_config = include_data_in_config
 
     def __enter__(self) -> Self:
         return self
@@ -71,7 +77,12 @@ class LocalConnector:
         The configuration contains all the information needed to reconstruct
         the connector object.
         """
-        return {'store_dict': self._store}
+        config: dict[str, Any] = {
+            'include_data_in_config': self._include_data_in_config,
+        }
+        if self._include_data_in_config:
+            config['store_dict'] = self._store
+        return config
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> LocalConnector:

--- a/tests/connectors/multi_test.py
+++ b/tests/connectors/multi_test.py
@@ -24,8 +24,8 @@ def multi_connector_from_policies(
     None,
     None,
 ]:
-    connector1 = LocalConnector()
-    connector2 = LocalConnector()
+    connector1 = LocalConnector(include_data_in_config=True)
+    connector2 = LocalConnector(include_data_in_config=True)
 
     connectors: dict[str, tuple[Connector[Any], Policy]] = {
         'c1': (connector1, p1),

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -47,7 +47,7 @@ def test_factory_evicts_on_resolve(store: Store[LocalConnector]) -> None:
 
 
 def test_factory_recreates_store() -> None:
-    with Store('test', LocalConnector()) as store:
+    with Store('test', LocalConnector(include_data_in_config=True)) as store:
         key = store.put([1, 2, 3])
         f: StoreFactory[Any, list[int]] = StoreFactory(
             key,
@@ -187,7 +187,7 @@ def test_proxy_resolve_none_type(store: Store[LocalConnector]) -> None:
 def test_proxy_recreates_store() -> None:
     with Store(
         'test',
-        LocalConnector(),
+        LocalConnector(include_data_in_config=True),
         cache_size=0,
         populate_target=False,
     ) as store:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

@KlaudiuszRydzy found that some proxies were very large when serialized which ended up being specific to the `LocalConnector` storing it's data dict in the connector config.

This causes proxies to unexpectedly contain all the data in the connector because the proxy stores the connector config. This was useful for some specific tests, so that feature is now available under a flag.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested serializing a proxy from a `LocalConnector` is small again.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
