### PR TITLE
Change Globus user auth to use `sub` field

### DIFF
--- a/proxystore/p2p/relay/authenticate.py
+++ b/proxystore/p2p/relay/authenticate.py
@@ -79,7 +79,7 @@ class GlobusUser:
 
     Attributes:
         username: Identity username.
-        client_id: The Globus Auth issues client id of the client to which
+        sub: The Globus Auth issued identity ID of the client to which
             the introspected token was issued.
         email: Email address associated with the effective identity of the
             introspected token. May be `None` if the user restricts their
@@ -90,14 +90,14 @@ class GlobusUser:
     """
 
     username: str
-    client_id: uuid.UUID
+    sub: uuid.UUID
     email: str | None = None
     display_name: str | None = None
 
     def __eq__(self, other: object) -> bool:
-        """Check equality using only Globus Auth client ID."""
+        """Check equality using only Globus Auth issued identity ID."""
         if isinstance(other, GlobusUser):
-            return self.client_id == other.client_id
+            return self.sub == other.sub
         else:
             return False
 
@@ -175,7 +175,7 @@ class GlobusAuthenticator:
 
         return GlobusUser(
             username=token_meta.get('username'),
-            client_id=uuid.UUID(token_meta.get('client_id')),
+            sub=uuid.UUID(token_meta.get('sub')),
             email=token_meta.get('email', None),
             display_name=token_meta.get('name', None),
         )

--- a/tests/p2p/relay/authenticate_test.py
+++ b/tests/p2p/relay/authenticate_test.py
@@ -27,11 +27,11 @@ def test_null_authenticator() -> None:
 
 
 def test_globus_user_equality() -> None:
-    user1 = GlobusUser('username', uuid.uuid4())
-    user2 = GlobusUser('username', uuid.uuid4())
+    user1 = GlobusUser('user1', uuid.uuid4())
+    user2 = GlobusUser('user2', uuid.uuid4())
     assert user1 != user2
 
-    user2 = GlobusUser('different-username', user1.client_id)
+    user2 = GlobusUser('user1', user1.sub)
     assert user1 == user2
 
     assert user1 != object()
@@ -43,7 +43,7 @@ def test_authenticate_user_with_token() -> None:
     token_meta: dict[str, Any] = {
         'active': True,
         'aud': [authenticator.audience],
-        'sub': authenticator.auth_client.client_id,
+        'sub': str(uuid.uuid4()),
         'username': 'username',
         'client_id': str(uuid.uuid4()),
         'email': 'username@example.com',
@@ -61,7 +61,7 @@ def test_authenticate_user_with_token() -> None:
 
     assert user == GlobusUser(
         username=token_meta['username'],
-        client_id=uuid.UUID(token_meta['client_id']),
+        sub=uuid.UUID(token_meta['sub']),
         email=token_meta['email'],
         display_name=token_meta['name'],
     )


### PR DESCRIPTION
# Description
The globus auth client id is the wrong field to use to validate the user. Instead, we change to use the sub which is unique to each globus identity.


### Fixes
- Fixes #714 

### Type of Change
- [x] Bug (fixes for a bug or issue)
- [x] Security (security related changes)

## Testing
Changed the testing of authenticate to use the username.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
