### PR TITLE
Support static endpoint host types and revert default to IP

### DIFF
--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -110,40 +110,45 @@ A typical configuration looks like the following.
 name = "my-endpoint"  # (1)!
 uuid = "d27cf8cb-45fa-46b0-b907-27c830da62e3"  # (2)!
 port = 8765  # (3)!
+host_type = "ip"  # (4)!
 
 [relay]
-address = "wss://relay.proxystore.dev"  # (4)!
-peer_channels = 1  # (5)!
-verify_certificate = true  # (6)!
+address = "wss://relay.proxystore.dev"  # (5)!
+peer_channels = 1  # (6)!
+verify_certificate = true  # (7)!
 
 [relay.auth]
-method = "globus"  # (7)!
+method = "globus"  # (8)!
 
-[relay.auth.kwargs]  # (8)!
+[relay.auth.kwargs]  # (9)!
 
 [storage]
-database_path = "~/.local/share/proxystore/my-endpoint/blobs.db"  # (9)!
-max_object_size = 10000000  # (10)!
+database_path = "~/.local/share/proxystore/my-endpoint/blobs.db"  # (10)!
+max_object_size = 10000000  # (11)!
 ```
 
 1. Human-readable name of this endpoint. Only used for logging and CLI
    operations.
 2. Unique identifier of this endpoint.
 3. Change the default port if running multiple endpoints on the same system.
-4. Comment out the relay address if you want to start the endpoint in SOLO
+4. When the `host_type` is "ip" or "fqdn", the host of the endpoint will be
+   determined at runtime and set as the IP address or fully-qualified domain
+   name, respectively. If `host_type` is "static", a static address can
+   be specified in a `host` field (e.g., `host = "localhost"`).
+5. Comment out the relay address if you want to start the endpoint in SOLO
    mode. Peering will not be available, but all other functionality will
    remain.
-5. Number of channels to multiplex peer communications over. Increasing this
+6. Number of channels to multiplex peer communications over. Increasing this
    to two or four may improve performance on certain networks.
-6. Only disable this when connecting to a local relay server using self-signed
+7. Only disable this when connecting to a local relay server using self-signed
    certificates for testing and development purposes.
-7. Authentication method to use with the relay server. Comment this out when
+8. Authentication method to use with the relay server. Comment this out when
    using a local relay server without authentication.
-8. Optional keyword arguments to use when creating the authorization headers.
+9. Optional keyword arguments to use when creating the authorization headers.
    Typically only used for testing and development purposes.
-9. Optional path to a SQLite database for persisting endpoint objects. See
-   the tip below for more details.
-10. Maximum object size. Comment out to disable object size limits.
+10. Optional path to a SQLite database for persisting endpoint objects. See
+    the tip below for more details.
+11. Maximum object size. Comment out to disable object size limits.
 
 !!! tip
 
@@ -163,6 +168,20 @@ port.
 ```bash
 $ proxystore-endpoint start my-endpoint
 ```
+
+!!! note
+
+    By default, the `host` address that an endpoint is served on is set to
+    the IP address of the node where the endpoint is started (so that an
+    endpoint can be configured and started on different nodes).
+    IP addresses can be incompatible with certain HTTP proxies, causing
+    clients to be unable to connect to their local endpoint (such as at ALCF).
+    Changing the `host_type` in the configuration from "ip" to "fqdn" will
+    use the fully-qualified domain name instead. Alternatively,
+    `host_type = "static"` will use a static host address specified in the
+    `host` field (i.e. `host = "12.34.56.78"`). The `--host` flag can also
+    be used during configuration to specify "ip" (default), "fqdn", or a
+    static host.
 
 ## EndpointConnector
 

--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -116,6 +116,12 @@ def check_nat_command(host: str, port: int) -> None:
 @cli.command()
 @click.argument('name', metavar='NAME', required=True)
 @click.option(
+    '--host',
+    default='ip',
+    type=str,
+    help='Set endpoint host using the "ip", "fqdn", or a static address.',
+)
+@click.option(
     '--port',
     default=None,
     type=int,
@@ -153,31 +159,26 @@ def check_nat_command(host: str, port: int) -> None:
     metavar='BOOL',
     help='Optionally persist data to a database.',
 )
-@click.option(
-    '--use-fqdn/--use-ip',
-    default=True,
-    help='Use the FQDN or IP address of the endpoint for client connections.',
-)
 def configure(
     name: str,
+    host: str,
     port: int | None,
     relay_address: str,
     relay_auth: bool,
     relay_server: bool,
     peer_channels: int,
     persist: bool,
-    use_fqdn: bool,
 ) -> None:
     """Configure a new endpoint."""
     raise SystemExit(
         configure_endpoint(
             name,
-            port=port,
-            relay_server=relay_address if relay_server else None,
-            relay_auth=relay_auth,
+            host=host,
             peer_channels=peer_channels,
             persist_data=persist,
-            use_fqdn=use_fqdn,
+            port=port,
+            relay_auth=relay_auth,
+            relay_server=relay_address if relay_server else None,
         ),
     )
 

--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -127,7 +127,7 @@ class EndpointConfig(BaseModel):
     uuid: str
     port: int
     host: Optional[str] = None  # noqa: UP007
-    host_type: Literal['fqdn', 'ip'] = 'fqdn'
+    host_type: Literal['fqdn', 'ip', 'static'] = 'ip'
     relay: EndpointRelayConfig = Field(
         default_factory=EndpointRelayConfig,
     )


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

A prior PR changed the default to fqdn, which resulted in a few users having to revert back to IP host name resolution. This reverts the default back to IP for broader compatibility.

I also added a "static" host type so users can force their endpoint host to be at a certain address, rather than trying to infer the correct host from the IP address or fqdn.

See #672 for the PR that added and changed the default to fqdn.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested locally and added some new unit tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
