### PR TITLE
Add warning to `Store` docstring about serialization

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -107,6 +107,17 @@ class Store(Generic[ConnectorT]):
         This class is generally thread-safe, with cache access and connector
         operations guarded by a lock that is local to each store instance.
 
+    Warning:
+        This class cannot be pickled. If you need to recreate a
+        [`Store`][proxystore.store.base.Store] within another process, share
+        a [`StoreConfig`][proxystore.store.config.StoreConfig], a serializable
+        and pickle-compatbile type, that can be created using
+        [`Store.config()`][proxystore.store.base.Store.config].
+
+        To reconstruct the instance from the config, use
+        [`Store.from_config()`][proxystore.store.base.Store.from_config] or
+        [`get_or_create_store()`][proxystore.store.get_or_create_store].
+
     Args:
         name: Name of the store instance.
         connector: Connector instance to use for object storage.


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Add warning to `Store` docstring about serialization. v0.7.1 made the `Store` explicitly non-pickleable because of the locks. My preference right now is to keep it this way since we provide the `StoreConfig` and registration tools for recreating a `Store` in another process. Inadvertently pickling the `Store` could result in users not being aware that they are not reusing the same instance within a process.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [x] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
