### PR TITLE
Use macos-latest instead of pinned version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,19 +29,19 @@ jobs:
         - os: ubuntu-latest
           python: '3.14'
           toxenv: py314
-        - os: macos-14
+        - os: macos-latest
           python: '3.10'
           toxenv: py310
-        - os: macos-14
+        - os: macos-latest
           python: '3.11'
           toxenv: py311
-        - os: macos-14
+        - os: macos-latest
           python: '3.12'
           toxenv: py312
-        - os: macos-14
+        - os: macos-latest
           python: '3.13'
           toxenv: py313
-        - os: macos-14
+        - os: macos-latest
           python: '3.14'
           toxenv: py314
     runs-on: ${{ matrix.os }}

--- a/tests/endpoint/commands_test.py
+++ b/tests/endpoint/commands_test.py
@@ -42,7 +42,13 @@ def _patch_hostname() -> Generator[None, None, None]:
     # Related:
     #   - https://apple.stackexchange.com/a/253834
     #   - https://stackoverflow.com/a/43549848
-    with mock.patch('socket.gethostbyname', return_value='localhost'):
+    # socket.getfqdn() is similarly mocked because it performs a reverse
+    # DNS lookup (gethostbyaddr) that can hang on MacOS runners with a
+    # .local hostname. See: https://github.com/actions/setup-python/issues/1223
+    with (
+        mock.patch('socket.gethostbyname', return_value='localhost'),
+        mock.patch('socket.getfqdn', return_value='localhost'),
+    ):
         yield
 
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Use macos-latest instead of pinned version in CI. This was causing CI to fail because the latest release of confluent-kafka only has wheels for MacOS 15, and building from source would fail.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [x] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
