### PR TITLE
Detect NAT mapping behavior instead of RFC 3489 NAT type

### DIFF
--- a/docs/guides/endpoints-debugging.md
+++ b/docs/guides/endpoints-debugging.md
@@ -117,18 +117,21 @@ Peer requests typically fail for two reasons:
 After ensuring both endpoints are running and connected to the relay server,
 you can check the NAT compatibility in two ways.
 
-1. Endpoints will attempt to discover and log the NAT type on startup, so check
-   the logs to see if this could be the reason.
+1. Endpoints will attempt to discover and log the NAT behavior on startup, so
+   check the logs to see if this could be the reason.
    ```
-   INFO  (proxystore.p2p.nat) :: Checking NAT type. This may take a moment...
-   INFO  (proxystore.p2p.nat) :: NAT Type:       Full-cone NAT
+   INFO  (proxystore.p2p.nat) :: Checking NAT behavior. This may take a moment...
+   INFO  (proxystore.p2p.nat) :: NAT Behavior:   Endpoint-independent mapping
    INFO  (proxystore.p2p.nat) :: External IP:    <IP ADDRESS>
    INFO  (proxystore.p2p.nat) :: External Port:  <PORT>
-   INFO  (proxystore.p2p.nat) :: NAT traversal for peer-to-peer methods (e.g., hole-punching) is likely to work. (NAT traversal does not work reliably across symmetric NATs or poorly behaved legacy NATs.)
+   INFO  (proxystore.p2p.nat) :: NAT traversal for peer-to-peer methods (e.g., hole-punching) is likely to work.
    ```
+   A NAT with *address-dependent* mapping assigns a different external address
+   to each peer, so the address one peer learns is not the address it must
+   send to and hole-punching will not work reliably.
 2. Use the
    [`proxystore-endpoint check-nat`](../api/cli.md#proxystore-endpoint-check-nat)
-   command to discover your NAT type.
+   command to discover your NAT behavior.
    ```
    $ proxystore-endpoint check-nat
    INFO: Checking NAT type. This may take a moment...

--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -103,13 +103,13 @@ def version() -> None:
 )
 @click.option(
     '--port',
-    default=54320,
+    default=0,
     type=int,
     metavar='PORT',
-    help='Port to listen on.',
+    help='Port to listen on. Defaults to an ephemeral port.',
 )
 def check_nat_command(host: str, port: int) -> None:
-    """Check the type of NAT you are behind."""
+    """Check the NAT mapping behavior of your network."""
     check_nat_and_log(host, port)
 
 

--- a/proxystore/endpoint/cli.py
+++ b/proxystore/endpoint/cli.py
@@ -6,6 +6,7 @@ See the CLI Reference for the
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import sys
@@ -110,7 +111,7 @@ def version() -> None:
 )
 def check_nat_command(host: str, port: int) -> None:
     """Check the NAT mapping behavior of your network."""
-    check_nat_and_log(host, port)
+    asyncio.run(check_nat_and_log(host, port))
 
 
 @cli.command()

--- a/proxystore/endpoint/endpoint.py
+++ b/proxystore/endpoint/endpoint.py
@@ -158,6 +158,7 @@ class Endpoint:
             asyncio.Future[EndpointRequest],
         ] = {}
         self._peer_handler_task: asyncio.Task[None] | None = None
+        self._closed = False
 
         if self._mode is EndpointMode.SOLO:
             # Initialization is not complete for endpoints in peering mode
@@ -490,7 +491,15 @@ class Endpoint:
             await self._storage.set(key, data)
 
     async def close(self) -> None:
-        """Close the endpoint and any open connections safely."""
+        """Close the endpoint and any open connections safely.
+
+        This is idempotent so that it is safe to call from both the Quart
+        `after_serving` shutdown hook and the
+        [`serve()`][proxystore.endpoint.serve.serve] cleanup path.
+        """
+        if self._closed:
+            return
+        self._closed = True
         if self._peer_handler_task is not None:
             self._peer_handler_task.cancel()
             try:

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -177,6 +177,13 @@ async def _serve_async(config: EndpointConfig) -> None:
             nat_check.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await nat_check
+        # Normally the endpoint is closed by the "after_app_serving" shutdown
+        # callback, but that callback only runs if the server's lifespan
+        # completes. Closing here as well ensures the endpoint's background
+        # tasks (e.g., the relay client's reconnect task) are always torn down
+        # so they cannot raise after serving has stopped. close() is
+        # idempotent so the redundant call in the normal path is a no-op.
+        await endpoint.close()
 
 
 def serve(

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -38,7 +38,7 @@ from proxystore.endpoint.storage import Storage
 from proxystore.globus.app import get_globus_app
 from proxystore.globus.scopes import get_relay_scopes_by_resource_server
 from proxystore.p2p.manager import PeerManager
-from proxystore.p2p.nat import check_nat_and_log_async
+from proxystore.p2p.nat import check_nat_and_log
 from proxystore.p2p.relay.client import RelayClient
 from proxystore.utils.data import chunk_bytes
 
@@ -144,7 +144,7 @@ async def _serve_async(config: EndpointConfig) -> None:
         # The NAT check only produces diagnostic logs so it is run
         # concurrently rather than delaying the endpoint from serving
         # requests on networks where STUN is slow or blocked.
-        nat_check = asyncio.create_task(check_nat_and_log_async())
+        nat_check = asyncio.create_task(check_nat_and_log())
 
     endpoint = await Endpoint(
         name=config.name,

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -37,7 +38,7 @@ from proxystore.endpoint.storage import Storage
 from proxystore.globus.app import get_globus_app
 from proxystore.globus.scopes import get_relay_scopes_by_resource_server
 from proxystore.p2p.manager import PeerManager
-from proxystore.p2p.nat import check_nat_and_log
+from proxystore.p2p.nat import check_nat_and_log_async
 from proxystore.p2p.relay.client import RelayClient
 from proxystore.utils.data import chunk_bytes
 
@@ -123,6 +124,7 @@ async def _serve_async(config: EndpointConfig) -> None:
         storage = DictStorage(max_object_size=config.storage.max_object_size)
 
     peer_manager: PeerManager | None = None
+    nat_check: asyncio.Task[None] | None = None
     if config.relay.address is not None:
         headers = _get_auth_headers(
             method=config.relay.auth.method,
@@ -139,7 +141,10 @@ async def _serve_async(config: EndpointConfig) -> None:
             relay_client,
             peer_channels=config.relay.peer_channels,
         )
-        check_nat_and_log()
+        # The NAT check only produces diagnostic logs so it is run
+        # concurrently rather than delaying the endpoint from serving
+        # requests on networks where STUN is slow or blocked.
+        nat_check = asyncio.create_task(check_nat_and_log_async())
 
     endpoint = await Endpoint(
         name=config.name,
@@ -165,7 +170,13 @@ async def _serve_async(config: EndpointConfig) -> None:
     )
     logger.info(f'Config: {config}')
 
-    await server.serve()
+    try:
+        await server.serve()
+    finally:
+        if nat_check is not None and not nat_check.done():
+            nat_check.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await nat_check
 
 
 def serve(

--- a/proxystore/p2p/nat.py
+++ b/proxystore/p2p/nat.py
@@ -1,175 +1,418 @@
-"""Tools for getting the NAT type using STUN.
+"""Tools for checking NAT mapping behavior using STUN.
 
-This module is a wrapper around the tools provided by
-[pystun3](https://github.com/talkiq/pystun3){target=_blank}.
+This module implements the mapping behavior discovery procedure of
+[RFC 5780](https://datatracker.ietf.org/doc/html/rfc5780){target=_blank}
+using [RFC 5389](https://datatracker.ietf.org/doc/html/rfc5389){target=_blank}
+binding requests.
+
+The classic NAT taxonomy of RFC 3489 (full-cone, restricted-cone, and so on)
+was deprecated because real NATs do not fall into those categories: mapping
+behavior and filtering behavior are independent. Only mapping behavior affects
+whether NAT traversal works. A NAT which assigns the same external address
+regardless of the destination (endpoint-independent mapping) can be traversed
+by hole-punching, even when it filters unsolicited traffic, because the relay
+server coordinates both peers to send simultaneously. A NAT which assigns a
+different external address per destination (address-dependent mapping,
+historically "symmetric") cannot, because the address a peer learns is not the
+address it must send to.
+
+Determining filtering behavior would require the RFC 3489 CHANGE-REQUEST
+attribute, which needs a STUN server listening on two IP addresses. Such
+servers are increasingly rare, and the answer would not change the advice
+given here, so this module does not use them.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import enum
 import logging
+import secrets
 import socket
+import struct
 from typing import NamedTuple
-
-import stun
 
 logger = logging.getLogger(__name__)
 
-# Selected from the following sources:
-#   https://github.com/pradt2/always-online-stun
-#   https://gist.github.com/mondain/b0ec1cf5f60ae726202e
+# Determining mapping behavior requires binding requests to at least two
+# servers on *different* IP addresses. Servers which resolve to the same
+# address are deduplicated at runtime, so entries here are chosen across
+# distinct operators rather than for redundancy.
 _STUN_SERVERS = (
-    'stun.l.google.com:19302',
-    'stun1.l.google.com:19302',
-    'stun2.l.google.com:19302',
-    'stun3.l.google.com:19302',
-    'stun4.l.google.com:19302',
-    'stun.ideasip.com:3478',
-    'stun.voiparound.com:3478',
-    'stun.voipstunt.com:3478',
+    ('stun.l.google.com', 19302),
+    ('stun.nextcloud.com', 3478),
+    ('stun.hot-chilli.net', 3478),
+    ('stun.m-online.net', 3478),
+    ('stun.dus.net', 3478),
 )
 
+_MAGIC_COOKIE = 0x2112A442
+_BINDING_REQUEST = 0x0001
+_BINDING_SUCCESS = 0x0101
+_MAPPED_ADDRESS = 0x0001
+_XOR_MAPPED_ADDRESS = 0x0020
+_IPV4_FAMILY = 0x01
+_TRANSACTION_ID_BYTES = 12
+_HEADER_FORMAT = '>HHI12s'
+_HEADER_BYTES = struct.calcsize(_HEADER_FORMAT)
 
-class NatType(enum.Enum):
-    """NAT type.
+# Delay after each round of (re)transmissions. UDP is lossy so unanswered
+# requests are resent, but the total is bounded so that a network which
+# blocks STUN entirely fails quickly rather than hanging.
+_RETRANSMIT_DELAYS = (0.5, 0.5, 1.0)
 
-    Learn more about NAT types at
-    https://en.wikipedia.org/wiki/Network_address_translation.
-    """
+Address = tuple[str, int]
 
-    OpenInternet = 'Open Internet (No NAT)'
-    """Host is not behind a NAT."""
-    FullCone = 'Full-cone NAT'
-    """Host is behind a full-cone NAT."""
-    SymmetricUDPFirewall = 'Symmetric UDP Firewall NAT'
-    """Host is behind a symmetric UDP firewall."""
-    RestrictedCone = 'Restricted-cone NAT'
-    """Host is behind a restricted-cone NAT."""
-    PortRestrictedCone = 'Port Restricted-cone NAT'
-    """Host is behind a port-restricted-cone NAT."""
-    Symmetric = 'Symmetric NAT'
-    """Host is behind a symmetric NAT."""
 
-    @classmethod
-    def _from_str(cls, nat_type: str) -> NatType:
-        if nat_type == stun.Blocked:
-            raise RuntimeError(
-                'No response from a STUN server. '
-                'Unable to determine NAT type.',
-            )
-        elif nat_type == stun.ChangedAddressError:
-            raise RuntimeError('Address changed during NAT type check.')
+class NatMapping(enum.Enum):
+    """How a NAT assigns external addresses to outbound flows."""
 
-        return {
-            stun.OpenInternet: cls.OpenInternet,
-            stun.FullCone: cls.FullCone,
-            stun.SymmetricUDPFirewall: cls.SymmetricUDPFirewall,
-            stun.RestricNAT: cls.RestrictedCone,
-            stun.RestricPortNAT: cls.PortRestrictedCone,
-            stun.SymmetricNAT: cls.Symmetric,
-        }[nat_type]
+    NoNat = 'No NAT'
+    """Host is not behind a NAT and is directly reachable."""
+    EndpointIndependent = 'Endpoint-independent mapping'
+    """Host is behind a NAT which reuses one external address for all peers."""
+    AddressDependent = 'Address-dependent mapping'
+    """Host is behind a NAT which uses a different address for each peer."""
 
 
 class Result(NamedTuple):
-    """Result of NAT type check.
+    """Result of a NAT mapping behavior check.
 
     Attributes:
-        nat_type: Enum type of the found NAT this host is behind.
+        mapping: Mapping behavior of the NAT this host is behind.
         external_ip: External IP of this host.
-        external_port: External port of this host.
+        external_port: External port of this host. This is only stable across
+            peers when `mapping` is not
+            [`AddressDependent`][proxystore.p2p.nat.NatMapping].
+        hole_punching_likely: Whether NAT traversal is expected to work.
     """
 
-    nat_type: NatType
+    mapping: NatMapping
     external_ip: str
     external_port: int
+    hole_punching_likely: bool
+
+
+def _encode_request(transaction_id: bytes) -> bytes:
+    """Encode a STUN binding request with an empty body."""
+    return struct.pack(
+        _HEADER_FORMAT,
+        _BINDING_REQUEST,
+        0,
+        _MAGIC_COOKIE,
+        transaction_id,
+    )
+
+
+def _decode_address(attribute_type: int, value: bytes) -> Address | None:
+    """Decode a (XOR-)MAPPED-ADDRESS attribute value, IPv4 only."""
+    if len(value) < 8 or value[1] != _IPV4_FAMILY:
+        return None
+
+    (port,) = struct.unpack('>H', value[2:4])
+    packed_ip = value[4:8]
+
+    if attribute_type == _XOR_MAPPED_ADDRESS:
+        # The address and port are obfuscated with the magic cookie so that
+        # NATs which rewrite payloads do not mangle them (RFC 5389 15.2).
+        port ^= _MAGIC_COOKIE >> 16
+        cookie = struct.pack('>I', _MAGIC_COOKIE)
+        packed_ip = bytes(
+            a ^ b for a, b in zip(packed_ip, cookie, strict=True)
+        )
+
+    return socket.inet_ntoa(packed_ip), port
+
+
+def _decode_response(data: bytes) -> tuple[bytes, Address] | None:
+    """Decode a STUN binding success response.
+
+    Returns:
+        Tuple of the transaction ID and the reflected external address, or
+        `None` if the datagram is not a binding success carrying an IPv4
+        address.
+    """
+    if len(data) < _HEADER_BYTES:
+        return None
+
+    message_type, length, cookie, transaction_id = struct.unpack(
+        _HEADER_FORMAT,
+        data[:_HEADER_BYTES],
+    )
+    if message_type != _BINDING_SUCCESS or cookie != _MAGIC_COOKIE:
+        return None
+
+    body = data[_HEADER_BYTES : _HEADER_BYTES + length]
+    address: Address | None = None
+    offset = 0
+
+    while offset + 4 <= len(body):
+        attribute_type, attribute_length = struct.unpack(
+            '>HH',
+            body[offset : offset + 4],
+        )
+        value = body[offset + 4 : offset + 4 + attribute_length]
+
+        if attribute_type in (_MAPPED_ADDRESS, _XOR_MAPPED_ADDRESS):
+            decoded = _decode_address(attribute_type, value)
+            # XOR-MAPPED-ADDRESS is preferred when a server sends both.
+            if decoded is not None and (
+                address is None or attribute_type == _XOR_MAPPED_ADDRESS
+            ):
+                address = decoded
+
+        # Attribute values are padded to a multiple of four bytes.
+        offset += 4 + attribute_length + (-attribute_length % 4)
+
+    return (transaction_id, address) if address is not None else None
+
+
+class _StunProtocol(asyncio.DatagramProtocol):
+    """Collects binding responses, keyed by transaction ID."""
+
+    def __init__(self, expected: int) -> None:
+        self.expected = expected
+        self.responses: dict[bytes, Address] = {}
+        self.complete = asyncio.Event()
+
+    def datagram_received(self, data: bytes, addr: Address) -> None:
+        decoded = _decode_response(data)
+        if decoded is None:  # pragma: no cover
+            return
+
+        transaction_id, address = decoded
+        self.responses[transaction_id] = address
+        if len(self.responses) >= self.expected:
+            self.complete.set()
+
+
+async def _resolve_servers(
+    servers: tuple[tuple[str, int], ...],
+) -> list[Address]:
+    """Resolve STUN server hostnames, dropping failures and duplicate IPs."""
+    loop = asyncio.get_running_loop()
+    results = await asyncio.gather(
+        *(
+            loop.getaddrinfo(host, port, family=socket.AF_INET)
+            for host, port in servers
+        ),
+        return_exceptions=True,
+    )
+
+    resolved: list[Address] = []
+    seen: set[str] = set()
+
+    for (host, port), result in zip(servers, results, strict=True):
+        if isinstance(result, BaseException) or not result:
+            logger.debug(f'Failed to resolve STUN server {host}:{port}')
+            continue
+
+        ip = str(result[0][4][0])
+        # Servers sharing an IP only provide one measurement point.
+        if ip in seen:
+            logger.debug(f'Skipping {host}:{port} which duplicates {ip}')
+            continue
+
+        seen.add(ip)
+        resolved.append((ip, port))
+
+    return resolved
+
+
+def _local_address(server: Address) -> str:
+    """Get the local address the kernel would use to reach a server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        # Connecting a UDP socket sends nothing but resolves the route.
+        s.connect(server)
+        return s.getsockname()[0]
+
+
+async def check_nat_async(
+    source_ip: str = '0.0.0.0',
+    source_port: int = 0,
+    timeout: float = 2.0,
+) -> Result:
+    """Check the NAT mapping behavior of this host.
+
+    Sends STUN binding requests from a single socket to several servers on
+    different IP addresses. If every server reflects the same external
+    address then the NAT reuses one mapping for all destinations and
+    hole-punching can work. If the addresses differ then the mapping is
+    address-dependent and a relay is required.
+
+    Args:
+        source_ip: Address to bind to.
+        source_port: Port to bind to. The default binds an ephemeral port.
+        timeout: Maximum number of seconds to wait for responses.
+
+    Returns:
+        Result describing the mapping behavior and external address.
+
+    Raises:
+        RuntimeError: if fewer than two STUN servers respond, in which case
+            the mapping behavior cannot be determined.
+    """
+    servers = await _resolve_servers(_STUN_SERVERS)
+    if len(servers) < 2:
+        raise RuntimeError(
+            f'Only {len(servers)} STUN servers could be resolved but at '
+            'least two are needed to determine NAT mapping behavior.',
+        )
+
+    loop = asyncio.get_running_loop()
+    transport, protocol = await loop.create_datagram_endpoint(
+        lambda: _StunProtocol(len(servers)),
+        local_addr=(source_ip, source_port),
+        family=socket.AF_INET,
+    )
+
+    requests = {secrets.token_bytes(_TRANSACTION_ID_BYTES): s for s in servers}
+    deadline = loop.time() + timeout
+
+    try:
+        for delay in _RETRANSMIT_DELAYS:
+            pending = [
+                (transaction_id, server)
+                for transaction_id, server in requests.items()
+                if transaction_id not in protocol.responses
+            ]
+            if not pending:
+                break
+
+            for transaction_id, server in pending:
+                transport.sendto(_encode_request(transaction_id), server)
+
+            remaining = min(delay, deadline - loop.time())
+            if remaining <= 0:
+                break
+
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(protocol.complete.wait(), remaining)
+    finally:
+        transport.close()
+
+    addresses = list(protocol.responses.values())
+    if len(addresses) < 2:
+        raise RuntimeError(
+            f'Only {len(addresses)} of {len(servers)} STUN servers responded '
+            'but at least two are needed to determine NAT mapping behavior. '
+            'Enable debug level logging for more details.',
+        )
+
+    external_ip, external_port = addresses[0]
+
+    if any(address != addresses[0] for address in addresses):
+        mapping = NatMapping.AddressDependent
+    elif external_ip == _local_address(servers[0]):
+        mapping = NatMapping.NoNat
+    else:
+        mapping = NatMapping.EndpointIndependent
+
+    return Result(
+        mapping=mapping,
+        external_ip=external_ip,
+        external_port=external_port,
+        hole_punching_likely=mapping is not NatMapping.AddressDependent,
+    )
 
 
 def check_nat(
     source_ip: str = '0.0.0.0',
-    source_port: int = 54320,
+    source_port: int = 0,
+    timeout: float = 2.0,
 ) -> Result:
-    """Check the NAT type this host is behind.
+    """Check the NAT mapping behavior of this host.
 
-    This function uses the STUN protocol (RFC 3489) to discover the
-    presence and type of the NAT between this host and the open Internet.
+    Synchronous wrapper around
+    [`check_nat_async()`][proxystore.p2p.nat.check_nat_async].
 
     Args:
         source_ip: Address to bind to.
-        source_port: Port to listen on.
+        source_port: Port to bind to. The default binds an ephemeral port.
+        timeout: Maximum number of seconds to wait for responses.
 
     Returns:
-        Result containing the NAT type and external IP/port of the host.
+        Result describing the mapping behavior and external address.
 
     Raises:
-        RuntimeError: if no STUN servers return a response or if the hosts
-            IP or port changed during the STUN process.
+        RuntimeError: if fewer than two STUN servers respond, in which case
+            the mapping behavior cannot be determined.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.settimeout(2)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.bind((source_ip, source_port))
+    return asyncio.run(
+        check_nat_async(
+            source_ip=source_ip,
+            source_port=source_port,
+            timeout=timeout,
+        ),
+    )
 
-        for stun_server in _STUN_SERVERS:
-            stun_server_address, stun_server_port = stun_server.split(':')
 
-            _nat_type, external = stun.get_nat_type(
-                s,
-                source_ip,
-                source_port,
-                stun_host=stun_server_address,
-                stun_port=int(stun_server_port),
-            )
+def _log_result(result: Result) -> None:
+    logger.info(f'NAT Behavior:   {result.mapping.value}')
+    logger.info(f'External IP:    {result.external_ip}')
+    logger.info(f'External Port:  {result.external_port}')
 
-            try:
-                nat_type = NatType._from_str(_nat_type)
-            except RuntimeError:
-                pass
-            else:
-                break
-        else:
-            raise RuntimeError(
-                'No STUN servers returned a valid response. '
-                'Enable debug level logging for more details.',
-            )
+    if result.hole_punching_likely:
+        logger.info(
+            'NAT traversal for peer-to-peer methods (e.g., hole-punching) '
+            'is likely to work.',
+        )
+    else:
+        logger.warning(
+            'This NAT assigns a different external address to each peer so '
+            'NAT traversal (e.g., hole-punching) will not work reliably. '
+            'Peer-to-peer methods may require a relay.',
+        )
 
-    return Result(nat_type, external['ExternalIP'], external['ExternalPort'])
+
+async def check_nat_and_log_async(
+    source_ip: str = '0.0.0.0',
+    source_port: int = 0,
+    timeout: float = 2.0,
+) -> None:
+    """Check the NAT mapping behavior of this host and log the results.
+
+    Wrapper around [`check_nat_async()`][proxystore.p2p.nat.check_nat_async]
+    that logs the results rather than return them.
+
+    Args:
+        source_ip: Address to bind to.
+        source_port: Port to bind to. The default binds an ephemeral port.
+        timeout: Maximum number of seconds to wait for responses.
+    """
+    logger.info('Checking NAT behavior. This may take a moment...')
+    try:
+        result = await check_nat_async(
+            source_ip=source_ip,
+            source_port=source_port,
+            timeout=timeout,
+        )
+    except Exception as e:
+        logger.error(f'Failed to determine NAT behavior: {e}')
+    else:
+        _log_result(result)
 
 
 def check_nat_and_log(
     source_ip: str = '0.0.0.0',
-    source_port: int = 54320,
+    source_port: int = 0,
+    timeout: float = 2.0,
 ) -> None:
-    """Check the NAT type this host is behind and log the results.
+    """Check the NAT mapping behavior of this host and log the results.
 
-    Wrapper around [`check_nat()`][proxystore.p2p.nat.check_nat] that logs
-    the results rather than return them.
+    Synchronous wrapper around
+    [`check_nat_and_log_async()`][proxystore.p2p.nat.check_nat_and_log_async].
 
     Args:
         source_ip: Address to bind to.
-        source_port: Port to listen on.
+        source_port: Port to bind to. The default binds an ephemeral port.
+        timeout: Maximum number of seconds to wait for responses.
     """
-    logger.info('Checking NAT type. This may take a moment...')
-    try:
-        nat_type, external_ip, external_port = check_nat(
+    asyncio.run(
+        check_nat_and_log_async(
             source_ip=source_ip,
             source_port=source_port,
-        )
-    except Exception as e:
-        logger.error(f'Failed to determine NAT type: {e}')
-    else:
-        logger.info(f'NAT Type:       {nat_type.value}')
-        logger.info(f'External IP:    {external_ip}')
-        logger.info(f'External Port:  {external_port}')
-
-        if nat_type == NatType.Symmetric:
-            logger.warning(
-                'NAT traversal (e.g., hole-punching) does not work reliably '
-                'across Symmetric NATs or poorly behaved legacy NATs. '
-                'Peer-to-peer methods may not work.',
-            )
-        else:
-            logger.info(
-                'NAT traversal for peer-to-peer methods (e.g., hole-punching) '
-                'is likely to work. (NAT traversal does not work reliably '
-                'across symmetric NATs or poorly behaved legacy NATs.)',
-            )
+            timeout=timeout,
+        ),
+    )

--- a/proxystore/p2p/nat.py
+++ b/proxystore/p2p/nat.py
@@ -317,24 +317,6 @@ async def check_nat(
     )
 
 
-def _log_result(result: Result) -> None:
-    logger.info(f'NAT Behavior:   {result.mapping.value}')
-    logger.info(f'External IP:    {result.external_ip}')
-    logger.info(f'External Port:  {result.external_port}')
-
-    if result.hole_punching_likely:
-        logger.info(
-            'NAT traversal for peer-to-peer methods (e.g., hole-punching) '
-            'is likely to work.',
-        )
-    else:
-        logger.warning(
-            'This NAT assigns a different external address to each peer so '
-            'NAT traversal (e.g., hole-punching) will not work reliably. '
-            'Peer-to-peer methods may require a relay.',
-        )
-
-
 async def check_nat_and_log(
     source_ip: str = '0.0.0.0',
     source_port: int = 0,
@@ -359,5 +341,20 @@ async def check_nat_and_log(
         )
     except Exception as e:
         logger.error(f'Failed to determine NAT behavior: {e}')
+        return
+
+    logger.info(f'NAT Behavior:   {result.mapping.value}')
+    logger.info(f'External IP:    {result.external_ip}')
+    logger.info(f'External Port:  {result.external_port}')
+
+    if result.hole_punching_likely:
+        logger.info(
+            'NAT traversal for peer-to-peer methods (e.g., hole-punching) '
+            'is likely to work.',
+        )
     else:
-        _log_result(result)
+        logger.warning(
+            'This NAT assigns a different external address to each peer so '
+            'NAT traversal (e.g., hole-punching) will not work reliably. '
+            'Peer-to-peer methods may require a relay.',
+        )

--- a/proxystore/p2p/nat.py
+++ b/proxystore/p2p/nat.py
@@ -228,7 +228,7 @@ def _local_address(server: Address) -> str:
         return s.getsockname()[0]
 
 
-async def check_nat_async(
+async def check_nat(
     source_ip: str = '0.0.0.0',
     source_port: int = 0,
     timeout: float = 2.0,
@@ -317,37 +317,6 @@ async def check_nat_async(
     )
 
 
-def check_nat(
-    source_ip: str = '0.0.0.0',
-    source_port: int = 0,
-    timeout: float = 2.0,
-) -> Result:
-    """Check the NAT mapping behavior of this host.
-
-    Synchronous wrapper around
-    [`check_nat_async()`][proxystore.p2p.nat.check_nat_async].
-
-    Args:
-        source_ip: Address to bind to.
-        source_port: Port to bind to. The default binds an ephemeral port.
-        timeout: Maximum number of seconds to wait for responses.
-
-    Returns:
-        Result describing the mapping behavior and external address.
-
-    Raises:
-        RuntimeError: if fewer than two STUN servers respond, in which case
-            the mapping behavior cannot be determined.
-    """
-    return asyncio.run(
-        check_nat_async(
-            source_ip=source_ip,
-            source_port=source_port,
-            timeout=timeout,
-        ),
-    )
-
-
 def _log_result(result: Result) -> None:
     logger.info(f'NAT Behavior:   {result.mapping.value}')
     logger.info(f'External IP:    {result.external_ip}')
@@ -366,14 +335,14 @@ def _log_result(result: Result) -> None:
         )
 
 
-async def check_nat_and_log_async(
+async def check_nat_and_log(
     source_ip: str = '0.0.0.0',
     source_port: int = 0,
     timeout: float = 2.0,
 ) -> None:
     """Check the NAT mapping behavior of this host and log the results.
 
-    Wrapper around [`check_nat_async()`][proxystore.p2p.nat.check_nat_async]
+    Wrapper around [`check_nat()`][proxystore.p2p.nat.check_nat]
     that logs the results rather than return them.
 
     Args:
@@ -383,7 +352,7 @@ async def check_nat_and_log_async(
     """
     logger.info('Checking NAT behavior. This may take a moment...')
     try:
-        result = await check_nat_async(
+        result = await check_nat(
             source_ip=source_ip,
             source_port=source_port,
             timeout=timeout,
@@ -392,27 +361,3 @@ async def check_nat_and_log_async(
         logger.error(f'Failed to determine NAT behavior: {e}')
     else:
         _log_result(result)
-
-
-def check_nat_and_log(
-    source_ip: str = '0.0.0.0',
-    source_port: int = 0,
-    timeout: float = 2.0,
-) -> None:
-    """Check the NAT mapping behavior of this host and log the results.
-
-    Synchronous wrapper around
-    [`check_nat_and_log_async()`][proxystore.p2p.nat.check_nat_and_log_async].
-
-    Args:
-        source_ip: Address to bind to.
-        source_port: Port to bind to. The default binds an ephemeral port.
-        timeout: Maximum number of seconds to wait for responses.
-    """
-    asyncio.run(
-        check_nat_and_log_async(
-            source_ip=source_ip,
-            source_port=source_port,
-            timeout=timeout,
-        ),
-    )

--- a/proxystore/p2p/relay/client.py
+++ b/proxystore/p2p/relay/client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import socket
 import ssl
 import sys
 import uuid
@@ -314,12 +313,19 @@ class RelayClient:
                         )
                         self._reconnect_task.set_name('relay-client-reconnect')
                 except (
-                    # May occur if relay is unavailable
-                    ConnectionRefusedError,
-                    # May occur if relay is too slow to respond
+                    # OSError covers a range of connection failures, all
+                    # subclasses of OSError:
+                    #   - ConnectionRefusedError if the relay is unavailable,
+                    #   - socket.gaierror on temporary DNS failures, and
+                    #   - a bare OSError ("Multiple exceptions: ...") raised by
+                    #     asyncio when every address a hostname resolves to
+                    #     (e.g. both ::1 and 127.0.0.1 for localhost) fails to
+                    #     connect.
+                    OSError,
+                    # asyncio.TimeoutError may occur if the relay is too slow
+                    # to respond. It is only an OSError subclass on Python
+                    # >=3.11 so it is listed explicitly.
                     asyncio.TimeoutError,
-                    # May occur if client experiences temporary DNS failure
-                    socket.gaierror,
                     websockets.exceptions.ConnectionClosed,
                 ) as e:
                     if not retry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ endpoints = [
     "aiosqlite",
     "uvicorn[standard]",
     "psutil",
-    "pystun3",
     "python-daemon",
     "quart>=0.18.0",
     "requests>=2.27.1",

--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -74,7 +74,7 @@ def test_check_nat_normal(caplog) -> None:
         True,
     )
     with mock.patch(
-        'proxystore.p2p.nat.check_nat_async',
+        'proxystore.p2p.nat.check_nat',
         mock.AsyncMock(return_value=r),
     ):
         result = runner.invoke(cli, ['check-nat'])

--- a/tests/endpoint/cli_test.py
+++ b/tests/endpoint/cli_test.py
@@ -17,7 +17,7 @@ from proxystore.endpoint.cli import cli
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import read_config
 from proxystore.endpoint.config import write_config
-from proxystore.p2p.nat import NatType
+from proxystore.p2p.nat import NatMapping
 from proxystore.p2p.nat import Result
 
 CLICK_VERSION = tuple(
@@ -67,12 +67,22 @@ def test_check_nat_normal(caplog) -> None:
     caplog.set_level(logging.INFO)
     runner = click.testing.CliRunner()
 
-    r = Result(NatType.RestrictedCone, '192.168.1.1', 1234)
-    with mock.patch('proxystore.p2p.nat.check_nat', return_value=r):
+    r = Result(
+        NatMapping.EndpointIndependent,
+        '192.168.1.1',
+        1234,
+        True,
+    )
+    with mock.patch(
+        'proxystore.p2p.nat.check_nat_async',
+        mock.AsyncMock(return_value=r),
+    ):
         result = runner.invoke(cli, ['check-nat'])
 
     assert result.exit_code == 0
-    assert caplog.records[1].message == 'NAT Type:       Restricted-cone NAT'
+    assert caplog.records[1].message == (
+        'NAT Behavior:   Endpoint-independent mapping'
+    )
     assert caplog.records[2].message == 'External IP:    192.168.1.1'
     assert caplog.records[3].message == 'External Port:  1234'
     assert caplog.records[4].message.startswith(

--- a/tests/endpoint/serve_test.py
+++ b/tests/endpoint/serve_test.py
@@ -20,6 +20,7 @@ from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import EndpointStorageConfig
 from proxystore.endpoint.endpoint import Endpoint
 from proxystore.endpoint.serve import _get_auth_headers
+from proxystore.endpoint.serve import _serve_async
 from proxystore.endpoint.serve import create_app
 from proxystore.endpoint.serve import MAX_CHUNK_LENGTH
 from proxystore.endpoint.serve import serve
@@ -440,3 +441,38 @@ def test_get_auth_headers_globus_missing() -> None:
         ),
     ):
         assert _get_auth_headers('globus')
+
+
+async def test_serve_cancels_nat_check(relay_server) -> None:
+    # The NAT check runs concurrently with serving so that a slow or blocked
+    # network cannot delay the endpoint from accepting requests. Shutting the
+    # endpoint down must therefore cancel a check which has not finished
+    # rather than wait for it.
+    cancelled = asyncio.Event()
+
+    async def never_finishes() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    config = EndpointConfig(
+        name='my-endpoint',
+        uuid=str(uuid.uuid4()),
+        host='localhost',
+        port=open_port(),
+        storage=EndpointStorageConfig(database_path=':memory:'),
+    )
+    config.relay.address = relay_server.address
+
+    with (
+        mock.patch('uvicorn.Server.serve', AsyncMock()),
+        mock.patch(
+            'proxystore.endpoint.serve.check_nat_and_log',
+            side_effect=never_finishes,
+        ),
+    ):
+        await _serve_async(config)
+
+    assert cancelled.is_set()

--- a/tests/p2p/nat_test.py
+++ b/tests/p2p/nat_test.py
@@ -1,121 +1,391 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import socket
+import struct
+from typing import Any
 from unittest import mock
 
 import pytest
-import stun
 
+from proxystore.p2p.nat import _decode_response
+from proxystore.p2p.nat import _encode_request
+from proxystore.p2p.nat import _local_address
+from proxystore.p2p.nat import _MAGIC_COOKIE
+from proxystore.p2p.nat import _resolve_servers
+from proxystore.p2p.nat import _STUN_SERVERS
 from proxystore.p2p.nat import check_nat
 from proxystore.p2p.nat import check_nat_and_log
-from proxystore.p2p.nat import NatType
+from proxystore.p2p.nat import check_nat_and_log_async
+from proxystore.p2p.nat import check_nat_async
+from proxystore.p2p.nat import NatMapping
 from proxystore.p2p.nat import Result
-from testing.utils import open_port
+
+TRANSACTION_ID = b'0123456789ab'
 
 
-def test_nat_type() -> None:
-    assert NatType._from_str(stun.FullCone) == NatType.FullCone
+def encode_attribute(attribute_type: int, value: bytes) -> bytes:
+    padding = b'\x00' * (-len(value) % 4)
+    return struct.pack('>HH', attribute_type, len(value)) + value + padding
 
-    with pytest.raises(RuntimeError, match=r'No response from a STUN server'):
-        NatType._from_str(stun.Blocked)
 
-    with pytest.raises(
-        RuntimeError,
-        match=r'Address changed during NAT type check',
+def encode_address(ip: str, port: int, xor: bool) -> bytes:
+    packed_ip = socket.inet_aton(ip)
+    if xor:
+        port ^= _MAGIC_COOKIE >> 16
+        cookie = struct.pack('>I', _MAGIC_COOKIE)
+        packed_ip = bytes(
+            a ^ b for a, b in zip(packed_ip, cookie, strict=True)
+        )
+    return b'\x00\x01' + struct.pack('>H', port) + packed_ip
+
+
+def encode_response(
+    ip: str = '192.168.1.1',
+    port: int = 1234,
+    *,
+    transaction_id: bytes = TRANSACTION_ID,
+    message_type: int = 0x0101,
+    cookie: int = _MAGIC_COOKIE,
+    attributes: bytes | None = None,
+) -> bytes:
+    if attributes is None:
+        attributes = encode_attribute(0x0020, encode_address(ip, port, True))
+    header = struct.pack(
+        '>HHI12s',
+        message_type,
+        len(attributes),
+        cookie,
+        transaction_id,
+    )
+    return header + attributes
+
+
+def test_encode_request() -> None:
+    request = _encode_request(TRANSACTION_ID)
+    message_type, length, cookie, transaction_id = struct.unpack(
+        '>HHI12s',
+        request,
+    )
+
+    assert message_type == 0x0001
+    assert length == 0
+    assert cookie == _MAGIC_COOKIE
+    assert transaction_id == TRANSACTION_ID
+
+
+def test_decode_response_xor_mapped_address() -> None:
+    decoded = _decode_response(encode_response('93.184.216.34', 40000))
+
+    assert decoded is not None
+    assert decoded == (TRANSACTION_ID, ('93.184.216.34', 40000))
+
+
+def test_decode_response_mapped_address_fallback() -> None:
+    # Servers which only send the pre-RFC 5389 attribute are still usable.
+    attributes = encode_attribute(
+        0x0001,
+        encode_address('93.184.216.34', 40000, False),
+    )
+    decoded = _decode_response(encode_response(attributes=attributes))
+
+    assert decoded == (TRANSACTION_ID, ('93.184.216.34', 40000))
+
+
+def test_decode_response_prefers_xor_mapped_address() -> None:
+    # A server sending both must be read via the XOR variant since middleboxes
+    # may have rewritten the plain one.
+    attributes = encode_attribute(
+        0x0001,
+        encode_address('10.0.0.1', 1, False),
+    ) + encode_attribute(
+        0x0020,
+        encode_address('93.184.216.34', 40000, True),
+    )
+    decoded = _decode_response(encode_response(attributes=attributes))
+
+    assert decoded == (TRANSACTION_ID, ('93.184.216.34', 40000))
+
+
+def test_decode_response_skips_unknown_attributes() -> None:
+    attributes = encode_attribute(0x8022, b'test server') + encode_attribute(
+        0x0020,
+        encode_address('93.184.216.34', 40000, True),
+    )
+    decoded = _decode_response(encode_response(attributes=attributes))
+
+    assert decoded == (TRANSACTION_ID, ('93.184.216.34', 40000))
+
+
+@pytest.mark.parametrize(
+    'data',
+    (
+        # Truncated header.
+        b'\x01\x01\x00\x00',
+        # Binding error response rather than success.
+        encode_response(message_type=0x0111),
+        # Response from something which is not a STUN server.
+        encode_response(cookie=0xDEADBEEF),
+        # Success carrying no address.
+        encode_response(attributes=b''),
+        # IPv6 address, which this check does not support.
+        encode_response(attributes=encode_attribute(0x0020, b'\x00\x02' * 9)),
+    ),
+)
+def test_decode_response_invalid(data: bytes) -> None:
+    assert _decode_response(data) is None
+
+
+async def test_resolve_servers_deduplicates_by_ip() -> None:
+    # Servers sharing an IP provide only one measurement point, so keeping
+    # both would make an address-dependent NAT look endpoint-independent.
+    def getaddrinfo(host: str, port: int, **kwargs: Any) -> list[Any]:
+        ip = '1.1.1.1' if host in ('a', 'b') else '2.2.2.2'
+        return [(socket.AF_INET, socket.SOCK_DGRAM, 17, '', (ip, port))]
+
+    with mock.patch.object(
+        asyncio.get_running_loop(),
+        'getaddrinfo',
+        side_effect=getaddrinfo,
     ):
-        NatType._from_str(stun.ChangedAddressError)
+        resolved = await _resolve_servers((('a', 1), ('b', 2), ('c', 3)))
+
+    assert resolved == [('1.1.1.1', 1), ('2.2.2.2', 3)]
 
 
-def test_check_nat() -> None:
-    external = {'ExternalIP': '192.168.1.1', 'ExternalPort': 1234}
+async def test_resolve_servers_ignores_failures() -> None:
+    async def getaddrinfo(host: str, port: int, **kwargs: Any) -> list[Any]:
+        if host == 'bad':
+            raise socket.gaierror('test error')
+        return [(socket.AF_INET, socket.SOCK_DGRAM, 17, '', ('1.1.1.1', port))]
 
+    with mock.patch.object(
+        asyncio.get_running_loop(),
+        'getaddrinfo',
+        side_effect=getaddrinfo,
+    ):
+        resolved = await _resolve_servers((('bad', 1), ('good', 2)))
+
+    assert resolved == [('1.1.1.1', 2)]
+
+
+class MockStunServers:
+    """Replies to binding requests with a configurable external address.
+
+    Args:
+        addresses: External address to reflect back per server IP. A value of
+            `None` means that server does not respond.
+    """
+
+    def __init__(self, addresses: dict[str, tuple[str, int] | None]) -> None:
+        self.addresses = addresses
+        self.transport = mock.MagicMock()
+        self.transport.sendto.side_effect = self._sendto
+        self.protocol: Any = None
+
+    def _sendto(self, data: bytes, server: tuple[str, int]) -> None:
+        address = self.addresses[server[0]]
+        if address is None:
+            return
+        transaction_id = data[8:20]
+        self.protocol.datagram_received(
+            encode_response(*address, transaction_id=transaction_id),
+            server,
+        )
+
+    async def create_datagram_endpoint(
+        self,
+        protocol_factory: Any,
+        **kwargs: Any,
+    ) -> tuple[Any, Any]:
+        self.protocol = protocol_factory()
+        return self.transport, self.protocol
+
+
+def patch_stun(
+    addresses: dict[str, tuple[str, int] | None],
+    local_ip: str = '10.0.0.1',
+) -> Any:
+    servers = [(ip, 3478) for ip in addresses]
+    mock_servers = MockStunServers(addresses)
+    loop = asyncio.get_running_loop()
+    return mock.patch.multiple(
+        'proxystore.p2p.nat',
+        _resolve_servers=mock.AsyncMock(return_value=servers),
+        _local_address=mock.MagicMock(return_value=local_ip),
+    ), mock.patch.object(
+        loop,
+        'create_datagram_endpoint',
+        side_effect=mock_servers.create_datagram_endpoint,
+    )
+
+
+async def test_check_nat_endpoint_independent() -> None:
+    # Every server reflects the same address, so one mapping serves all peers.
+    patches = patch_stun(
+        {
+            '1.1.1.1': ('93.184.216.34', 40000),
+            '2.2.2.2': ('93.184.216.34', 40000),
+        },
+    )
+    with patches[0], patches[1]:
+        result = await check_nat_async()
+
+    assert result.mapping == NatMapping.EndpointIndependent
+    assert result.external_ip == '93.184.216.34'
+    assert result.external_port == 40000
+    assert result.hole_punching_likely
+
+
+async def test_check_nat_address_dependent() -> None:
+    # A different port per server means a peer cannot use the address it is
+    # told about. Regression test for #729, which reported such NATs as
+    # full-cone.
+    patches = patch_stun(
+        {
+            '1.1.1.1': ('93.184.216.34', 40000),
+            '2.2.2.2': ('93.184.216.34', 50000),
+        },
+    )
+    with patches[0], patches[1]:
+        result = await check_nat_async()
+
+    assert result.mapping == NatMapping.AddressDependent
+    assert not result.hole_punching_likely
+
+
+async def test_check_nat_no_nat() -> None:
+    # The reflected address matching the local address means no NAT at all.
+    patches = patch_stun(
+        {
+            '1.1.1.1': ('93.184.216.34', 40000),
+            '2.2.2.2': ('93.184.216.34', 40000),
+        },
+        local_ip='93.184.216.34',
+    )
+    with patches[0], patches[1]:
+        result = await check_nat_async()
+
+    assert result.mapping == NatMapping.NoNat
+    assert result.hole_punching_likely
+
+
+async def test_check_nat_requires_two_responses() -> None:
+    # One response cannot distinguish the two behaviors, so it must not be
+    # reported as though it could. Unanswered requests are retransmitted, so
+    # this also exercises every retransmission round.
+    patches = patch_stun(
+        {'1.1.1.1': ('93.184.216.34', 40000), '2.2.2.2': None},
+    )
+    with (
+        patches[0],
+        patches[1],
+        mock.patch(
+            'proxystore.p2p.nat._RETRANSMIT_DELAYS',
+            (0.001, 0.001, 0.001),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match='Only 1 of 2 STUN servers'):
+            await check_nat_async()
+
+
+async def test_check_nat_stops_at_timeout() -> None:
+    # A network which blocks STUN must fail within the timeout rather than
+    # running every retransmission round.
+    patches = patch_stun({'1.1.1.1': None, '2.2.2.2': None})
+    with patches[0], patches[1]:
+        with pytest.raises(RuntimeError, match='Only 0 of 2 STUN servers'):
+            await check_nat_async(timeout=0)
+
+
+def test_local_address() -> None:
+    # 192.0.2.1 is TEST-NET-1 so connecting resolves a route without sending.
+    assert _local_address(('192.0.2.1', 3478)) != '0.0.0.0'
+
+
+async def test_check_nat_requires_two_servers() -> None:
     with mock.patch(
-        'stun.get_nat_type',
-        return_value=(stun.RestricNAT, external),
+        'proxystore.p2p.nat._resolve_servers',
+        mock.AsyncMock(return_value=[('1.1.1.1', 3478)]),
     ):
-        result = check_nat(source_port=open_port())
-
-    assert result.nat_type == NatType.RestrictedCone
-    assert result.external_ip == external['ExternalIP']
-    assert result.external_port == external['ExternalPort']
+        with pytest.raises(RuntimeError, match='Only 1 STUN servers'):
+            await check_nat_async()
 
 
-def test_check_nat_failure() -> None:
-    external = {'ExternalIP': '192.168.1.1', 'ExternalPort': 1234}
-
+def test_check_nat_sync_wrapper() -> None:
+    result = Result(NatMapping.EndpointIndependent, '93.184.216.34', 1, True)
     with mock.patch(
-        'stun.get_nat_type',
-        return_value=(stun.Blocked, external),
+        'proxystore.p2p.nat.check_nat_async',
+        mock.AsyncMock(return_value=result),
     ):
-        with pytest.raises(RuntimeError, match='No STUN servers returned'):
-            check_nat(source_port=open_port())
+        assert check_nat() == result
 
 
-def test_check_nat_and_log_normal(caplog) -> None:
+def test_stun_servers_are_distinct_hosts() -> None:
+    hosts = [host for host, _ in _STUN_SERVERS]
+
+    assert len(_STUN_SERVERS) >= 2
+    assert len(set(hosts)) == len(hosts)
+
+
+async def test_check_nat_and_log_hole_punching_likely(caplog) -> None:
     caplog.set_level(logging.INFO)
 
-    result = Result(NatType.RestrictedCone, '192.168.1.1', 1234)
-    with mock.patch('proxystore.p2p.nat.check_nat', return_value=result):
-        check_nat_and_log()
+    result = Result(
+        NatMapping.EndpointIndependent,
+        '93.184.216.34',
+        1234,
+        True,
+    )
+    with mock.patch(
+        'proxystore.p2p.nat.check_nat_async',
+        mock.AsyncMock(return_value=result),
+    ):
+        await check_nat_and_log_async()
 
-    assert any(
-        [
-            'NAT Type:       Restricted-cone NAT' in r.message
-            for r in caplog.records
-        ],
-    )
-    assert any(
-        ['External IP:    192.168.1.1' in r.message for r in caplog.records],
-    )
-    assert any(['External Port:  1234' in r.message for r in caplog.records])
-    assert any(
-        [
-            r.message.startswith(
-                'NAT traversal for peer-to-peer methods (e.g., hole-punching) '
-                'is likely to work.',
-            )
-            for r in caplog.records
-        ],
-    )
+    messages = [r.message for r in caplog.records]
+    assert any('Endpoint-independent mapping' in m for m in messages)
+    assert any('External IP:    93.184.216.34' in m for m in messages)
+    assert any('External Port:  1234' in m for m in messages)
+    assert any(m.startswith('NAT traversal for peer') for m in messages)
 
 
-def test_check_nat_and_log_symmetric(caplog) -> None:
+async def test_check_nat_and_log_address_dependent(caplog) -> None:
     caplog.set_level(logging.INFO)
 
-    result = Result(NatType.Symmetric, '192.168.1.1', 1234)
-    with mock.patch('proxystore.p2p.nat.check_nat', return_value=result):
-        check_nat_and_log()
+    result = Result(NatMapping.AddressDependent, '93.184.216.34', 1234, False)
+    with mock.patch(
+        'proxystore.p2p.nat.check_nat_async',
+        mock.AsyncMock(return_value=result),
+    ):
+        await check_nat_and_log_async()
 
-    assert any(
-        ['NAT Type:       Symmetric NAT' in r.message for r in caplog.records],
-    )
-    assert any(
-        ['External IP:    192.168.1.1' in r.message for r in caplog.records],
-    )
-    assert any(['External Port:  1234' in r.message for r in caplog.records])
-    assert any(
-        [
-            r.message.startswith(
-                'NAT traversal (e.g., hole-punching) does not work '
-                'reliably across',
-            )
-            for r in caplog.records
-        ],
-    )
+    messages = [r.message for r in caplog.records]
+    assert any('Address-dependent mapping' in m for m in messages)
+    assert any('will not work reliably' in m for m in messages)
 
 
-def test_check_nat_and_log_failure(caplog) -> None:
+async def test_check_nat_and_log_failure(caplog) -> None:
     caplog.set_level(logging.INFO)
 
     with mock.patch(
-        'proxystore.p2p.nat.check_nat',
-        side_effect=RuntimeError('test error'),
+        'proxystore.p2p.nat.check_nat_async',
+        mock.AsyncMock(side_effect=RuntimeError('test error')),
     ):
-        check_nat_and_log()
+        await check_nat_and_log_async()
 
     assert any(
-        [
-            r.message.startswith('Failed to determine NAT type: test error')
-            for r in caplog.records
-        ],
+        r.message.startswith('Failed to determine NAT behavior: test error')
+        for r in caplog.records
     )
+
+
+def test_check_nat_and_log_sync_wrapper() -> None:
+    with mock.patch(
+        'proxystore.p2p.nat.check_nat_and_log_async',
+        mock.AsyncMock(),
+    ) as mock_check:
+        check_nat_and_log()
+
+    assert mock_check.call_count == 1

--- a/tests/p2p/nat_test.py
+++ b/tests/p2p/nat_test.py
@@ -17,8 +17,6 @@ from proxystore.p2p.nat import _resolve_servers
 from proxystore.p2p.nat import _STUN_SERVERS
 from proxystore.p2p.nat import check_nat
 from proxystore.p2p.nat import check_nat_and_log
-from proxystore.p2p.nat import check_nat_and_log_async
-from proxystore.p2p.nat import check_nat_async
 from proxystore.p2p.nat import NatMapping
 from proxystore.p2p.nat import Result
 
@@ -230,7 +228,7 @@ async def test_check_nat_endpoint_independent() -> None:
         },
     )
     with patches[0], patches[1]:
-        result = await check_nat_async()
+        result = await check_nat()
 
     assert result.mapping == NatMapping.EndpointIndependent
     assert result.external_ip == '93.184.216.34'
@@ -249,7 +247,7 @@ async def test_check_nat_address_dependent() -> None:
         },
     )
     with patches[0], patches[1]:
-        result = await check_nat_async()
+        result = await check_nat()
 
     assert result.mapping == NatMapping.AddressDependent
     assert not result.hole_punching_likely
@@ -265,7 +263,7 @@ async def test_check_nat_no_nat() -> None:
         local_ip='93.184.216.34',
     )
     with patches[0], patches[1]:
-        result = await check_nat_async()
+        result = await check_nat()
 
     assert result.mapping == NatMapping.NoNat
     assert result.hole_punching_likely
@@ -287,7 +285,7 @@ async def test_check_nat_requires_two_responses() -> None:
         ),
     ):
         with pytest.raises(RuntimeError, match='Only 1 of 2 STUN servers'):
-            await check_nat_async()
+            await check_nat()
 
 
 async def test_check_nat_stops_at_timeout() -> None:
@@ -296,7 +294,7 @@ async def test_check_nat_stops_at_timeout() -> None:
     patches = patch_stun({'1.1.1.1': None, '2.2.2.2': None})
     with patches[0], patches[1]:
         with pytest.raises(RuntimeError, match='Only 0 of 2 STUN servers'):
-            await check_nat_async(timeout=0)
+            await check_nat(timeout=0)
 
 
 def test_local_address() -> None:
@@ -310,16 +308,7 @@ async def test_check_nat_requires_two_servers() -> None:
         mock.AsyncMock(return_value=[('1.1.1.1', 3478)]),
     ):
         with pytest.raises(RuntimeError, match='Only 1 STUN servers'):
-            await check_nat_async()
-
-
-def test_check_nat_sync_wrapper() -> None:
-    result = Result(NatMapping.EndpointIndependent, '93.184.216.34', 1, True)
-    with mock.patch(
-        'proxystore.p2p.nat.check_nat_async',
-        mock.AsyncMock(return_value=result),
-    ):
-        assert check_nat() == result
+            await check_nat()
 
 
 def test_stun_servers_are_distinct_hosts() -> None:
@@ -339,10 +328,10 @@ async def test_check_nat_and_log_hole_punching_likely(caplog) -> None:
         True,
     )
     with mock.patch(
-        'proxystore.p2p.nat.check_nat_async',
+        'proxystore.p2p.nat.check_nat',
         mock.AsyncMock(return_value=result),
     ):
-        await check_nat_and_log_async()
+        await check_nat_and_log()
 
     messages = [r.message for r in caplog.records]
     assert any('Endpoint-independent mapping' in m for m in messages)
@@ -356,10 +345,10 @@ async def test_check_nat_and_log_address_dependent(caplog) -> None:
 
     result = Result(NatMapping.AddressDependent, '93.184.216.34', 1234, False)
     with mock.patch(
-        'proxystore.p2p.nat.check_nat_async',
+        'proxystore.p2p.nat.check_nat',
         mock.AsyncMock(return_value=result),
     ):
-        await check_nat_and_log_async()
+        await check_nat_and_log()
 
     messages = [r.message for r in caplog.records]
     assert any('Address-dependent mapping' in m for m in messages)
@@ -370,22 +359,12 @@ async def test_check_nat_and_log_failure(caplog) -> None:
     caplog.set_level(logging.INFO)
 
     with mock.patch(
-        'proxystore.p2p.nat.check_nat_async',
+        'proxystore.p2p.nat.check_nat',
         mock.AsyncMock(side_effect=RuntimeError('test error')),
     ):
-        await check_nat_and_log_async()
+        await check_nat_and_log()
 
     assert any(
         r.message.startswith('Failed to determine NAT behavior: test error')
         for r in caplog.records
     )
-
-
-def test_check_nat_and_log_sync_wrapper() -> None:
-    with mock.patch(
-        'proxystore.p2p.nat.check_nat_and_log_async',
-        mock.AsyncMock(),
-    ) as mock_check:
-        check_nat_and_log()
-
-    assert mock_check.call_count == 1

--- a/tests/p2p/relay/client_test.py
+++ b/tests/p2p/relay/client_test.py
@@ -168,6 +168,36 @@ async def test_relay_server_retry_backoff(relay_server, caplog) -> None:
 
 
 @pytest.mark.asyncio
+async def test_relay_server_retry_bare_oserror(relay_server, caplog) -> None:
+    # asyncio raises a bare OSError ("Multiple exceptions: ...") rather than
+    # a ConnectionRefusedError when every address a hostname resolves to fails
+    # to connect (e.g. both ::1 and 127.0.0.1 for localhost on macOS). This
+    # must be treated as a retryable connection failure.
+    caplog.set_level(logging.WARNING)
+    client = RelayClient(relay_server.address, reconnect_task=False)
+    client._initial_backoff_seconds = 0.01
+    error = OSError(
+        "Multiple exceptions: [Errno 61] Connect call failed ('::1', 1), "
+        "[Errno 61] Connect call failed ('127.0.0.1', 1)",
+    )
+    with mock.patch.object(
+        client,
+        '_register',
+        AsyncMock(side_effect=[error, None]),
+    ):
+        await client.connect(retry=True)
+
+    records = [
+        record.message
+        for record in caplog.records
+        if 'Retrying connection in' in record.message
+    ]
+    assert len(records) == 1
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_relay_server_connect_fatal_error(relay_server) -> None:
     error = websockets.exceptions.ConnectionClosedError(
         # Mimic a ForbiddenError from the relay server that caused


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

`check_nat()` reported a full-cone NAT for every host behind any NAT. It listed the stun.l.google.com family first, and those servers implement RFC 5389 only: they ignore the RFC 3489 CHANGE-REQUEST attribute and reply from their original address. pystun3 only checks that *some* response arrived, never that it came from a different address, so any response was read as full-cone.

Rather than chase servers which still implement CHANGE-REQUEST, drop the RFC 3489 taxonomy entirely. It was deprecated because mapping and filtering behavior are independent, and only mapping behavior determines whether NAT traversal works: hole-punching succeeds through a filtering NAT because the relay coordinates both peers to send simultaneously, and fails only when the NAT assigns a different external address per destination.

Implement the RFC 5780 mapping behavior test instead. Binding requests go from one socket to several servers on different IP addresses; identical reflected addresses mean the mapping is endpoint-independent and traversal can work, differing addresses mean it is address-dependent and a relay is required. This needs no CHANGE-REQUEST support, so it works against modern servers, and the requests are sent concurrently so the check completes in about one round trip rather than several seconds.

`NatType` is replaced by `NatMapping` and `Result` gains `hole_punching_likely`. Servers resolving to the same IP are deduplicated since they only provide one measurement point. pystun3 is no longer needed so it is dropped as a dependency, along with its non-terminating loop on binding error responses.

The check is now async, and endpoint startup schedules it as a cancellable task rather than blocking on it. It only produces diagnostic logs, so it should never delay an endpoint from serving requests on a network where STUN is slow or blocked.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #729

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Update unit tests and tested different STUN servers to understand behavior.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
