### PR TITLE
Improve which relay registration errors are raised versus retried

### DIFF
--- a/proxystore/p2p/relay/client.py
+++ b/proxystore/p2p/relay/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import socket
 import ssl
 import sys
 import uuid
@@ -301,9 +302,12 @@ class RelayClient:
                         )
                         self._reconnect_task.set_name('relay-client-reconnect')
                 except (
-                    # Exceptions that we should wait and retry again for
+                    # May occur if relay is unavailable
                     ConnectionRefusedError,
+                    # May occur if relay is too slow to respond
                     asyncio.TimeoutError,
+                    # May occur if client experiences temporary DNS failure
+                    socket.gaierror,
                     websockets.exceptions.ConnectionClosed,
                 ) as e:
                     if not retry:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Authentication errors (unauthorized/forbidden) are now raised since they are mostly unrecoverable from and require user intervention. Address failures (`socket.gaierror`) are caught and retried.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #619

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update test cases.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
