### PR TITLE
Fix recursion error when using mypy plugin on classes that derive from Proxy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - repo: 'https://github.com/astral-sh/ruff-pre-commit'
     rev: v0.12.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - '--fix'
           - '--exit-non-zero-on-fix'

--- a/proxystore/mypy_plugin.py
+++ b/proxystore/mypy_plugin.py
@@ -133,10 +133,19 @@ def _proxy_attribute_access(
     if not isinstance(instance, Instance):
         return ctx.default_attr_type
 
+    is_proxy_subclass = False
+    if isinstance(ctx.type, Instance):
+        is_proxy_subclass = any(
+            base.fullname in PROXY_TYPES for base in ctx.type.type.mro
+        )
+
     # Instance is not a Proxy type so handle it normally. This case happens
     # when checking the T branch of a type annotated as Proxy[T] | T.
     fullname = instance.type.fullname
-    if not any(fullname.startswith(name) for name in PROXY_TYPES):
+    if not (
+        any(fullname.startswith(name) for name in PROXY_TYPES)
+        or is_proxy_subclass
+    ):
         member = find_member(attr, instance, instance)
         if member is None:
             return ctx.default_attr_type

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import proxystore as ps
 from proxystore.factory import LambdaFactory
 from proxystore.factory import SimpleFactory
+from proxystore.serialize import deserialize
+from proxystore.serialize import serialize
 
 
 def test_simple_factory() -> None:
@@ -12,8 +13,8 @@ def test_simple_factory() -> None:
     assert f() == [1, 2, 3]
 
     # Test pickleable
-    f_pkl = ps.serialize.serialize(f)
-    f = ps.serialize.deserialize(f_pkl)
+    f_pkl = serialize(f)
+    f = deserialize(f_pkl)
     assert f() == [1, 2, 3]
 
 
@@ -24,8 +25,8 @@ def test_lambda_factory() -> None:
     assert f1() == [1, 2, 3]
 
     # Test pickleable
-    f1_pkl = ps.serialize.serialize(f1)
-    f1 = ps.serialize.deserialize(f1_pkl)
+    f1_pkl = serialize(f1)
+    f1 = deserialize(f1_pkl)
     assert f1() == [1, 2, 3]
 
     # Test with function
@@ -33,8 +34,8 @@ def test_lambda_factory() -> None:
         return 'abc'
 
     f2 = LambdaFactory(myfunc)
-    f2_pkl = ps.serialize.serialize(f2)
-    f2 = ps.serialize.deserialize(f2_pkl)
+    f2_pkl = serialize(f2)
+    f2 = deserialize(f2_pkl)
     assert f2() == 'abc'
 
     # Test args/kwargs


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Fix recursion error when using mypy plugin on classes that derive from Proxy.

This error appeared after some changes to `find_member` in mypy 1.17.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

N/A

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested with both mypy 1.16 and 1.17.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
