### PR TITLE
Fix deadlock in `StoreExecutor` test with MacOS runners

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -170,7 +170,7 @@ class Store(Generic[ConnectorT]):
                     pass
                 raise
 
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         logger.info(f'Initialized {self}')
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

The `tests/store/executor_test.py::test_default_behaviour[ThreadPoolExecutor]` test would sometimes deadlock in the MacOS GitHub actions runners. This started after adding the lock to `Store` and `LRUCache` methods, so I suspect it is a deadlock there related to the slower runners with fewer cores.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

TODO

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
