### PR TITLE
Improve clarity of proxy resolve errors

### DIFF
--- a/proxystore/store/exceptions.py
+++ b/proxystore/store/exceptions.py
@@ -46,9 +46,11 @@ class ProxyResolveMissingKeyError(Exception):
         self.store_type = store_type
         self.store_name = store_name
         super().__init__(
-            f"Proxy cannot resolve target object with key='{self.key}' "
-            f"from {self.store_type.__name__}(name='{self.store_name}'): "
-            'store returned NoneType with key.',
+            f"Cannot resolve target object with key='{self.key}' "
+            f"from {self.store_type.__name__}(name='{self.store_name}') "
+            'because there is no object associated with the key. This can '
+            'often occur when the target object is evicted from the store '
+            'while proxies of the target still exist.',
         )
 
 

--- a/tests/store/store_proxy_test.py
+++ b/tests/store/store_proxy_test.py
@@ -10,6 +10,7 @@ from proxystore.proxy import get_factory
 from proxystore.proxy import is_resolved
 from proxystore.proxy import Proxy
 from proxystore.proxy import ProxyLocker
+from proxystore.proxy import ProxyResolveError
 from proxystore.proxy import resolve
 from proxystore.serialize import deserialize
 from proxystore.serialize import serialize
@@ -155,12 +156,14 @@ def test_proxy_missing_key(store: Store[LocalConnector]) -> None:
     assert not store.exists(key)
 
     assert isinstance(get_factory(proxy), StoreFactory)
-    with pytest.raises(ProxyResolveMissingKeyError):
+    with pytest.raises(ProxyResolveError) as exc_info:
         resolve(proxy)
+    assert isinstance(exc_info.value.cause, ProxyResolveMissingKeyError)
 
     proxy = store.proxy_from_key(key=key)
-    with pytest.raises(ProxyResolveMissingKeyError):
+    with pytest.raises(ProxyResolveError) as exc_info:
         proxy()
+    assert isinstance(exc_info.value.cause, ProxyResolveMissingKeyError)
 
 
 def test_proxy_bad_serializer(store: Store[LocalConnector]) -> None:


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Previously, errors during the resolve of a proxy looked odd due to the exception handling, resulting in errors starting with this:
```
  File "/Users/jgpaul/workspace/proxystore/venv/lib/python3.13/site-packages/proxystore/proxy/__init__.py", line 283, in __proxy_wrapped__
    return cast(T, object.__getattribute__(self, '__proxy_target__'))
                   ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Proxy' object has no attribute '__proxy_target__'

During handling of the above exception, another exception occurred
....
```

For example, run this:

```python
from proxystore.connectors.local import LocalConnector
from proxystore.store import Store

with Store('proxy-future-example', LocalConnector()) as store:
    key = store.put([1, 2, 3])
    proxy = store.proxy_from_key(key)
    store.evict(key)
    len(proxy)
```

And you get the following error that starts in a very cryptic manner with object attribute errors.
```
Traceback (most recent call last):
  File "/Users/jgpaul/workspace/academy/venv/lib/python3.13/site-packages/proxystore/proxy/__init__.py", line 283, in __proxy_wrapped__
    return cast(T, object.__getattribute__(self, '__proxy_target__'))
                   ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Proxy' object has no attribute '__proxy_target__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jgpaul/workspace/academy/t.py", line 8, in <module>
    len(proxy)
    ~~~^^^^^^^
  File "/Users/jgpaul/workspace/academy/venv/lib/python3.13/site-packages/proxystore/proxy/__init__.py", line 577, in __len__
    return len(self.__proxy_wrapped__)  # type: ignore[arg-type]
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jgpaul/workspace/academy/venv/lib/python3.13/site-packages/proxystore/proxy/__init__.py", line 291, in __proxy_wrapped__
    target = factory()
  File "/Users/jgpaul/workspace/academy/venv/lib/python3.13/site-packages/proxystore/store/factory.py", line 79, in __call__
    obj = self.resolve()
  File "/Users/jgpaul/workspace/academy/venv/lib/python3.13/site-packages/proxystore/store/factory.py", line 119, in resolve
    raise ProxyResolveMissingKeyError(
    ...<3 lines>...
    )
proxystore.store.exceptions.ProxyResolveMissingKeyError: Proxy cannot resolve target object with key='LocalKey(id='89a42e28-b70e-48da-b13a-1025ff28199d')' from Store(name='proxy-future-example'): store returned NoneType with key.
```

Now, the error handling is improved to raise a standardized `ProxyResolveError` which is raised from the underlying exception from the factory.
```
Traceback (most recent call last):
  File "/Users/jgpaul/workspace/proxystore/proxystore/proxy/__init__.py", line 310, in __proxy_wrapped__
    target = factory()
             ^^^^^^^^^
  File "/Users/jgpaul/workspace/proxystore/proxystore/store/factory.py", line 79, in __call__
    obj = self.resolve()
          ^^^^^^^^^^^^^^
  File "/Users/jgpaul/workspace/proxystore/proxystore/store/factory.py", line 119, in resolve
    raise ProxyResolveMissingKeyError(
proxystore.store.exceptions.ProxyResolveMissingKeyError: Cannot resolve target object with key='LocalKey(id='36882d49-9915-46a3-9649-80d52a42f771')' from Store(name='proxy-future-example') because there is no object associated with the key. This can often occur when the target object is evicted from the store while proxies of the target still exist.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jgpaul/workspace/proxystore/t.py", line 8, in <module>
    len(proxy)
  File "/Users/jgpaul/workspace/proxystore/proxystore/proxy/__init__.py", line 604, in __len__
    return len(self.__proxy_wrapped__)  # type: ignore[arg-type]
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jgpaul/workspace/proxystore/proxystore/proxy/__init__.py", line 312, in __proxy_wrapped__
    raise ProxyResolveError(
proxystore.proxy.ProxyResolveError: The factory of this proxy raised an error while resolving the target object. See the full stack trace for the direct cause of this exception.
```

I'm classifying this as a breaking change because the error return types will change for users, but the return type of the resolve errors was never defined anywhere.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [x] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated tests.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
