### PR TITLE
Check correct CLI exit codes in newer click versions

### DIFF
--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import os
 import pathlib
@@ -18,6 +19,10 @@ from proxystore.endpoint.config import read_config
 from proxystore.endpoint.config import write_config
 from proxystore.p2p.nat import NatType
 from proxystore.p2p.nat import Result
+
+CLICK_VERSION = tuple(
+    int(x) for x in importlib.metadata.version('click').split('.')
+)
 
 
 @pytest.fixture
@@ -38,7 +43,9 @@ def home_dir(tmp_path: pathlib.Path) -> Generator[str, None, None]:
 def test_no_command() -> None:
     runner = click.testing.CliRunner()
     result = runner.invoke(cli)
-    assert result.exit_code == 0
+    # https://github.com/pallets/click/pull/1489
+    expected = 2 if CLICK_VERSION >= (8, 2, 0) else 0
+    assert result.exit_code == expected
     assert result.output.startswith('Usage:')
 
 

--- a/tests/globus/cli_test.py
+++ b/tests/globus/cli_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import uuid
 from unittest import mock
 
@@ -13,11 +14,17 @@ from proxystore.globus.cli import login
 from proxystore.globus.cli import logout
 from testing.mocked.globus import get_testing_app
 
+CLICK_VERSION = tuple(
+    int(x) for x in importlib.metadata.version('click').split('.')
+)
+
 
 def test_cli() -> None:
     runner = click.testing.CliRunner()
     result = runner.invoke(cli)
-    assert result.exit_code == 0
+    # https://github.com/pallets/click/pull/1489
+    expected = 2 if CLICK_VERSION >= (8, 2, 0) else 0
+    assert result.exit_code == expected
 
 
 @mock.patch('proxystore.globus.cli.get_user_app')


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Click v8.2.0 changed the return code of the "help" output when no args are passed to be 2 rather than 0. We now check the error code based on the version of Click.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [x] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tests pass.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
