### PR TITLE
Add configurable ICE servers to endpoint peer connections

### DIFF
--- a/proxystore/endpoint/config.py
+++ b/proxystore/endpoint/config.py
@@ -42,12 +42,34 @@ class EndpointRelayAuthConfig(BaseModel):
     kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
+class EndpointRelayICEServerConfig(BaseModel):
+    """STUN/TURN server used when gathering ICE candidates.
+
+    Attributes:
+        urls: One or more URLs of the STUN or TURN server (e.g.,
+            `stun:stun.l.google.com:19302`).
+        username: Optional username for authenticating with a TURN server.
+        credential: Optional credential for authenticating with a TURN server.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+    urls: str | list[str]
+    username: str | None = None
+    credential: str | None = None
+
+
 class EndpointRelayConfig(BaseModel):
     """Endpoint relay server configuration.
 
     Attributes:
         address: Address of the relay server to register with.
         auth: Relay server authentication configuration.
+        ice_servers: STUN/TURN servers to use when gathering ICE candidates
+            for peer connections. If `None`, a default set of public STUN
+            servers is used. An empty list disables server-reflexive candidate
+            gathering entirely, which is useful when all peers are on the same
+            host or when STUN servers are unreachable.
         peer_channels: Number of peer channels to multiplex communication over.
         verify_certificates: Validate the relay server's SSL certificate. This
             should only be disabled when testing endpoint with local relay
@@ -58,6 +80,7 @@ class EndpointRelayConfig(BaseModel):
     auth: EndpointRelayAuthConfig = Field(
         default_factory=EndpointRelayAuthConfig,
     )
+    ice_servers: list[EndpointRelayICEServerConfig] | None = None
     peer_channels: int = 1
     verify_certificate: bool = True
 

--- a/proxystore/endpoint/serve.py
+++ b/proxystore/endpoint/serve.py
@@ -26,6 +26,7 @@ except ImportError as e:  # pragma: no cover
         '"pip install proxystore[endpoints]".',
     ) from e
 
+from aiortc import RTCIceServer
 from globus_sdk.token_storage import TokenValidationError
 
 from proxystore.endpoint.config import EndpointConfig
@@ -137,9 +138,22 @@ async def _serve_async(config: EndpointConfig) -> None:
             extra_headers=headers,
             verify_certificate=config.relay.verify_certificate,
         )
+        ice_servers = (
+            None
+            if config.relay.ice_servers is None
+            else [
+                RTCIceServer(
+                    urls=server.urls,
+                    username=server.username,
+                    credential=server.credential,
+                )
+                for server in config.relay.ice_servers
+            ]
+        )
         peer_manager = PeerManager(
             relay_client,
             peer_channels=config.relay.peer_channels,
+            ice_servers=ice_servers,
         )
         # The NAT check only produces diagnostic logs so it is run
         # concurrently rather than delaying the endpoint from serving

--- a/proxystore/p2p/connection.py
+++ b/proxystore/p2p/connection.py
@@ -13,8 +13,10 @@ from typing import Any
 from uuid import UUID
 
 try:
+    from aiortc import RTCConfiguration
     from aiortc import RTCDataChannel
     from aiortc import RTCIceCandidate
+    from aiortc import RTCIceServer
     from aiortc import RTCPeerConnection
     from aiortc import RTCSessionDescription
     from aiortc.contrib.signaling import BYE
@@ -94,6 +96,9 @@ class PeerConnection:
     Args:
         relay_client: Client connection to the relay server.
         channels: Number of datachannels to open with peer.
+        ice_servers: STUN/TURN servers to use when gathering ICE candidates.
+            If `None`, aiortc's default set of public STUN servers is used.
+            An empty list disables server-reflexive candidate gathering.
     """
 
     def __init__(
@@ -101,6 +106,7 @@ class PeerConnection:
         relay_client: RelayClient,
         *,
         channels: int = 1,
+        ice_servers: list[RTCIceServer] | None = None,
     ) -> None:
         self._relay_client = relay_client
         self._max_channels = channels
@@ -108,7 +114,12 @@ class PeerConnection:
         self._handshake_success: asyncio.Future[bool] = (
             asyncio.get_running_loop().create_future()
         )
-        self._pc = RTCPeerConnection()
+        if ice_servers is None:
+            self._pc = RTCPeerConnection()
+        else:
+            self._pc = RTCPeerConnection(
+                RTCConfiguration(iceServers=list(ice_servers)),
+            )
 
         self._incoming_queue: asyncio.Queue[bytes | str] = asyncio.Queue()
         self._incoming_chunks: dict[int, list[Chunk]] = defaultdict(list)

--- a/proxystore/p2p/manager.py
+++ b/proxystore/p2p/manager.py
@@ -21,6 +21,12 @@ except ImportError as e:  # pragma: no cover
         stacklevel=2,
     )
 
+try:
+    from aiortc import RTCIceServer
+except ImportError:  # pragma: no cover
+    # Handled by the aiortc import warning in proxystore.p2p.connection.
+    pass
+
 from proxystore.p2p.connection import log_name
 from proxystore.p2p.connection import PeerConnection
 from proxystore.p2p.exceptions import PeerConnectionError
@@ -77,6 +83,11 @@ class PeerManager:
             established.
         peer_channels: number of datachannels to split message sending over
             between each peer.
+        ice_servers: STUN/TURN servers passed to each
+            [`PeerConnection`][proxystore.p2p.connection.PeerConnection] when
+            gathering ICE candidates. If `None`, aiortc's default set of
+            public STUN servers is used. An empty list disables
+            server-reflexive candidate gathering.
 
     Raises:
         ValueError: If the relay server address does not start with "ws://"
@@ -89,10 +100,12 @@ class PeerManager:
         *,
         timeout: int = 30,
         peer_channels: int = 1,
+        ice_servers: list[RTCIceServer] | None = None,
     ) -> None:
         self._relay_client = relay_client
         self._timeout = timeout
         self._peer_channels = peer_channels
+        self._ice_servers = ice_servers
 
         self._peers_lock = asyncio.Lock()
         self._peers: dict[frozenset[UUID], PeerConnection] = {}
@@ -230,6 +243,7 @@ class PeerManager:
                     connection = PeerConnection(
                         relay_client=self.relay_client,
                         channels=self._peer_channels,
+                        ice_servers=self._ice_servers,
                     )
                     async with self._peers_lock:
                         self._peers[peers] = connection
@@ -363,6 +377,7 @@ class PeerManager:
             connection = PeerConnection(
                 self.relay_client,
                 channels=self._peer_channels,
+                ice_servers=self._ice_servers,
             )
             self._peers[peers] = connection
 

--- a/testing/endpoint.py
+++ b/testing/endpoint.py
@@ -73,6 +73,9 @@ def endpoint(use_uvloop: bool) -> Generator[EndpointConfig, None, None]:
         host='localhost',
         port=open_port(),
     )
+    # Disable ICE server candidate gathering in the spawned child where the
+    # _disable_ice_servers conftest fixture does not apply (see #599).
+    config.relay.ice_servers = []
     context = multiprocessing.get_context('spawn')
     server_handle = context.Process(
         target=serve_endpoint_silent,

--- a/tests/endpoint/config_test.py
+++ b/tests/endpoint/config_test.py
@@ -10,6 +10,7 @@ import pytest
 from proxystore.endpoint.config import ENDPOINT_CONFIG_FILE
 from proxystore.endpoint.config import EndpointConfig
 from proxystore.endpoint.config import EndpointRelayConfig
+from proxystore.endpoint.config import EndpointRelayICEServerConfig
 from proxystore.endpoint.config import EndpointStorageConfig
 from proxystore.endpoint.config import get_configs
 from proxystore.endpoint.config import get_log_filepath
@@ -33,6 +34,29 @@ def test_write_read_config(tmp_path: pathlib.Path) -> None:
     assert os.path.exists(tmp_dir)
 
     # Overwriting is okay
+    write_config(cfg, tmp_dir)
+
+    new_cfg = read_config(tmp_dir)
+    assert cfg == new_cfg
+
+
+def test_write_read_config_with_ice_servers(tmp_path: pathlib.Path) -> None:
+    tmp_dir = os.path.join(tmp_path, 'config-dir')
+
+    cfg = EndpointConfig(
+        name='name',
+        uuid=str(uuid.uuid4()),
+        host='host',
+        port=1234,
+    )
+    cfg.relay.ice_servers = [
+        EndpointRelayICEServerConfig(urls='stun:stun.example.com:3478'),
+        EndpointRelayICEServerConfig(
+            urls=['turn:turn.example.com:3478'],
+            username='user',
+            credential='secret',
+        ),
+    ]
     write_config(cfg, tmp_dir)
 
     new_cfg = read_config(tmp_dir)

--- a/tests/integration/endpoints_test.py
+++ b/tests/integration/endpoints_test.py
@@ -77,6 +77,10 @@ def endpoints() -> Generator[tuple[list[uuid.UUID], list[str]], None, None]:
                 port=port,
             )
             cfg.relay.address = f'ws://{ss_host}:{ss_port}'
+            # Disable ICE server candidate gathering in the spawned child
+            # where the _disable_ice_servers conftest fixture does not
+            # apply (see #599).
+            cfg.relay.ice_servers = []
             assert cfg.host is not None
 
             # We want a unique proxystore_dir for each endpoint to simulate

--- a/tests/p2p/connection_test.py
+++ b/tests/p2p/connection_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest import mock
 from uuid import uuid4
 
 import aiortc
@@ -57,6 +58,46 @@ async def test_p2p_connection(relay_server) -> None:
     await client2.close()
     await connection1.close()
     await connection2.close()
+
+
+@pytest.mark.asyncio
+async def test_p2p_connection_default_ice_servers(relay_server) -> None:
+    client = RelayClient(relay_server.address)
+    await client.connect()
+
+    with mock.patch(
+        'proxystore.p2p.connection.RTCPeerConnection',
+    ) as mock_pc:
+        PeerConnection(client)
+        # No configuration is passed so aiortc uses its default STUN servers.
+        mock_pc.assert_called_once_with()
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_p2p_connection_custom_ice_servers(relay_server) -> None:
+    client = RelayClient(relay_server.address)
+    await client.connect()
+
+    ice_servers = [aiortc.RTCIceServer(urls='stun:stun.example.com:3478')]
+    with mock.patch(
+        'proxystore.p2p.connection.RTCPeerConnection',
+    ) as mock_pc:
+        PeerConnection(client, ice_servers=ice_servers)
+        mock_pc.assert_called_once()
+        (configuration,) = mock_pc.call_args.args
+        assert configuration.iceServers == ice_servers
+
+    # An empty list disables server-reflexive candidate gathering.
+    with mock.patch(
+        'proxystore.p2p.connection.RTCPeerConnection',
+    ) as mock_pc:
+        PeerConnection(client, ice_servers=[])
+        (configuration,) = mock_pc.call_args.args
+        assert configuration.iceServers == []
+
+    await client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/p2p/manager_test.py
+++ b/tests/p2p/manager_test.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from unittest import mock
 
+import aiortc
 import pytest
 
 from proxystore.p2p.exceptions import PeerConnectionError
@@ -20,6 +22,29 @@ async def test_awaitable(relay_server) -> None:
     manager = await PeerManager(RelayClient(relay_server.address))
     # Calling async_init again should do nothing
     await manager.async_init()
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_ice_servers_forwarded_to_connection(relay_server) -> None:
+    ice_servers = [aiortc.RTCIceServer(urls='stun:stun.example.com:3478')]
+    manager = await PeerManager(
+        RelayClient(relay_server.address),
+        ice_servers=ice_servers,
+    )
+
+    async def _block() -> None:
+        await asyncio.Event().wait()
+
+    with mock.patch('proxystore.p2p.manager.PeerConnection') as mock_conn:
+        mock_conn.return_value.send_offer = mock.AsyncMock()
+        mock_conn.return_value.ready = mock.AsyncMock()
+        mock_conn.return_value.close = mock.AsyncMock()
+        # Block the peer message handler task so it does not busy loop.
+        mock_conn.return_value.recv = mock.AsyncMock(side_effect=_block)
+        await manager.get_connection(uuid.uuid4())
+        assert mock_conn.call_args.kwargs['ice_servers'] is ice_servers
+
     await manager.close()
 
 


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Adds STUN/TURN server configuration to `EndpointConfig.relay` and threads it through to the underlying `RTCPeerConnection`, so peer connections can use custom ICE servers or disable server-reflexive candidate gathering entirely.

Because config objects are serialized into `spawn`ed child processes, it also fixes the WSL slowdown in #599: the integration test fixtures previously relied on the in-process `_disable_ice_servers` conftest mock, which never reached the spawned endpoints, leaving them to stall ~5s per connection gathering ICE candidates against `stun.l.google.com` on hosts with an unroutable loopback address.

## Changes

- **`EndpointRelayConfig.ice_servers`** — new optional `list[EndpointRelayICEServerConfig]` (`urls`, `username`, `credential`). Semantics:
  - `None` (default) → aiortc's default public STUN servers (unchanged behavior)
  - `[]` → disable server-reflexive gathering (host candidates only)
  - non-empty → use the specified STUN/TURN servers
- **`PeerConnection`** and **`PeerManager`** accept `ice_servers` and pass an `RTCConfiguration(iceServers=...)` to `RTCPeerConnection` when set.
- **`serve()`** converts the config entries to `RTCIceServer` objects and forwards them to `PeerManager`.
- **Test fixtures** (`testing/endpoint.py`, `tests/integration/endpoints_test.py`) set `ice_servers = []` on spawned endpoint configs, removing the per-connection STUN stall on WSL.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

Related to #729

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

- New unit tests for default/custom/empty `ice_servers` on `PeerConnection`, forwarding through `PeerManager`, and TOML round-trip of the config.
- 246 tests pass across `tests/p2p`, `tests/endpoint`, and the integration endpoint suite; `ruff` and `mypy` clean.


## Pull Request Checklist

- [x] I have read the [Contributing](https://docs.proxystore.dev/main/contributing/) and [PR submission](https://docs.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
