### PR TITLE
Fix docstring link for websockets>=13.0

### DIFF
--- a/proxystore/p2p/relay/client.py
+++ b/proxystore/p2p/relay/client.py
@@ -85,8 +85,8 @@ class RelayClient:
             Otherwise, reconnections will only be attempted when sending or
             receiving a message.
         ssl_context: Custom SSL context to pass to
-            [`websockets.connect()`][websockets.client.connect]. A TLS context
-            is created with
+            [`websockets.connect()`][websockets.legacy.client.connect]. A TLS
+            context is created with
             [`ssl.create_default_context()`][ssl.create_default_context]
             when connecting to a `wss://` URI and `ssl_context` is not
             provided.


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Websockets 13.0 introduces a new asyncio implementation so the docstring path for `connect()` has changed. For the time being we are still using the legacy implementation, but we may want to reevaluate this later.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [x] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
