### PR TITLE
Skip `data_access` scopes on HA Globus Collections and add CLI option for session required domains

### DIFF
--- a/proxystore/connectors/globus.py
+++ b/proxystore/connectors/globus.py
@@ -702,7 +702,6 @@ def _submit_transfer_action(
         else:
             raise AssertionError('Unreachable.')
     except globus_sdk.TransferAPIError as e:  # pragma: no cover
-        # https://github.com/globus/globus-sdk-python/blob/054a29167c86f66b77bb99beca45ce317b02a5a7/src/globus_sdk/exc/err_info.py#L93  # noqa: E501
         raise Exception(
             f'Failure initiating Globus Transfer. Error info: {e.info}',
         ) from e

--- a/proxystore/globus/client.py
+++ b/proxystore/globus/client.py
@@ -9,8 +9,9 @@ from globus_sdk.globus_app import GlobusApp
 
 from proxystore.globus.app import _APP_NAME
 from proxystore.globus.app import get_client_credentials_from_env
-from proxystore.globus.app import get_user_app
+from proxystore.globus.app import get_globus_app
 from proxystore.globus.app import PROXYSTORE_GLOBUS_CLIENT_ID
+from proxystore.globus.scopes import uses_data_access
 
 
 def get_confidential_app_auth_client(
@@ -91,9 +92,14 @@ def get_transfer_client(
         Transfer client.
     """
     if globus_app is None:
-        globus_app = get_user_app()
+        globus_app = get_globus_app()
 
     client = globus_sdk.TransferClient(app=globus_app)
-    client.add_app_data_access_scope(collections)
+    data_access_collections = [
+        collection
+        for collection in collections
+        if uses_data_access(client, collection)
+    ]
+    client.add_app_data_access_scope(data_access_collections)
 
     return client

--- a/testing/mocked/globus.py
+++ b/testing/mocked/globus.py
@@ -52,6 +52,9 @@ class MockTransferClient:
     def __init__(self, *args, **kwargs):
         pass
 
+    def get_endpoint(self, *args, **kwargs) -> Any:  # pragma: no cover
+        pass
+
     def get_task(self, task_id: str) -> Any:
         """Get task."""
         assert isinstance(task_id, str)

--- a/tests/globus/scopes_test.py
+++ b/tests/globus/scopes_test.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import uuid
+from typing import Any
+from unittest import mock
+
+import pytest
 from globus_sdk.scopes import AuthScopes
 from globus_sdk.scopes import TransferScopes
 
@@ -8,6 +13,8 @@ from proxystore.globus.scopes import get_auth_scopes_by_resource_server
 from proxystore.globus.scopes import get_relay_scopes_by_resource_server
 from proxystore.globus.scopes import get_transfer_scopes_by_resource_server
 from proxystore.globus.scopes import ProxyStoreRelayScopes
+from proxystore.globus.scopes import uses_data_access
+from testing.mocked.globus import MockTransferClient
 
 
 def test_get_all_scopes_by_resource_server() -> None:
@@ -20,7 +27,11 @@ def test_get_all_scopes_by_resource_server() -> None:
 def test_get_auth_scopes_by_resource_server() -> None:
     scopes = get_auth_scopes_by_resource_server()
     expected = {
-        AuthScopes.resource_server: [AuthScopes.openid, AuthScopes.email],
+        AuthScopes.resource_server: [
+            AuthScopes.openid,
+            AuthScopes.email,
+            AuthScopes.view_identity_set,
+        ],
     }
     assert scopes == expected
 
@@ -55,3 +66,27 @@ def test_get_transfer_scopes_by_resource_server_with_collections() -> None:
         ],
     }
     assert scopes == expected
+
+
+@pytest.mark.parametrize(
+    ('data', 'expected'),
+    (
+        ({'entity_type': 'GCSv4'}, False),
+        (
+            {'entity_type': 'GCSv5_mapped_collection', 'high_assurance': True},
+            False,
+        ),
+        (
+            {
+                'entity_type': 'GCSv5_mapped_collection',
+                'high_assurance': False,
+            },
+            True,
+        ),
+    ),
+)
+def test_use_data_access(data: dict[str, Any], expected: bool) -> None:
+    client = MockTransferClient()
+    with mock.patch.object(client, 'get_endpoint', return_value=data):
+        result = uses_data_access(client, str(uuid.uuid4()))  # type: ignore[arg-type]
+        assert result == expected


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

This fixes an issue collaborators had using ProxyStore's `GlobusConnector` at OLCF which uses high assurance collections which do not have `data_access` scopes. This would produce an "Unknown scopes" error when following the link to perform the Globus auth token exchange.

The `get_transfer_client()` method now checks the type of the collection before adding `data_access` scopes and the CLI help message has been updated to instruct users not to include HA collections.

This wasn't quite enough to fix the OLCF use case though. It turns out the session tokens also need to require an associated identity from a specific domain. The CLI has been updated to provide require domains that get passed along to the scope creation.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #679 

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added unit tests and tested using a Globus HA test collection.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
