### PR TITLE
Disable ICE servers in tests to avoid 5s stalls

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,26 @@ def event_loop_policy(
         yield policy
 
 
+@pytest.fixture(scope='session', autouse=True)
+def _disable_ice_servers() -> Generator[None, None, None]:
+    """Disable STUN servers when gathering ICE candidates.
+
+    Peers created in the test suite are always on the same host so host
+    candidates are sufficient to establish a connection and server-reflexive
+    candidates are never used. Gathering them is not merely wasted work: a
+    local address which cannot route to the STUN server stalls candidate
+    gathering for five seconds because aioice does not support trickle ICE
+    and waits for every STUN request to time out. WSL, for example, assigns
+    a non-routable address to the loopback interface, causing every peer
+    connection to take an additional five seconds to open (#599).
+    """
+    with mock.patch(
+        'aiortc.rtcicetransport.RTCIceGatherer.getDefaultIceServers',
+        return_value=[],
+    ):
+        yield
+
+
 @pytest.fixture(autouse=True)
 def _verify_no_registered_stores() -> Generator[None, None, None]:
     yield


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

aiortc defaults to stun:stun.l.google.com:19302 when no ICE servers are configured, so every PeerConnection opened in the test suite gathers server-reflexive candidates. Because aioice does not support trickle ICE, gathering waits for every STUN request to complete, and any local address which cannot route to the STUN server stalls the whole gather for the full five second timeout.

WSL triggers this: it assigns 10.255.255.254/32 to the loopback interface, which aioice keeps as a candidate address because it only filters the literal 127.0.0.1. STUN requests sourced from it never leave the machine.

Peers in the test suite are always on the same host so host candidates are sufficient and server-reflexive candidates are never used. Disable them with a session-wide fixture.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #599

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [x] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tests now run much faster on WSL.

## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
